### PR TITLE
Point image/video skills at unified images_generate / videos_generate

### DIFF
--- a/skills/ad-creative-generation/SKILL.md
+++ b/skills/ad-creative-generation/SKILL.md
@@ -16,9 +16,9 @@ This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to y
 | Group | Tools |
 |-------|-------|
 | Brand extraction | `firecrawl_extract_branding` |
-| Image generation (default) | `openai_image_edit`, `openai_image_generation` |
-| Image generation (text-heavy) | `nano_banana_image_generation`, `nano_banana_image_edit` |
-| Image generation (photoreal product shots) | `seedream_image_generation` |
+| Image generation (default) | `images_generate` (`model="gpt-image-2"`) |
+| Image generation (text-heavy) | `images_generate` (`model="nano-banana-pro"`) |
+| Image generation (photoreal product shots) | `images_generate` (`model="seedream-4.5"`) |
 
 For deeper image-tool selection guidance see the `image-generation` skill. To turn finished creatives into running campaigns see `google-ads` and `meta-ads`.
 
@@ -35,9 +35,9 @@ For deeper image-tool selection guidance see the `image-generation` skill. To tu
 - **DO NOT display image URLs** — they are automatically shown in chat.
 - **Read `brand.screenshot.description`** to understand the product — never guess from the company name.
 - **Default to logo + headline + product screenshot** for SaaS / product ads unless the user requests a different style.
-- **Use OpenAI for the initial ad creative by default** — `openai_image_edit` for branded / reference-based work, `openai_image_generation` for loose first-pass concepts.
-- **Do not default to Nano Banana for the first creative pass** — use it when the user explicitly asks or when readable text inside the image is the main requirement.
-- **`openai_image_edit` supported sizes:** `1024x1024` (square), `1024x1536` (portrait / story), `1536x1024` (landscape / banner). Match to platform placement.
+- **Use `model="gpt-image-2"` for the initial ad creative by default** — with reference images for branded work, or without for loose first-pass concepts.
+- **Do not default to `model="nano-banana-pro"` for the first creative pass** — use it when the user explicitly asks or when readable text inside the image is the main requirement.
+- **Set `aspect_ratio` to the placement** — `1:1` (feed), `9:16` (story), `16:9` (banner) — and `quality` (`"draft" | "standard" | "high"`); `images_generate` takes those, not raw pixel sizes.
 - **Respect character limits** — Google RSA headlines are 30 chars, descriptions 90 chars; Meta primary text is 125 chars visible.
 - **Change one variable per variant** so test results are attributable.
 - **Match aspect ratio to placement** — feed is 1:1, story is 9:16 (use `1024x1536`), banner is 16:9 (use `1536x1024`).
@@ -92,14 +92,14 @@ Generate ad images using brand assets as references. Always pass **both logo and
 
 **Read `brand.screenshot.description`** to understand what the product actually does and what the UI looks like. Do not guess from the company name.
 
-**Preferred tool for the first creative pass: `openai_image_edit`**
+**Preferred first pass: `images_generate` with `model="gpt-image-2"`**
 
 #### Default approach (best practice for SaaS / product ads)
 
-By default, a strong ad creative has three layers: **brand** (logo), **copy** (headline), and **product** (realistic screenshot showing the core value prop). This is the recommended starting point when the user hasn't specified a creative direction. Use OpenAI for this initial composition unless the user explicitly asks for Nano Banana or the image is primarily a text-rendering task.
+By default, a strong ad creative has three layers: **brand** (logo), **copy** (headline), and **product** (realistic screenshot showing the core value prop). This is the recommended starting point when the user hasn't specified a creative direction. Use `model="gpt-image-2"` for this initial composition unless the user explicitly asks for another model or the image is primarily a text-rendering task.
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Social media ad creative for [company name]. "
@@ -111,7 +111,8 @@ openai_image_edit(
         ),
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
-    size="1024x1024",
+    model="gpt-image-2",
+    aspect_ratio="1:1",
     quality="high"
 )
 ```
@@ -131,11 +132,11 @@ If the user asks for a specific creative style (lifestyle imagery, abstract, ill
 
 | Scenario | Tool | Why |
 |----------|------|-----|
-| On-brand creative (default) | `openai_image_edit` with logo + screenshot refs | Best default for the first branded concept |
-| Text-heavy creative (headlines in image) | `nano_banana_image_generation` with `model="pro"` | Use only when text rendering inside the image is the main requirement |
-| Quick ideation / concept exploration | `openai_image_generation` | Fast first-pass concepting with no references needed |
-| Iterative refinement of existing image | `nano_banana_image_edit` | Edit a specific generated image |
-| Photoreal product shots / material detail | `seedream_image_generation` | Strong fabric/texture/spatial depth |
+| On-brand creative (default) | `images_generate` (`model="gpt-image-2"`) with logo + screenshot refs | Best default for the first branded concept |
+| Text-heavy creative (headlines in image) | `images_generate` (`model="nano-banana-pro"`) | Use only when text rendering inside the image is the main requirement |
+| Quick ideation / concept exploration | `images_generate` (`model="gpt-image-2"`) | Fast first-pass concepting with no references needed |
+| Iterative refinement of existing image | `images_generate` (`model="nano-banana"`) with the image as a reference | Edit a specific generated image |
+| Photoreal product shots / material detail | `images_generate` (`model="seedream-4.5"`) | Strong fabric/texture/spatial depth |
 
 ## Platform Quick Reference
 

--- a/skills/ad-creative-generation/SKILL.md
+++ b/skills/ad-creative-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ad-creative-generation
 description: Generate on-brand ad creatives — visuals + copy — for Google, Meta (Facebook / Instagram), and other paid platforms via the Hyper MCP. Extracts brand identity from a website, writes ad copy variants, and produces brand-consistent images using reference-based image generation. Use when the user asks for ad creative, ad copy variants, RSA headlines, Meta ad creative, display ads, carousel ads, or A/B test variants.
+metadata:
+  version: 1.0.0
 ---
 
 # Ad Creative Generation

--- a/skills/ad-creative-generation/references/brand-extraction.md
+++ b/skills/ad-creative-generation/references/brand-extraction.md
@@ -50,7 +50,7 @@ The logo provides brand mark consistency. The screenshot shows the actual produc
 By default, compose: **logo + headline + realistic product screenshot**. Describe the product screenshot based on `brand.screenshot.description`, not guessed.
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Social media ad creative for [company name]. "
@@ -61,7 +61,6 @@ openai_image_edit(
         ),
         "reference_images": reference_images
     }],
-    size="1024x1024",
     quality="high"
 )
 ```

