### PR TITLE
Add marketing skills release workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "displayName": "Hyper Marketing",
       "source": "./",
       "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 19 skills wrapping 100+ integrations and 500+ marketing tools.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "marketing",
       "tags": ["marketing", "ads", "seo", "social-media", "analytics", "email", "google-ads", "meta-ads", "tiktok"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hyper-marketing",
   "displayName": "Hyper Marketing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 19 skills wrapping 100+ integrations and 500+ marketing tools.",
   "author": {
     "name": "Hyper AI",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: marketing-skills-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: tag-and-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate skills
+        run: |
+          chmod +x ./validate-skills.sh
+          ./validate-skills.sh
+
+      - name: Read plugin version
+        id: version
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          with open(".claude-plugin/plugin.json", "r", encoding="utf-8") as handle:
+              plugin = json.load(handle)
+          with open(".claude-plugin/marketplace.json", "r", encoding="utf-8") as handle:
+              marketplace = json.load(handle)
+
+          name = plugin.get("name")
+          version = str(plugin.get("version", "")).strip()
+          if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version):
+              print(f"Invalid .claude-plugin/plugin.json version: {version!r}", file=sys.stderr)
+              sys.exit(1)
+
+          matches = [
+              entry
+              for entry in marketplace.get("plugins", [])
+              if entry.get("name") == name
+          ]
+          if len(matches) != 1:
+              print(
+                  f"Expected exactly one marketplace entry for plugin {name!r}, found {len(matches)}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          marketplace_version = str(matches[0].get("version", "")).strip()
+          if marketplace_version != version:
+              print(
+                  "Version mismatch: "
+                  f".claude-plugin/plugin.json has {version}, "
+                  f".claude-plugin/marketplace.json has {marketplace_version}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"version={version}", file=output)
+              print(f"tag=v{version}", file=output)
+          PY
+
+      - name: Check release state
+        id: release_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tag_exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release_exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "release_exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create version tag
+        if: steps.release_state.outputs.tag_exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "marketing-skills ${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Create GitHub release
+        if: steps.release_state.outputs.release_exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Hyper Marketing Skills ${VERSION}" \
+            --generate-notes
+
+      - name: Report existing release
+        if: steps.release_state.outputs.release_exists == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          echo "::notice title=Release skipped::${TAG} already has a GitHub release. Bump .claude-plugin/plugin.json and .claude-plugin/marketplace.json to release a new version."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     paths:
       - "skills/**"
+      - ".claude-plugin/**"
       - "README.md"
       - "AGENTS.md"
+      - "CONTRIBUTING.md"
       - "validate-skills.sh"
       - ".github/workflows/validate.yml"
+      - ".github/workflows/release.yml"
   push:
     branches: [main]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,12 @@ skills/<skill-name>/
 
 The script checks frontmatter, name/folder match, length, the Requirements section, and a banned-strings list. CI runs the same check on every PR.
 
+## Releasing
+
+The current release version lives in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. Keep those versions in sync.
+
+When a commit lands on `main`, the release workflow validates the skills, reads that version, creates the matching `v<version>` tag if it does not exist, and creates a GitHub Release. If the tag/release already exists, the workflow skips it. To publish a new release, bump both manifest versions in the PR before merging.
+
 ## Reporting issues
 
 Open an issue with:

--- a/skills/hyper-cli/SKILL.md
+++ b/skills/hyper-cli/SKILL.md
@@ -23,7 +23,7 @@ If `hyperai info` fails, stop and tell the user to authenticate the CLI before c
 | --- | --- |
 | Confirm auth/workspace | `hyperai info` |
 | Find tools by intent or raw MCP name | `hyperai search "<intent or raw tool name>" --json --signature` |
-| Browse friendly aliases | `hyperai describe <namespace>` |
+| Browse friendly aliases in a namespace | `hyperai describe <namespace>` |
 | Inspect a friendly alias schema | `hyperai describe <alias path> --parameters` |
 | Call a friendly alias | `hyperai call <alias path> --json '{...}'` |
 | Inspect a raw toolkit tool | `hyperai tools describe <toolkit> <tool_name> --parameters` |
@@ -60,6 +60,36 @@ hyperai tools call gmail gmail_send_message --json '{...}'
 ```
 
 Never assume `hyperai call gmail_send_message` will work.
+
+## Describe progression
+
+Use `describe` progressively. Start broad, then narrow to the exact alias before calling:
+
+```bash
+hyperai describe gmail
+hyperai describe gmail messages send --parameters
+hyperai call gmail messages send --to person@example.com --subject "Hello" --body "Hi"
+```
+
+For friendly aliases, use `hyperai describe <namespace>` and `hyperai describe <alias path> --parameters`. Do not use `hyperai tools describe gmail` for namespace browsing; `tools describe` is the raw toolkit form and needs both toolkit and raw tool name.
+
+## Structured arguments
+
+Flags are safest for simple scalar fields:
+
+```bash
+hyperai call gmail messages send --to person@example.com --subject "cli test" --body "this is a test"
+```
+
+Use `--json` for arrays, objects, nested schemas, and model-specific tools. Do not pass arrays or objects as string flags unless the live schema explicitly says the field is a string.
+
+```bash
+hyperai describe images generate nano-banana --parameters
+hyperai call images generate nano-banana \
+  --json '{"requests":[{"prompt":"a cat wearing a propeller hat"}],"model":"pro"}'
+```
+
+If validation says an object field was received as a string, retry with `--json` after re-reading `describe --parameters`.
 
 ## Workflow
 
@@ -130,6 +160,30 @@ Raw fallback:
 hyperai tools describe meta_business meta_business_list_ad_accounts --parameters
 hyperai tools call meta_business meta_business_list_ad_accounts --json '{"detail":"id_only"}'
 ```
+
+Image generation:
+
+```bash
+# Default image generation alias accepts the prompt positionally.
+hyperai call images generate "a cat wearing a propeller hat" --quality draft --output json
+
+# Model-specific image tools often need JSON because their schema is nested.
+hyperai describe images generate nano-banana --parameters
+hyperai call images generate nano-banana \
+  --json '{"requests":[{"prompt":"a cat wearing a propeller hat"}],"model":"pro"}' \
+  --output json
+```
+
+Meta ads performance:
+
+```bash
+hyperai search "meta ads insights" --json --signature
+hyperai call meta-ads ad-accounts list --output json
+hyperai describe meta-ads insights get --parameters
+hyperai call meta-ads insights get --json '{"object_id":"act_<ad_account_id>","object_type":"account","date_range":"last_month"}'
+```
+
+Always list ad accounts first when the user asks for account-level performance and did not provide an `act_...` account id.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- add a main-branch release workflow for marketing skills
- read the release version from `.claude-plugin/plugin.json` and verify it matches `.claude-plugin/marketplace.json`
- create the matching `v<version>` tag and GitHub Release after validation when the tag/release does not already exist
- include plugin metadata and release workflow changes in PR validation paths
- bump plugin manifests to `1.0.1`
- update the `hyper-cli` skill from CLI testing: progressive `describe`, scalar flags vs structured JSON, model-specific image generation, and Meta ads account discovery

## Testing
- `./validate-skills.sh`
- local manifest version consistency check (`v1.0.1`)

## Release behavior
`v1.0.0` is already tagged and released from current `main`. When this PR lands on `main`, the workflow should validate, create `v1.0.1`, and publish a GitHub Release. Future releases require bumping both plugin manifest versions before merging to `main`.