--- a/skills/ad-creative-generation/references/google-ads-creatives.md
+++ b/skills/ad-creative-generation/references/google-ads-creatives.md
@@ -91,7 +91,7 @@ Every creative needs three layers: **brand** (logo), **copy** (headline), and **
 Square (1:1):
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Display ad creative for [company name]. "
@@ -101,7 +101,6 @@ openai_image_edit(
         ),
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
-    size="1024x1024",
     quality="high"
 )
 ```
@@ -109,7 +108,7 @@ openai_image_edit(
 Landscape (1.91:1):
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Wide display ad creative for [company name]. "
@@ -119,7 +118,6 @@ openai_image_edit(
         ),
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
-    size="1536x1024",
     quality="high"
 )
 ```

--- a/skills/ad-creative-generation/references/meta-ads-creatives.md
+++ b/skills/ad-creative-generation/references/meta-ads-creatives.md
@@ -107,13 +107,12 @@ Carousel ads display up to 10 scrollable cards, each with its own image, headlin
 Generate all cards in a single batch. Each card should have the brand logo, a short headline for that card's feature, and a relevant product screenshot.
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[
         {"prompt": "Card 1 for [company]. Logo at top. Headline: '[feature 1]'. Below: product screenshot showing [feature 1 UI]. Match brand style.", "reference_images": [logo_id, screenshot_id]},
         {"prompt": "Card 2 for [company]. Logo at top. Headline: '[feature 2]'. Below: product screenshot showing [feature 2 UI]. Same style as card 1.", "reference_images": [logo_id, screenshot_id]},
         {"prompt": "Card 3 for [company]. Logo at top. Headline: '[feature 3]'. Below: product screenshot showing [feature 3 UI]. Same style as card 1.", "reference_images": [logo_id, screenshot_id]},
     ],
-    size="1024x1024",
     quality="high"
 )
 ```
@@ -162,7 +161,7 @@ Every creative needs three layers: **brand** (logo), **copy** (headline + sublin
 ### Feed Creative (1:1)
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Social media ad creative for [company name]. "
@@ -173,7 +172,6 @@ openai_image_edit(
         ),
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
-    size="1024x1024",
     quality="high"
 )
 ```
@@ -181,7 +179,7 @@ openai_image_edit(
 ### Story Creative (9:16)
 
 ```python
-openai_image_edit(
+images_generate(
     requests=[{
         "prompt": (
             "Vertical story ad creative for [company name]. "
@@ -192,7 +190,6 @@ openai_image_edit(
         ),
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
-    size="1024x1536",
     quality="high"
 )
 ```
@@ -202,8 +199,7 @@ openai_image_edit(
 When the creative needs large, readable text baked into the image, use Nano Banana for better text rendering:
 
 ```python
-nano_banana_image_generation(
-    model="pro",
+images_generate(
     requests=[{
         "prompt": (
             "Ad creative for [company name]. "
@@ -214,6 +210,5 @@ nano_banana_image_generation(
         "reference_images": [brand.logo.file_id, brand.screenshot.file_id]
     }],
     aspect_ratio="1:1",
-    image_size="2K"
 )
 ```

--- a/skills/amazon-ads/SKILL.md
+++ b/skills/amazon-ads/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: amazon-ads
 description: Plan and create Amazon Sponsored Products campaigns end-to-end via the Hyper MCP. Use when the user wants to launch Amazon Ads, set up Sponsored Products, manage keyword targeting and bids, configure ASIN or category product targeting, add negative keywords, automate budget rules, analyze ACoS / ROAS, or generate Sponsored Products reports. Also triggers on amazon ppc, amazon campaign, amazon keywords, or amazon report.
+metadata:
+  version: 1.0.0
 ---
 
 # Amazon Ads

--- a/skills/analytics-insights/SKILL.md
+++ b/skills/analytics-insights/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: analytics-insights
 description: Drive Google Analytics (GA4), Google Tag Manager, Google Search Console, and BigQuery from chat — tracking plans, GA4 reports, key-event (conversion) setup, custom dimensions and metrics, GTM audits, GSC performance, and GA4 BigQuery export queries. Use when the user wants an analytics audit, a GA4 report, a tracking plan, conversion setup, GTM cleanup, search-performance data, or asks "how is the site performing?" or "are my conversions firing?".
+metadata:
+  version: 1.0.0
 ---
 
 # Analytics Insights

--- a/skills/cold-email-outreach/SKILL.md
+++ b/skills/cold-email-outreach/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: cold-email-outreach
 description: Run end-to-end B2B cold-email outreach through the Hyper MCP — enrich prospects with Apollo, scrape per-prospect signals from company sites and LinkedIn, draft personalized emails using proven hook frameworks, send via Gmail with safe defaults, and route replies into labeled folders. Use when the user wants to write cold emails, run an outbound sequence, prospect a list, build a follow-up cadence, "reach out to leads," or asks why nobody is replying to their cold emails.
+metadata:
+  version: 1.0.0
 ---
 
 # Cold Email Outreach

--- a/skills/competitor-intel/SKILL.md
+++ b/skills/competitor-intel/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: competitor-intel
 description: Run end-to-end competitor research and monitoring through the Hyper MCP — pick the set, scrape every public surface (site, blog, pricing, organic social, search rank, mentions, demand) via Firecrawl + HyperSEO + the Apify scrapers, diff against last run, and synthesize a brief. Use when the user wants to research competitors, build a battle card or comparison page, run a weekly digest, or asks "what's [competitor] doing?" or "how do we compare?".
+metadata:
+  version: 1.0.0
 ---
 
 # Competitor Intel

--- a/skills/competitor-intel/SKILL.md
+++ b/skills/competitor-intel/SKILL.md
@@ -43,7 +43,7 @@ If none of those tool prefixes appear in the agent's tool list (`firecrawl_*`, `
 | Community / sentiment — Reddit | `scrape_reddit`, `scrape_reddit_leads` |
 | Ecommerce competitor specifics | `scrape_ecommerce_products`, `scrape_ecommerce_reviews` |
 | Demand / trend signals | `scrape_google_trends`, `hyperseo_search_volume`, `hyperseo_search_intent` |
-| Optional: comparison-page assets | `openai_image_generation`, `nano_banana_image_generation`, `seedream_image_generation`, `nano_banana_multi_turn` |
+| Optional: comparison-page assets | `images_generate` |
 
 ## Critical rules
 

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: customer-research
 description: Mine online communities and analyze existing assets to understand what customers actually think, say, and struggle with. Use when the user wants to do customer research, ICP research, voice-of-customer (VOC), review mining, Reddit mining, YouTube comment analysis, G2/Capterra scraping, build customer personas, map jobs to be done, understand churn reasons, or find authentic customer language for copy. Also use when given transcripts, surveys, or support tickets to synthesize.
+metadata:
+  version: 1.0.0
 ---
 
 # Customer Research

--- a/skills/email-lifecycle/SKILL.md
+++ b/skills/email-lifecycle/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: email-lifecycle
 description: Plan, build, and run lifecycle email programs through the Hyper MCP — welcome / onboarding, nurture, re-engagement, win-back, and abandoned-cart sequences across whichever provider fits (Klaviyo for ecommerce, Resend for SaaS / dev tools, Beehiiv for newsletters, Gmail for low-volume ops). Use when the user wants to build an email sequence, set up a welcome flow, recover lapsed users, send a broadcast, manage a list / audience / segment, or asks about lifecycle / drip / nurture campaigns.
+metadata:
+  version: 1.0.0
 ---
 
 # Email Lifecycle

--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: google-ads
 description: Plan and create new Google Ads campaigns end-to-end via the Hyper MCP. Use when the user wants to launch Search, Display, or Performance Max campaigns, or mentions Google Ads, AdWords, search ads, display ads, Performance Max, PMax, PPC, Google campaigns, Google blueprint, search term reports, negative keywords, or manager accounts (MCC). For ongoing optimization, search-term cleanup, conversion diagnosis, or restructuring existing accounts, defer to a future `google-ads-operator` sibling skill.
+metadata:
+  version: 1.0.0
 ---
 
 # Google Ads

--- a/skills/hyper-cli/SKILL.md
+++ b/skills/hyper-cli/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: hyper-cli
 description: Use the Hyper CLI to run Hyper marketing skills from a terminal. Use when the user wants to use `hyperai`, inspect live tool schemas, translate MCP tool names from a skill into CLI commands, switch connected accounts, or run marketing tools outside an MCP-native agent host.
+metadata:
+  version: 1.0.0
 ---
 
 # Hyper CLI

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: image-generation
 description: Generate images through the Hyper MCP with the unified `images_generate` tool — text-to-image, image-to-image, and branded ad creatives — choosing the model (gpt-image-2, nano-banana, nano-banana-pro, seedream-4.5) per task. Use when the user asks to generate an image, create an ad creative, do an image-to-image edit, render text inside an image, or produce a print-quality poster.
+metadata:
+  version: 1.0.0
 ---
 
 # Image Generation

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -1,181 +1,90 @@
 ---
 name: image-generation
-description: Choose the right image generation tool through the Hyper MCP — OpenAI (gpt-image-2), Nano Banana (Gemini), Seedream (ByteDance via fal.ai) — for ad creatives, branded compositions, text-heavy assets, photorealistic product shots, image-to-image edits, and high-resolution output. Use when the user asks to generate an image, create an ad creative, do an image-to-image edit, render text inside an image, or produce a print-quality poster.
+description: Generate images with images_generate — text-to-image, image-to-image, and branded ad creatives — choosing the right model per task
+use_cases:
+  - Generate images with AI
+  - Create ad creatives with text
+  - Image-to-image generation
+  - Style transfer
+  - High-resolution image production
+triggers:
+  - image
+  - generate image
+  - create image
+  - ad creative
+  - image with text
+requires_toolkits:
+  - image_gen
+suggested_toolkits:
+  - file_manager
+  - firecrawl
 ---
 
 # Image Generation
 
-Guide for selecting the right image generation tool through the Hyper MCP based on what the user is trying to make.
+Generate images with the `images_generate` tool. It handles text-to-image,
+image-to-image (pass `reference_images`), and multi-image composition. By default
+(`model="auto"`) it picks the best model for the request; set `model` to choose one.
 
-## Requirements
-
-This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to your agent so the tools below are available. For brand-consistent ad creative work, Firecrawl must also be configured under your Hyper integrations.
-
-## Tool surface
-
-| Group | Tools |
-|-------|-------|
-| OpenAI (`gpt-image-2`) | `openai_image_generation`, `openai_image_edit` |
-| Nano Banana (Gemini) | `nano_banana_image_generation`, `nano_banana_image_edit`, `nano_banana_multi_turn` |
-| Seedream (ByteDance via fal.ai) | `seedream_image_generation` |
-| Brand extraction (companion) | `firecrawl_extract_branding` |
-
-## Out of scope
-
-- Full ad creative workflows (brand extraction → copy → image) — use `ad-creative-generation`.
-- Video generation, transcription, captions, voiceover — use `video-generation`.
-
-## Tool Selection Framework
-
-### Rule 0: Website / brand ad creative requests → extract branding first (Firecrawl)
-If the user provides a website URL and asks for ad creatives, brand-consistent visuals, or marketing assets, **always extract branding before generating images**.
-
-1. Call `firecrawl_extract_branding` with the URL. The result returns brand colors, fonts, personality / tone, and saved image files (logo, favicon, og_image).
-2. Optionally call `firecrawl_scrape_url` with `formats=["screenshot"]` to capture the landing page for visual context.
-3. Compose your image generation prompt using the extracted colors (hex codes), font names, and personality tone. Pass the logo `file_id` from the result as a `reference_image_file_id`.
-
-**Critical:** The result includes a `file` field — this is a JSON data file, NOT an image. Never pass it to image gen tools. Only `logo.file_id` and `images.*.file_id` are actual images you can use as references.
-
-### Rule 1: Explicit text-heavy assets → Nano Banana Pro (Gemini)
-If the primary requirement is readable embedded text inside the image itself, such as headlines, labels, UI text, or poster copy:
+## Call shape
 
 ```python
-nano_banana_image_generation(
-    model="pro",
-    requests=[{"id": "ad1", "prompt": "Create an ad with readable text '50% OFF'"}],
-    aspect_ratio="16:9",
-    image_size="2K"
+images_generate(
+    requests=[{"id": "ad1", "prompt": "A polished SaaS ad, clean composition"}],
+    aspect_ratio="16:9",     # "1:1" (default), "9:16", "16:9", "4:5", "2:3", "3:2", "3:4", "4:3", "21:9", ...
+    quality="standard",      # "draft" | "standard" | "high"
+    n=1,                      # 1-4 images per request
+    model="auto",            # see "Choosing a model" below
 )
 ```
 
-### Rule 2: Reference images or brand assets → OpenAI Edit by default
-If the user provides images, branding assets, screenshots, or wants an initial branded composition, prefer `openai_image_edit`.
+- **Image-to-image / brand references:** put files in the request:
+  `requests=[{"prompt": "Compose into a gift basket", "reference_images": ["file1", "file2"]}]`.
+- **Reproducible output:** pass `seed=...`.
+- **Ground in real-world search:** pass `use_search=True`.
+- Do not display image URLs — they render automatically in chat.
 
-```python
-openai_image_edit(
-    requests=[{"prompt": "Compose into gift basket", "reference_images": ["file1", "file2"]}]
-)
-```
+## Choosing a model
 
-Use Nano Banana only when the user explicitly wants Nano Banana or the image is text-heavy enough that text rendering is the main concern.
+`model="auto"` is the right default. Override only when the task clearly calls for a
+specific model:
 
-### Rule 3: Initial ad creative or first-pass concepts → OpenAI
-For initial creative exploration, first-pass ad concepts, or early branded directions, prefer OpenAI tools:
+| Task | `model` |
+|------|---------|
+| First-pass concepts / quick ad ideation | `gpt-image-2` |
+| Image-to-image with references, high-resolution refinement, broad aspect ratios | `nano-banana` |
+| Readable text inside the image (posters, labels, infographics) or search-grounded scenes | `nano-banana-pro` |
+| Product photography, material/fabric fidelity, accurate spatial depth | `seedream-4.5` |
 
-```python
-openai_image_generation(
-    requests=[{"prompt": "A polished SaaS ad concept with clean composition"}],
-    size="1024x1024"
-)
-```
+## Branded / website ad creatives — extract branding first
 
-For reference-based branded ads, prefer:
+If the user gives a website URL and wants on-brand creatives:
 
-```python
-openai_image_edit(
-    requests=[{"prompt": "Create a polished branded ad concept", "reference_images": ["file1", "file2"]}]
-)
-```
+1. Call `firecrawl_branding_extract` with the URL → returns brand colors, fonts,
+   personality/tone, and saved image files (logo, favicon, og_image).
+2. Optionally `firecrawl_urls_scrape` with `formats=["screenshot"]` for visual context.
+3. Write the prompt using the actual hex colors, font names, and tone, and pass the
+   logo `file_id` in `reference_images`.
 
-### Rule 4: Nano Banana Pro for production text rendering
-Use `nano_banana_image_generation(model="pro")` when the user explicitly wants Nano Banana or when the output needs strong text rendering inside the image. Do not default to Nano Banana for the first creative pass when OpenAI tools can handle the concept.
+The branding result's `file` field is a JSON data file, NOT an image — never pass it
+as a reference. Only `logo.file_id` and `images.*.file_id` are usable images.
 
-## Available Tools
+## Workflows (prefer these for product / marketplace work)
 
-### OpenAI Image Generation
-**Best for:** Quick ideation, first-pass concepts, general creative requests without reference images.
+When the request is more specific than "generate an image", reach for a workflow
+tool — it preserves product identity and returns structured results.
 
-- Model: `gpt-image-2`
-- Standard sizes: 1024x1024, 1024x1536, 1536x1024
-- Quality: `low`, `medium`, `high`
-- Fast results for general creative requests
+| Goal | Tool | Reference |
+|------|------|-----------|
+| Multi-shot product photography (studio, lifestyle, hero, carousel, ad pack) | `images_product_photoshoots_create` | [references/product-photoshoot.md](references/product-photoshoot.md) |
+| Marketplace listing image set (Amazon main + secondary, A+ modules, Shopify) | `images_marketplace_cards_create` | [references/marketplace-cards.md](references/marketplace-cards.md) |
+| Prompt-writing tips per model | — | [references/image-prompting.md](references/image-prompting.md) |
 
-### OpenAI Image Edit
-**Best for:** Initial branded compositions, website-based ad creatives, image-to-image generation with OpenAI quality.
+## Reminders
 
-- Editing or composing images using references
-- Multi-image composition
-
-### Nano Banana Image Generation (Gemini)
-**Best for:** Text-heavy production assets, explicit Nano Banana requests, and high-resolution refinements.
-
-**Models:**
-- `model="pro"` (default): Gemini 3 Pro — best quality, supports Google Search grounding
-- `model="flash"`: Gemini 2.5 Flash — faster and cheaper
-
-**Key Capabilities:**
-- Text in images (headlines, labels, UI elements)
-- High-resolution output (1K, 2K, 4K)
-- Various aspect ratios (1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9)
-- Image-to-image with `reference_images`
-- Real-world grounding via `use_google_search=True`
-
-### Seedream 4.5 Image Generation (ByteDance via fal.ai)
-**Best for:** Product photography, marketing assets, text rendering in images, material / fabric preservation, scenes with accurate spatial depth.
-
-**Key Capabilities:**
-- Fast generation (~2-3 seconds)
-- Resolutions up to 4K (`auto_2K`, `auto_4K`, or preset sizes)
-- Photorealistic quality with strong material / texture detail
-- Size presets: `square_hd`, `square`, `portrait_4_3`, `portrait_16_9`, `landscape_4_3`, `landscape_16_9`, `auto_2K`, `auto_4K`
-
-```python
-seedream_image_generation(
-    requests=[{"prompt": "Product shot of leather handbag on marble surface"}],
-    image_size="auto_2K"
-)
-```
-
-### Nano Banana Image Edit
-**Best for:** Modifying single existing images.
-
-- Targeted changes to uploaded images
-- Same quality options as generation
-
-### Nano Banana Multi-Turn
-**ONLY use when the user explicitly says "use multi turn image editing".**
-
-- `mode="sync"`: Chain mode — output from turn N becomes input for turn N+1
-- `mode="parallel"`: Independent mode — all turns processed independently
-
-## Request Format
-
-All tools use the `requests` parameter:
-
-```python
-requests=[
-    {"id": "optional_id", "prompt": "Description", "reference_images": ["optional"]}
-]
-```
-
-## Common Patterns
-
-| Pattern | Tool | Notes |
-|---------|------|-------|
-| Website-based ad creative | `firecrawl_extract_branding` → `openai_image_edit` | Extract branding first, then create the first branded concept |
-| Ad with text | `nano_banana_image_generation(model="pro")` | Use when readable text inside the image is a core requirement |
-| Quick concept | `openai_image_generation` | Simple, no constraints |
-| Style transfer | Nano Banana + references | Image-to-image |
-| Print-quality poster | Nano Banana + 4K | High resolution |
-| Product photography | `seedream_image_generation` | Photorealistic, material detail |
-| Edit existing image | `nano_banana_image_edit` | Single image modification |
-| Batch generation | Multiple requests | Parallel generation |
-
-### Pattern H: Brand-Consistent Ad Creative
-
-1. Call `firecrawl_extract_branding` with the website URL
-2. Read the returned colors, fonts, personality, and logo `file_id`
-3. Write a prompt that includes the actual hex colors, font names, and tone from the result
-4. Pass the logo `file_id` as a reference image
-5. Generate the first pass with `openai_image_edit` when using brand references, or `openai_image_generation` for loose ideation
-6. Use `nano_banana_image_generation(model="pro")` only if the image itself needs strong readable text rendering
-
-## Important Reminders
-
-- **DO NOT display image URLs to the user** — they are automatically shown in chat
-- **Refine vague prompts** — unless the user explicitly wants verbatim generation
-- **Match aspect ratio to intent** — social media, print, web, etc.
-- **Use appropriate resolution** — 4K for production, 1K / 2K for iteration
-- **Remember `file_id`s** — generated images can be reused in subsequent operations
-- **For website-based brand work** — call `firecrawl_extract_branding` before generating ad creatives
-- **For initial ad creatives** — prefer OpenAI tools first; reserve Nano Banana Pro for explicit text-heavy assets or explicit user preference
+- Do NOT display image URLs to the user — they show automatically in chat.
+- Refine vague prompts unless the user wants verbatim generation.
+- Match `aspect_ratio` to intent (social, print, web).
+- Use `quality="high"` for production, `"draft"`/`"standard"` while iterating.
+- Generated `file_id`s can be reused as `reference_images` in later calls.
+- For website brand work, call `firecrawl_branding_extract` before generating.

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -1,23 +1,6 @@
 ---
 name: image-generation
-description: Generate images with images_generate — text-to-image, image-to-image, and branded ad creatives — choosing the right model per task
-use_cases:
-  - Generate images with AI
-  - Create ad creatives with text
-  - Image-to-image generation
-  - Style transfer
-  - High-resolution image production
-triggers:
-  - image
-  - generate image
-  - create image
-  - ad creative
-  - image with text
-requires_toolkits:
-  - image_gen
-suggested_toolkits:
-  - file_manager
-  - firecrawl
+description: Generate images through the Hyper MCP with the unified `images_generate` tool — text-to-image, image-to-image, and branded ad creatives — choosing the model (gpt-image-2, nano-banana, nano-banana-pro, seedream-4.5) per task. Use when the user asks to generate an image, create an ad creative, do an image-to-image edit, render text inside an image, or produce a print-quality poster.
 ---
 
 # Image Generation
@@ -25,6 +8,12 @@ suggested_toolkits:
 Generate images with the `images_generate` tool. It handles text-to-image,
 image-to-image (pass `reference_images`), and multi-image composition. By default
 (`model="auto"`) it picks the best model for the request; set `model` to choose one.
+
+## Requirements
+
+This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to your
+agent so the `images_generate` tool is available. For brand-consistent ad creative
+work, Firecrawl must also be configured under your Hyper integrations.
 
 ## Call shape
 
@@ -56,6 +45,9 @@ specific model:
 | Readable text inside the image (posters, labels, infographics) or search-grounded scenes | `nano-banana-pro` |
 | Product photography, material/fabric fidelity, accurate spatial depth | `seedream-4.5` |
 
+See [references/image-prompting.md](references/image-prompting.md) for per-model
+prompt-writing tips.
+
 ## Branded / website ad creatives — extract branding first
 
 If the user gives a website URL and wants on-brand creatives:
@@ -69,16 +61,15 @@ If the user gives a website URL and wants on-brand creatives:
 The branding result's `file` field is a JSON data file, NOT an image — never pass it
 as a reference. Only `logo.file_id` and `images.*.file_id` are usable images.
 
-## Workflows (prefer these for product / marketplace work)
+## Higher-level workflows
 
-When the request is more specific than "generate an image", reach for a workflow
-tool — it preserves product identity and returns structured results.
+For multi-shot product or marketplace work, prefer the workflow tools — they preserve
+product identity and return structured results:
 
-| Goal | Tool | Reference |
-|------|------|-----------|
-| Multi-shot product photography (studio, lifestyle, hero, carousel, ad pack) | `images_product_photoshoots_create` | [references/product-photoshoot.md](references/product-photoshoot.md) |
-| Marketplace listing image set (Amazon main + secondary, A+ modules, Shopify) | `images_marketplace_cards_create` | [references/marketplace-cards.md](references/marketplace-cards.md) |
-| Prompt-writing tips per model | — | [references/image-prompting.md](references/image-prompting.md) |
+- `images_product_photoshoots_create` — multi-shot product photography (studio,
+  lifestyle, hero, carousel, ad pack).
+- `images_marketplace_cards_create` — marketplace listing image sets (Amazon main +
+  secondary, A+ modules, Shopify).
 
 ## Reminders
 

--- a/skills/image-generation/references/image-prompting.md
+++ b/skills/image-generation/references/image-prompting.md
@@ -1,0 +1,45 @@
+# Image Prompting (per model)
+
+`images_generate` picks a model for you when `model="auto"`, but the prompt you
+write should still play to whichever model runs. Set `model` when the task clearly
+calls for a specific one; otherwise let `auto` decide.
+
+## Choosing a model (cheat sheet)
+
+| Need | `model` |
+|------|---------|
+| First-pass concepts, ad ideation, compositions with reference images | `gpt-image-2` |
+| High-resolution refinement, broad aspect ratios, image-to-image with multiple references | `nano-banana` |
+| Readable text inside the image (posters, labels, infographics) or search-grounded scenes | `nano-banana-pro` |
+| Product photography, material/fabric fidelity, accurate spatial depth | `seedream-4.5` |
+| No strong preference | `auto` (default) |
+
+## Per-model prompt shapes
+
+### `gpt-image-2` (OpenAI)
+- Best for: first-pass concepts, ad creative ideation, compositions with references.
+- Prompt sections: objective → composition → style → brand constraints.
+- Avoid long blocks of literal text and aspect ratios beyond 1:1, 2:3, 3:2.
+
+### `nano-banana` (Gemini)
+- Best for: high-resolution refinements, broad aspect ratios, image-to-image with multiple references.
+- Prompt sections: subject → composition → style → lighting.
+- Avoid competing visual instructions in the same prompt.
+
+### `nano-banana-pro` (Gemini Pro)
+- Best for: exact readable text inside the image (posters, labels, infographics) and search-grounded scenes.
+- Prompt sections: exact_text → layout → hierarchy → style → aspect_ratio.
+- Avoid ambiguous copy and too many independent text blocks.
+
+### `seedream-4.5`
+- Best for: product photography, material/fabric preservation, scenes requiring accurate spatial depth.
+- Prompt sections: product_identity → surface_materials → lighting → camera_angle → environment.
+- Avoid changing logo/text, warping packaging geometry, and busy backgrounds.
+
+## Parameters
+
+`images_generate` takes: `requests` (each `{prompt, id?, reference_images?}`),
+`model`, `aspect_ratio`, `quality` (`"draft" | "standard" | "high"`), `n` (1-4),
+`seed`, and `use_search`. `aspect_ratio` is the single spatial control and `quality`
+covers the resolution/quality tier across models — pass intent through those, not
+raw pixel sizes.

--- a/skills/instagram/SKILL.md
+++ b/skills/instagram/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: instagram
 description: Manage Instagram professional accounts via the Hyper MCP — publish photos, Reels, Stories, and carousels; moderate comments and mentions; send Direct Messages; pull account and media insights. Uses the Instagram API with Instagram Login (Business Login). Use when the user mentions Instagram posts, Reels, Stories, carousels, IG DMs, Instagram comments, mentions, profile, or analytics. For paid Instagram advertising, use `meta-ads`.
+metadata:
+  version: 1.0.0
 ---
 
 # Instagram

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: linkedin
 description: Publish and manage LinkedIn content via the Hyper MCP — text posts, article / link previews, document and PDF posts, organization (company page) posts, and AI-generated text-to-carousel posts. Use when the user wants to post on LinkedIn, share an article on LinkedIn, post to a LinkedIn company page, upload a PDF / document to LinkedIn, or build a LinkedIn carousel from text.
+metadata:
+  version: 1.0.0
 ---
 
 # LinkedIn

--- a/skills/meta-ads-library/SKILL.md
+++ b/skills/meta-ads-library/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: meta-ads-library
 description: Research competitor Facebook and Instagram ads from the Meta Ads Library via the Hyper MCP — search by keyword, pull full ad creative and metadata, enrich with page contact info for lead generation, and surface structured ad-intelligence summaries in chat. Use when the user wants to scrape the Meta Ads Library, spy on competitor ads, monitor new ads in a category, build a lead list from advertisers, or surface creative trends across an industry.
+metadata:
+  version: 1.0.0
 ---
 
 # Meta Ads Library

--- a/skills/meta-ads/SKILL.md
+++ b/skills/meta-ads/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: meta-ads
 description: Plan and create Meta (Facebook + Instagram) advertising campaigns end-to-end via the Hyper MCP, defaulting to Advantage+ automation. Use when the user wants to launch Meta ads, Facebook ads, Instagram ads, Advantage+ campaigns, carousel ads, dynamic creative ads, set up Meta conversion tracking, or build Meta performance dashboards. Also triggers on phrases like meta campaign, facebook campaign, advantage+, or meta blueprint.
+metadata:
+  version: 1.0.0
 ---
 
 # Meta Ads

--- a/skills/pinterest-ads/SKILL.md
+++ b/skills/pinterest-ads/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pinterest-ads
 description: Plan and create Pinterest Ads campaigns through the Hyper MCP — Awareness, Consideration, Video View, Web Conversion, Catalog Sales, and Web Sessions objectives — with strict microcurrency budgeting, CBO rules, audience and customer-list management, conversion tag handling, keyword targeting, and campaign analytics. Use when the user mentions Pinterest ads, Pinterest campaign, Pinterest ad group, Pinterest audience, Pinterest conversion tracking, Pinterest tag, or Pinterest customer list.
+metadata:
+  version: 1.0.0
 ---
 
 # Pinterest Ads

--- a/skills/seo-research/SKILL.md
+++ b/skills/seo-research/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: seo-research
 description: Data-driven SEO research and analysis through the Hyper MCP — keyword research, competitor analysis, content planning, AI search visibility (ChatGPT, Claude, Perplexity, Google AI Overviews), backlink trends, search intent classification, page speed / Core Web Vitals, and full site audits. Use when the user asks for an SEO audit, keyword research, content strategy, competitor benchmarks, brand visibility in AI search, ranking history, or any organic search analysis.
+metadata:
+  version: 1.0.0
 ---
 
 # SEO Research

--- a/skills/tiktok-ads/SKILL.md
+++ b/skills/tiktok-ads/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: tiktok-ads
 description: Plan and create TikTok advertising campaigns end-to-end via the Hyper MCP, with strict parameter validation for objective-specific requirements. Use when the user wants to launch TikTok ads, set up TikTok traffic or reach campaigns, configure conversions or app-promotion campaigns, upload TikTok video creatives, or analyze TikTok ad performance. Also triggers on tiktok marketing, tiktok campaign, tiktok ppc, or tiktok ads manager.
+metadata:
+  version: 1.0.0
 ---
 
 # TikTok Ads

--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: tiktok
 description: Publish organic TikTok content (videos, photos, carousels) through the TikTok-compliant interactive posting form via the Hyper MCP. Use when the user wants to post a video to TikTok, share photos on TikTok, upload to TikTok, or any phrase like "post this to TikTok" / "share on TikTok" / "put this on my TikTok". For paid TikTok advertising campaigns, use the `tiktok-ads` skill instead.
+metadata:
+  version: 1.0.0
 ---
 
 # TikTok

--- a/skills/video-generation/SKILL.md
+++ b/skills/video-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: video-generation
 description: End-to-end AI video production through the Hyper MCP — text-to-video and image-to-video generation (Sora, Veo, Seedance), scene chaining, video analysis, transcription, subtitles, TikTok / karaoke captions, voiceover (TTS), audio mixing, clipping, stitching, and text overlays. Use when the user asks to generate a video, create UGC, scene-chain, add captions or subtitles, add narration, stitch clips, clip a podcast highlight, or do any AI video editing.
+metadata:
+  version: 1.0.0
 ---
 
 # Video Generation & Editing

--- a/skills/video-generation/SKILL.md
+++ b/skills/video-generation/SKILL.md
@@ -15,7 +15,7 @@ This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to y
 
 | Group | Tools |
 |-------|-------|
-| Generation | `generate_video`, `sora_remix_video`, `sora_delete_video` |
+| Generation | `videos_generate`, `sora_remix_video`, `sora_delete_video` |
 | Analysis | `analyze_video`, `capture_video_frame`, `transcribe_video` |
 | Subtitles & captions | `generate_subtitles`, `burn_subtitles`, `burn_highlighted_captions` |
 | Audio | `text_to_speech`, `add_audio_to_video` |
@@ -31,7 +31,7 @@ This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to y
 
 | Tool | Purpose | Runs in Background |
 |------|---------|-------------------|
-| `generate_video` | Generate video from text / image prompt | Yes |
+| `videos_generate` | Generate video from text / image prompt | Yes |
 | `sora_remix_video` | Modify existing Sora video | Yes |
 | `sora_delete_video` | Delete a Sora video | No |
 | `capture_video_frame` | Extract frame as image | No |
@@ -71,7 +71,7 @@ analyze_video(file_id="...", question="Does this match: [original prompt]?")
 Always review generated videos before delivering to the user:
 
 ```python
-result = generate_video(prompt="...", model="veo-3.1-generate-preview")
+result = videos_generate(prompt="...", model="veo-3.1-generate-preview")
 review = analyze_video(file_id="video_file_id", analysis_type="quality_review")
 # If issues found, regenerate with adjustments. If quality is good, proceed to editing.
 ```
@@ -96,14 +96,14 @@ To create seamless multi-scene videos:
 ### Scene 1 (text-to-video)
 
 ```python
-generate_video(prompt="...", model="veo-3.1-generate-preview")
+videos_generate(prompt="...", model="veo-3.1-generate-preview")
 ```
 
 ### Scene 2+ (image-to-video)
 
 ```python
 capture_video_frame(video_file_id="scene1_file_id", frame_position="last")
-generate_video(prompt="continuation: ...", image_file_id="captured_frame_id")
+videos_generate(prompt="continuation: ...", image_file_id="captured_frame_id")
 ```
 
 Repeat: extract last frame → generate next scene.
@@ -251,7 +251,7 @@ clip_video(
 Complete workflow for producing UGC-style content:
 
 1. **Script:** plan scenes, dialogue, and visual style
-2. **Generate:** create each scene with `generate_video`
+2. **Generate:** create each scene with `videos_generate`
 3. **Review:** use `analyze_video` to check each scene for quality
 4. **Chain:** extract last frames with `capture_video_frame`, generate next scenes
 5. **Stitch:** combine all scenes with `stitch_videos`
@@ -263,7 +263,7 @@ Complete workflow for producing UGC-style content:
 ### Example: Narrated UGC Video
 
 ```python
-generate_video(prompt="...", model="veo-3.1-generate-preview")
+videos_generate(prompt="...", model="veo-3.1-generate-preview")
 
 audio = text_to_speech(text="Your narration script here...", voice="nova")
 

--- a/skills/youtube-transcript/SKILL.md
+++ b/skills/youtube-transcript/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: youtube-transcript
 description: Fetch and work with YouTube video transcripts and content. Use when the user pastes a YouTube URL and wants a transcript, summary, blog post, social post, quote extraction, show notes, or any other text derived from a video. Also use when the user wants to repurpose video content, research competitor videos, extract key points without watching, pull timestamps, translate a video, or analyze what someone said in a YouTube video.
+metadata:
+  version: 1.0.0
 ---
 
 # YouTube Transcript

--- a/validate-skills.sh
+++ b/validate-skills.sh
@@ -4,6 +4,7 @@
 # - `name` matches the folder name.
 # - SKILL.md is <= 500 lines.
 # - Description includes a "Use when" trigger phrase and is 50-500 chars.
+# - Frontmatter declares metadata.version (semantic version).
 # - Body contains a Requirements section pointing at app.hyperfx.ai/mcp.
 # - No banned internal references slipped through (hyper_cache_, seti., etc.).
 
@@ -74,6 +75,14 @@ for skill_dir in "${SKILLS_DIR}"/*/; do
             echo "FAIL ${skill_name}: description must include a trigger phrase ('Use when' or 'when the user')" >&2
             errors=$((errors + 1))
         fi
+    fi
+
+    # Required: metadata.version (semantic version) for clean per-skill versioning.
+    # Per the Agent Skills open standard, Hyper-specific fields live under the
+    # `metadata:` map; version is `metadata.version`.
+    if ! printf '%s\n' "${frontmatter}" | grep -qE '^[[:space:]]+version:[[:space:]]*"?[0-9]+\.[0-9]+\.[0-9]+'; then
+        echo "FAIL ${skill_name}: missing metadata.version (semantic version, e.g. 1.0.0)" >&2
+        errors=$((errors + 1))
     fi
 
     # Length cap: 500 lines.


### PR DESCRIPTION
## Summary
Companion to the seti tool change (one `images_generate` with a `model` arg + one `videos_generate`; the per-backend image tools are hidden from agents). Marketing skills that named the old per-backend tools (`openai_image_*`, `nano_banana_image_*`, `seedream_image_generation`, `generate_video`) would point the agent at tools it can't discover, so they're updated.

## Changes
- **image-generation** — clean rewrite: call `images_generate`, choose a `model` (`"gpt-image-2" | "nano-banana" | "nano-banana-pro" | "seedream-4.5"`, default `"auto"`); real params only. Adds `references/image-prompting.md`.
- **ad-creative-generation** (+ `references/*`) — tool/table/rules/examples updated to `images_generate(model=...)`; dropped the per-backend `size`/`image_size`/`model="pro"` params and the wrong "supported sizes" rule (the tool uses `aspect_ratio`/`quality`).
- **competitor-intel** — comparison-page asset tools → `images_generate`.
- **video-generation** — `generate_video` → `videos_generate`.

## Verification
- `grep` across `skills/` → 0 references to old tool names, `backend_hint`, or collapsed-duplicate / stale-`model="pro"` artifacts.