### PR TITLE
Migrate seti's curated skills: 14 new skills, 5 consolidations, frontmatter enrichment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
       "name": "hyper-marketing",
       "displayName": "Hyper Marketing",
       "source": "./",
-      "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 19 skills wrapping 100+ integrations and 500+ marketing tools.",
-      "version": "1.0.1",
+      "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 35 skills wrapping 100+ integrations and 500+ marketing tools.",
+      "version": "1.1.0",
       "category": "marketing",
       "tags": ["marketing", "ads", "seo", "social-media", "analytics", "email", "google-ads", "meta-ads", "tiktok"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hyper-marketing",
   "displayName": "Hyper Marketing",
-  "version": "1.0.1",
-  "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 19 skills wrapping 100+ integrations and 500+ marketing tools.",
+  "version": "1.1.0",
+  "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 35 skills wrapping 100+ integrations and 500+ marketing tools.",
   "author": {
     "name": "Hyper AI",
     "url": "https://hyperfx.ai"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Auto-detects your agent and drops the skills in the right directory. Then ask yo
 # install one
 npx skills add hyperfx-ai/marketing-skills --skill google-ads
 
-# install all 20
+# install all 35
 npx skills add hyperfx-ai/marketing-skills --all
 ```
 
@@ -77,12 +77,13 @@ That's `meta-ads` + `google-ads` + `tiktok-ads` + `ad-creative-generation` + `vi
 | Skill | What it does | Required integrations |
 |---|---|---|
 | **Paid ads** | | |
-| [`google-ads`](skills/google-ads) | Plan and launch Google Ads campaigns — Search, Display, and Performance Max. | Google Ads |
-| [`meta-ads`](skills/meta-ads) | Plan and launch Meta ad campaigns across Facebook and Instagram. | Meta Business, Firecrawl |
+| [`google-ads`](skills/google-ads) | Plan and launch Google Ads campaigns — Search, Display, Performance Max — and report on existing accounts with GAQL-backed evidence. | Google Ads |
+| [`meta-ads`](skills/meta-ads) | Plan and launch Meta ad campaigns across Facebook and Instagram, audit accounts, and build insight dashboards. | Meta Business, Firecrawl |
 | [`meta-ads-library`](skills/meta-ads-library) | Research competitor ads in the Meta Ads Library. | Apify |
 | [`amazon-ads`](skills/amazon-ads) | Plan and launch Amazon Sponsored Products campaigns. | Amazon Ads |
 | [`tiktok-ads`](skills/tiktok-ads) | Plan and launch TikTok ad campaigns across all objectives. | TikTok Marketing |
 | [`pinterest-ads`](skills/pinterest-ads) | Plan and launch Pinterest ad campaigns across all objectives. | Pinterest Ads |
+| [`openai-ads`](skills/openai-ads) | Manage OpenAI Ads campaigns — account discovery, chat_card creatives, status flow, insights. | OpenAI Ads |
 | **Social media** | | |
 | [`tiktok`](skills/tiktok) | Publish videos, photos, and carousels to TikTok. | TikTok (Login Kit) |
 | [`instagram`](skills/instagram) | Publish posts, Reels, Stories, and carousels. Moderate comments, send DMs, pull insights. | Instagram (Business Login) |
@@ -91,16 +92,35 @@ That's `meta-ads` + `google-ads` + `tiktok-ads` + `ad-creative-generation` + `vi
 | [`seo-research`](skills/seo-research) | Keyword research, SERP and AI Overview analysis, competitor benchmarks, AI search visibility, backlinks, site audits. | HyperSEO toolkit |
 | [`competitor-intel`](skills/competitor-intel) | Research competitors end-to-end — site, social, search rank, AI-search citations, mentions — and produce battle cards, weekly digests, or board-prep updates. | Firecrawl + at least one of HyperSEO or Apify scrapers |
 | [`customer-research`](skills/customer-research) | Mine Reddit, YouTube comments, G2/Capterra, Twitter, and TikTok to surface what customers actually say — build personas, VOC quote banks, JTBD maps, and synthesis reports. | Apify scrapers toolkit (Reddit, Twitter, YouTube, TikTok, Instagram) |
-| [`youtube-transcript`](skills/youtube-transcript) | Fetch the transcript of any YouTube video and turn it into blog posts, social content, summaries, show notes, quote extractions, or timestamped chapters. | YouTube toolkit |
+| [`youtube`](skills/youtube) | Fetch transcripts and turn them into blog posts, social content, summaries, or show notes; create high-CTR thumbnails and SEO titles/descriptions. | YouTube toolkit (+ image gen, sandbox for thumbnails) |
+| [`reddit`](skills/reddit) | Research Reddit discussions with high signal — pain points, intent discovery, trend tracking. | Reddit scraper |
 | **Creative** | | |
 | [`ad-creative-generation`](skills/ad-creative-generation) | Generate ad copy and on-brand images for Google and Meta placements. | Firecrawl + image gen toolkit |
 | [`image-generation`](skills/image-generation) | Generate and edit images — picks the right model for text-heavy creatives, photoreal product shots, or high-res output. | Image gen toolkit |
 | [`video-generation`](skills/video-generation) | Generate AI video and prep it for distribution — text/image-to-video, captions, voiceover, stitching, overlays. | Video gen toolkit |
+| **Strategy & orchestration** | | |
+| [`gtm`](skills/gtm) | GTM operating system — choose the focus (content, community, ads), write the marketing plan, run brand audits, and orchestrate the channel skills. | CMO toolkit + sandbox, Firecrawl, HyperSEO |
 | **Outbound & lifecycle** | | |
 | [`cold-email-outreach`](skills/cold-email-outreach) | Run end-to-end B2B cold outreach — prospect, enrich, personalize, send, follow up, route replies. | Gmail + Apollo (Firecrawl + LinkedIn scraper bundled) |
 | [`email-lifecycle`](skills/email-lifecycle) | Build welcome, nurture, re-engagement, win-back, and abandoned-cart email programs. | At least one of Klaviyo, Resend, Beehiiv, or Gmail |
+| **Messaging & comms** | | |
+| [`gmail`](skills/gmail) | Manage Gmail end-to-end — send, reply, drafts, labels, attachments, inbox organization. | Gmail |
+| [`slack`](skills/slack) | Slack messaging, Block Kit formatting, file sharing, channel management. | Slack |
+| [`twilio`](skills/twilio) | SMS, WhatsApp, voice calls, phone numbers, and OTP verification. | Twilio |
 | **Analytics** | | |
 | [`analytics-insights`](skills/analytics-insights) | Drive GA4, Google Tag Manager, Search Console, and BigQuery from chat — tracking plans, reports, conversions, container audits, BigQuery export queries. | At least one of GA4, GTM, GSC, or BigQuery |
+| **Documents & production** | | |
+| [`documents`](skills/documents) | Generate professional PDFs — reports, invoices, proposals, factsheets — and convert Markdown to styled PDFs. | Sandbox |
+| [`slides`](skills/slides) | Themed slide decks with reveal.js — in-browser preview, PPTX export. | Sandbox |
+| **Workspace & platform** | | |
+| [`sandbox`](skills/sandbox) | Execute code, build webapps, process files, and analyze data in the Hyper sandbox. | Sandbox |
+| [`database`](skills/database) | Hyper Database (PostgreSQL) for analytics, dashboards, data apps, and structured storage. | Hyper Database |
+| [`google-sheets`](skills/google-sheets) | Read, map, and write Google Sheets safely without shifting columns or clobbering ranges. | Google Sheets |
+| [`browser`](skills/browser) | Web browser automation, including authenticated sessions. | Web browsing toolkit |
+| [`agents`](skills/agents) | Manage agents — schedule tasks, update settings, create agents, delegate work. | Agents toolkit |
+| [`skill-creation`](skills/skill-creation) | Create new skills with the right folder structure and frontmatter. | — |
+| **Other** | | |
+| [`polymarket-trading`](skills/polymarket-trading) | Trade Polymarket prediction markets with a safe workflow and risk management. | Polymarket |
 | **Execution** | | |
 | [`hyper-cli`](skills/hyper-cli) | Run these marketing skills through the Hyper CLI (beta), translating raw MCP tool names into CLI aliases or raw toolkit calls. | Hyper CLI + the integrations required by the sibling skill |
 
@@ -212,17 +232,17 @@ Near-term skills and surfaces:
 
 - [x] `hyper-cli` (beta) — run these skills through the Hyper CLI from a terminal, cron job, or shell pipeline.
 - [ ] `google-ads-operator` — production Google Ads account operation and optimization.
-- [ ] `meta-account-audit` — Meta account diagnostics, spend checks, and performance recommendations.
+- [x] `meta-account-audit` — shipped inside [`meta-ads`](skills/meta-ads) (`references/account-audit.md`).
 - [ ] `social-carousel` — carousel planning, copy, and export for social channels.
-- [ ] `cmo` — executive marketing reporting and cross-channel performance summaries.
-- [ ] `reddit-research` — focused Reddit research workflows for VOC, market maps, and positioning.
-- [ ] `slide-generation` — turn research, reports, and campaign plans into presentation decks.
-- [ ] `pdf-generation` — generate polished marketing reports and briefs.
+- [x] `cmo` — shipped as [`gtm`](skills/gtm) (decision layer + execution orchestration).
+- [x] `reddit-research` — shipped as [`reddit`](skills/reddit).
+- [x] `slide-generation` — shipped as [`slides`](skills/slides).
+- [x] `pdf-generation` — shipped as [`documents`](skills/documents), markdown-to-PDF included.
 - [ ] `copywriting` — general-purpose marketing copy workflows.
 - [ ] `lead-generation` — prospect sourcing, enrichment, scoring, and handoff.
 - [ ] `crm-revops` — CRM hygiene, routing, attribution, and pipeline operations.
-- [ ] `google-sheets-writing` — structured spreadsheet creation and reporting.
-- [ ] `gmail-email-management` — inbox triage, labeling, reply drafting, and operational email workflows.
+- [x] `google-sheets-writing` — shipped as [`google-sheets`](skills/google-sheets).
+- [x] `gmail-email-management` — shipped as [`gmail`](skills/gmail).
 - [ ] `figma` — design workflow support for ad creative, landing pages, and campaign assets.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) to contribute a skill.

--- a/skills/ad-creative-generation/SKILL.md
+++ b/skills/ad-creative-generation/SKILL.md
@@ -1,6 +1,35 @@
 ---
 name: ad-creative-generation
 description: Generate on-brand ad creatives — visuals + copy — for Google, Meta (Facebook / Instagram), and other paid platforms via the Hyper MCP. Extracts brand identity from a website, writes ad copy variants, and produces brand-consistent images using reference-based image generation. Use when the user asks for ad creative, ad copy variants, RSA headlines, Meta ad creative, display ads, carousel ads, or A/B test variants.
+use_cases:
+  - Generate on-brand ad creatives for Meta campaigns
+  - Create Google Ads responsive search ad copy
+  - Produce brand-consistent display ad visuals
+  - Write ad copy variants from top-performing ads
+  - Generate carousel ad creatives
+  - Create A/B test ad variants
+  - Build ad creative packages from a landing page URL
+triggers:
+  - ad creative
+  - ad copy
+  - ad variant
+  - creative generation
+  - branded ad
+  - marketing creative
+  - rsa headlines
+  - meta ad creative
+  - google ad creative
+  - facebook ad
+  - instagram ad
+  - display ad
+requires_toolkits:
+  - firecrawl
+  - image_gen
+suggested_toolkits:
+  - meta_business
+  - file_manager
+  - google_ads
+  - tiktok_marketing
 ---
 
 # Ad Creative Generation

--- a/skills/agents/SKILL.md
+++ b/skills/agents/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: agents
+description: Manage yourself and other agents — schedule tasks, update settings, create new agents, and delegate work. Use when the user wants to modify an agent's behavior or prompt, adjust toolkits, attach skills or files, create a new agent, schedule recurring tasks, or run another agent.
+use_cases:
+  - Modify an agent's behavior
+  - Update an agent's system prompt
+  - Rename or describe agents
+  - Adjust agent toolkits
+  - Attach or detach agent skills/files/knowledge bases
+  - Create a new agent
+  - Schedule tasks on yourself or another agent
+  - Run agents
+  - Configure agent commands
+triggers:
+  - update agent
+  - modify system prompt
+  - change agent prompt
+  - edit agent settings
+  - agent configuration
+  - create agent
+  - build agent
+  - schedule task
+  - agent settings
+requires_toolkits:
+  - agents
+suggested_toolkits: []
+---
+
+# Agent Management
+
+Use this skill to manage yourself and other agents — creating, updating, scheduling, webhook tasks, and running.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Agents toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Task, Schedule, Trigger, Automation
+
+In Hyper these are the same stored concept: an agent trigger with task instructions.
+Users may call it a task, schedule, reminder, automation, webhook, or trigger.
+Choose the matching trigger type and create/update the trigger on the current agent unless the user explicitly names another agent.
+
+## Self-Management vs Creating New Agents
+
+You know your own agent ID (provided in your prompt context). Use this decision tree:
+
+| User intent | Action |
+|---|---|
+| "Do X every day" / "Schedule Y" / "Remind me weekly" | `agents_schedule(agent_id=YOUR_OWN_ID, ...)` |
+| "Create a webhook for this" / "Call this webhook" | `agents_triggers_create(agent_id=YOUR_OWN_ID, trigger_type="webhook", ...)` |
+| "Create a new agent for X" / "Build me an agent that does Y" | `agents_create(...)` |
+| "Run this on agent Z" | `agents_run(agent_id="Z", ...)` or `agents_schedule(agent_id="Z", ...)` |
+
+**Default to the current agent.** If the user says "create a task", "do this daily", "make a webhook", or "call this webhook", configure yourself — do not ask which agent or create a new agent unless explicitly asked.
+
+## Hard Delegation Rules
+
+- Use `agents_run` only when the user explicitly asks to run a specific agent, delegate to another agent, or approves creating a one-off dynamic agent.
+- Do not use `agents_run` as a fallback because another tool is unclear or inconvenient.
+- Do not use `agents_run` for normal media generation, image generation, video generation, browsing, research, or ad-creative work when direct tools already exist.
+- If the user did not ask for delegation, stay in the current agent and use the direct domain tools.
+
+## Prompt Field Rules
+
+1. `system_prompt` is the canonical behavior field for agents.
+2. `instructions` is for workflow-oriented use. Do not modify it unless the user explicitly asks.
+3. If the user says "modify your system prompt", update `system_prompt` only.
+
+## Resource Mentions
+
+Use canonical resource references in text:
+- Files: `{{$file:<file_id>}}`
+
+When you pass a plain-text `system_prompt` via `agents_create` or `agents_update`, the backend converts it to BlockNote format automatically. Resource references like `{{$file:id}}` become rich mention nodes in the UI.
+
+## Creating Agents
+
+Use `agents_create` with:
+
+**Required:** `name`, `system_prompt`, `description`
+
+**Optional:** `model`, `model_settings`, `toolkits`, `commands`, `output_type`, `exclude_native_toolkits`, `scope`
+
+**CRITICAL: Do NOT call `enable_toolkit` for toolkits intended for the new agent.** The `agents_create` tool accepts toolkit IDs directly via its `toolkits` parameter. Enabling toolkits in the current chat session adds them to your own session, not to the new agent. Just pass the toolkit IDs directly to `agents_create`. Use `search_toolkits` if you need to discover valid toolkit IDs.
+
+```python
+agents_create(
+    name="Research Assistant",
+    description="Helps with research tasks",
+    system_prompt="You are a helpful research assistant.",
+    toolkits=["system_web_toolkit"],
+    model="hyper-claude-sonnet"
+)
+```
+
+**After creation:** configure context resources with `agents_update_context`, then render a link: `agent/{agent_id}`
+
+## Updating Agents
+
+Use `agents_update` for core fields (name, description, system_prompt, model, toolkits, scope, etc.):
+
+```python
+agents_update(
+    agent_id="agent_123",
+    system_prompt="You are a concise assistant focused on actionable answers."
+)
+```
+
+For context resources (skills, files, knowledge bases), use `agents_update_context`:
+
+```python
+agents_update_context(
+    agent_id="agent_123",
+    resource_type="skill",
+    op="add",
+    ids=["curated/seo-research"]
+)
+```
+
+Only provided fields are changed.
+
+## Scheduling Tasks
+
+Use `agents_schedule` to set up recurring tasks — on yourself or another agent:
+
+```python
+agents_schedule(
+    agent_id="YOUR_OWN_ID",
+    instructions="Generate daily report",
+    cron="0 9 * * *",
+    timezone="UTC",
+)
+```
+
+## Running Agents
+
+Use `agents_run` to execute a specific agent immediately:
+
+```python
+agents_run(
+    agent_id="agent_123",
+    instructions="Analyze this data"
+)
+```
+
+## Trigger Creation Playbook
+
+Use this flow whenever a user asks to create or manage triggers.
+
+1. Discover trigger types with `agents_triggers_inventory(query=..., provider=...)`. Use `query`, not `search_query`.
+2. If the compact result is not enough, inspect the trigger with `agents_trigger_definition_get(trigger_type=...)`.
+3. Call resolver toolkit tools to fetch valid values (for example `twilio_phone_numbers_list`).
+4. Ask the user to confirm the target value when needed (for example which Twilio number to listen on).
+5. Create the trigger with `agents_triggers_create(...)`.
+
+### Native Webhook Example
+
+Use the native `webhook` trigger for inbound HTTP POSTs. The webhook endpoint is:
+
+```text
+https://api.hyperfx.ai/api/v1/webhooks/triggers/{trigger_id}
+```
+
+Create it on the current agent:
+
+```python
+agents_triggers_create(
+    agent_id="YOUR_OWN_ID",
+    trigger_type="webhook",
+    label="Inbound lead webhook",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "surname": {"type": "string"},
+        },
+    },
+    input={"message": "Process the webhook body."},
+    status="active",
+)
+```
+
+The tool returns `webhook_url` and the token needed for the `X-Webhook-Token` header.
+
+### Twilio SMS Example
+
+```python
+agents_triggers_inventory(query="twilio sms", provider="twilio")
+```
+
+Look for:
+- `trigger_type`: `twilio_sms_received`
+- required config: `phone_number_sid`
+- resolver tool: `twilio_phone_numbers_list`
+
+Then:
+
+```python
+agents_triggers_create(
+    agent_id="YOUR_OWN_ID",
+    trigger_type="twilio_sms_received",
+    label="Inbound SMS",
+    config={"phone_number_sid": "PN123"},
+    input={"message": "Handle inbound SMS and reply when needed."},
+    integration_auth_id="u_integration_...",
+    status="active",
+)
+```
+
+### Slack Trigger Example
+
+```python
+agents_triggers_inventory(query="slack message", provider="slack")
+```
+
+Pick the correct Slack trigger type, gather required config/integration values, then create:
+
+```python
+agents_triggers_create(
+    agent_id="YOUR_OWN_ID",
+    trigger_type="slack_message_posted",
+    label="Slack mentions",
+    config={"conversations": ["C123"]},
+    input={"message": "Handle Slack events for configured channels."},
+    integration_auth_id="u_integration_...",
+    status="active",
+)
+```
+
+## Trigger Listing And Search
+
+- Use `agents_triggers_list` to inspect only the selected agent's triggers.
+- Use `agents_triggers_get` for full task details, input schema, and webhook configuration.
+- Use `query`, `offset`, and `limit` for paginated review.
+- Keep `limit` small for iterative discovery (default is 10).
+
+## Commands (Slash Commands)
+
+Agents can define reusable commands that show up in the chat `/` menu.
+
+| Field | Description |
+|-------|-------------|
+| `name` | Required display label |
+| `description` | Optional help text |
+| `shortcut` | Optional keyboard shortcut (e.g., `cmd+k`) |
+| `action` | Editor content inserted into chat input when selected |
+
+## What Not To Do
+
+- Do not rewrite both `system_prompt` and `instructions` unless explicitly requested.
+- Do not clear toolkits unless the user asks to remove them.
+- Do not mutate `attached_resources` via `agents_update(field=...|path=...)`.
+- Do not use `agents_update` to change skills/files/knowledge bases — use `agents_update_context`.
+- Do not create a new agent when the user just wants to schedule a task on themselves.
+- Do not ask which agent to use for a task/webhook unless the user explicitly references another agent.
+- Do not call `agents_run` without `agent_id` unless the user explicitly approved a dynamic one-off agent.
+- Do not call `enable_toolkit` for toolkits that are only intended for a new agent — pass them directly to `agents_create(toolkits=[...])`.

--- a/skills/amazon-ads/SKILL.md
+++ b/skills/amazon-ads/SKILL.md
@@ -1,6 +1,32 @@
 ---
 name: amazon-ads
 description: Plan and create Amazon Sponsored Products campaigns end-to-end via the Hyper MCP. Use when the user wants to launch Amazon Ads, set up Sponsored Products, manage keyword targeting and bids, configure ASIN or category product targeting, add negative keywords, automate budget rules, analyze ACoS / ROAS, or generate Sponsored Products reports. Also triggers on amazon ppc, amazon campaign, amazon keywords, or amazon report.
+use_cases:
+  - Create Amazon Sponsored Products campaigns
+  - Manage keyword targeting and bids
+  - Set up product targeting (ASIN/category)
+  - Add negative keywords to reduce wasted spend
+  - Configure budget rules for automation
+  - Analyze campaign performance and ACoS
+  - Generate SP reports (campaign, search term, targeting)
+  - Check integration health and profile setup
+  - Create campaigns with multi-profile support
+triggers:
+  - amazon ads
+  - sponsored products
+  - amazon campaign
+  - amazon ppc
+  - acos
+  - amazon keywords
+  - product targeting
+  - amazon report
+  - amazon budget rule
+requires_toolkits:
+  - amazon_ads
+suggested_toolkits:
+  - hyper_database
+  - sandbox
+  - file_manager
 ---
 
 # Amazon Ads

--- a/skills/analytics-insights/SKILL.md
+++ b/skills/analytics-insights/SKILL.md
@@ -1,6 +1,24 @@
 ---
 name: analytics-insights
 description: Drive Google Analytics (GA4), Google Tag Manager, Google Search Console, and BigQuery from chat — tracking plans, GA4 reports, key-event (conversion) setup, custom dimensions and metrics, GTM audits, GSC performance, and GA4 BigQuery export queries. Use when the user wants an analytics audit, a GA4 report, a tracking plan, conversion setup, GTM cleanup, search-performance data, or asks "how is the site performing?" or "are my conversions firing?".
+use_cases:
+  - Analyze GA4 traffic trends
+  - Evaluate page performance
+  - Review source and medium performance
+  - Assess engagement and conversion metrics
+  - Build analytics summaries with SQL-backed evidence
+  - Build Google Analytics dashboards
+triggers:
+  - google analytics
+  - ga4
+  - web analytics
+  - traffic analysis
+  - conversion analysis
+  - analytics dashboard
+requires_toolkits:
+  - google_analytics_toolkit
+suggested_toolkits:
+  - hyper_database
 ---
 
 # Analytics Insights

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: browser
+description: Control a web browser for automation tasks, including authenticated sessions. Use when the user wants to automate a website, fill forms, navigate logged-in pages, save auth state, or extract data that requires real browser interaction.
+use_cases:
+  - Browse websites automatically
+  - Interact with web pages
+  - Use authenticated browser sessions
+  - Scrape web content
+  - Automate browser workflows
+  - LinkedIn automation
+  - Web navigation tasks
+triggers:
+  - browser
+  - web automation
+  - browse
+  - navigate
+  - linkedin
+  - authenticated browsing
+requires_toolkits:
+  - web_browsing_toolkit
+suggested_toolkits: []
+---
+
+# Web Browser Automation
+
+You have access to a full browser that you can control for web automation tasks.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Web browsing toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Authenticated Sessions
+
+When using a browser that already has an authenticated context, try to go as far as possible without user assistance. For example, when using LinkedIn, you could be redirected to select an active login - use it.
+
+### Using Browser Contexts
+
+Browser contexts allow you to use pre-authenticated sessions for sites like LinkedIn, Gmail, etc.
+
+**If a browser context is selected:**
+- Use `web_browser_initialize_session(browser_context_id="<id>")` to start the browser with that context
+
+**If no context is selected but the task requires authentication:**
+1. Call `web_browser_list_contexts` to see available contexts
+2. If a relevant context exists, confirm with the user FIRST before using it
+3. Start with `web_browser_initialize_session(browser_context_id="<id>")`
+4. If no suitable context exists, ask the user to add or select one
+
+## Key Rules
+
+- **Only use browser contexts within the web_browsing_toolkit** - don't try to use them with other toolkits
+- When working with authenticated sites, always try to proceed as far as possible automatically
+- Handle login prompts and redirects automatically when using an authenticated context
+- **Do NOT take screenshots after every action** - the user can see the browser via the live view. Only take screenshots when the user explicitly requests one or you need to visually analyze page content
+
+## Common Workflows
+
+### Basic Web Navigation
+1. Initialize browser session
+2. Navigate to target URL
+3. Interact with page elements
+4. Extract or process content
+
+### Authenticated Site Access
+1. List available browser contexts
+2. Confirm context selection with user
+3. Initialize session with context
+4. Proceed with automated tasks
+
+### Workflow Mode Differences
+In workflow/automated environments:
+- Attempt to use the browser without context first
+- Only ask about browser contexts if it clearly fails
+
+In interactive mode:
+- Confirm browser context usage with the user before starting

--- a/skills/cold-email-outreach/SKILL.md
+++ b/skills/cold-email-outreach/SKILL.md
@@ -1,6 +1,28 @@
 ---
 name: cold-email-outreach
 description: Run end-to-end B2B cold-email outreach through the Hyper MCP — enrich prospects with Apollo, scrape per-prospect signals from company sites and LinkedIn, draft personalized emails using proven hook frameworks, send via Gmail with safe defaults, and route replies into labeled folders. Use when the user wants to write cold emails, run an outbound sequence, prospect a list, build a follow-up cadence, "reach out to leads," or asks why nobody is replying to their cold emails.
+use_cases:
+  - Build and enrich a B2B prospect list with Apollo
+  - Scrape per-prospect signals from company sites
+  - Draft personalized cold emails with proven hook frameworks
+  - Send cold email sequences via Gmail with safe volumes
+  - Build a follow-up cadence and route replies into labeled folders
+  - Diagnose why a cold email campaign gets no replies
+triggers:
+  - cold email
+  - cold outreach
+  - outbound
+  - prospecting
+  - email sequence
+  - follow-up cadence
+  - apollo
+requires_toolkits:
+  - apollo
+  - gmail
+suggested_toolkits:
+  - firecrawl
+  - sandbox
+  - file_manager
 ---
 
 # Cold Email Outreach

--- a/skills/competitor-intel/SKILL.md
+++ b/skills/competitor-intel/SKILL.md
@@ -1,6 +1,27 @@
 ---
 name: competitor-intel
 description: Run end-to-end competitor research and monitoring through the Hyper MCP — pick the set, scrape every public surface (site, blog, pricing, organic social, search rank, mentions, demand) via Firecrawl + HyperSEO + the Apify scrapers, diff against last run, and synthesize a brief. Use when the user wants to research competitors, build a battle card or comparison page, run a weekly digest, or asks "what's [competitor] doing?" or "how do we compare?".
+use_cases:
+  - Pick and track a competitor set
+  - Scrape competitor sites, blogs, and pricing pages
+  - Monitor competitor search rankings and mentions
+  - Diff competitor changes against the last run
+  - Build a battle card or comparison page
+  - Run a weekly competitor digest
+triggers:
+  - competitor research
+  - competitor analysis
+  - competitive intel
+  - battle card
+  - comparison page
+  - what are competitors doing
+requires_toolkits:
+  - firecrawl
+  - hyperseo
+suggested_toolkits:
+  - sandbox
+  - file_manager
+  - hyper_database
 ---
 
 # Competitor Intel

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -1,6 +1,28 @@
 ---
 name: customer-research
 description: Mine online communities and analyze existing assets to understand what customers actually think, say, and struggle with. Use when the user wants to do customer research, ICP research, voice-of-customer (VOC), review mining, Reddit mining, YouTube comment analysis, G2/Capterra scraping, build customer personas, map jobs to be done, understand churn reasons, or find authentic customer language for copy. Also use when given transcripts, surveys, or support tickets to synthesize.
+use_cases:
+  - Mine Reddit threads for customer pain points
+  - Analyze YouTube comments for voice-of-customer language
+  - Scrape and synthesize G2/Capterra reviews
+  - Build customer personas from real quotes
+  - Map jobs to be done from community discussions
+  - Synthesize transcripts, surveys, or support tickets
+triggers:
+  - customer research
+  - voice of customer
+  - review mining
+  - reddit mining
+  - customer personas
+  - jobs to be done
+  - icp research
+requires_toolkits:
+  - reddit_scraper
+  - youtube_toolkit
+suggested_toolkits:
+  - firecrawl
+  - sandbox
+  - file_manager
 ---
 
 # Customer Research

--- a/skills/database/SKILL.md
+++ b/skills/database/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: database
+description: Use the Hyper Database (PostgreSQL) for analytics, dashboards, data apps, and structured data storage. Use when the user wants to save datasets, build dashboards or data apps, run SQL queries, or move data between tools.
+use_cases:
+  - Save data to database for analysis
+  - Build analytics dashboards and data apps
+  - Query structured data with SQL
+  - Cross-tool data transfers
+triggers:
+  - dashboard
+  - data app
+  - analytics
+  - save to database
+  - SQL query
+  - data table
+  - chart
+  - KPI
+  - metrics
+requires_toolkits:
+  - hyper_database
+---
+
+# Hyper Database (PostgreSQL)
+
+Tenant-isolated database for structured data, analytics, dashboards, and data
+apps.
+NOTE: This is different from external databases that are connected by users.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Hyper Database toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Database Tools
+
+| Tool | Purpose |
+|------|---------|
+| `hyper_data_sql(sql, limit, confirm_mutation)` | Run SQL for exploration, aggregation, joins, and intentional mutations; `query` is accepted only as a compatibility alias |
+| `hyper_data_save(table, data, mode)` | Save data to table |
+| `hyper_data_sync(source_tool, dest_tool, ...)` | Tool-to-tool transfers |
+| `hyper_data_list_tables()` | List available tables |
+| `hyper_data_describe_tables(tables, ...)` | Describe selected tables; `table_names` is accepted only as a compatibility alias |
+| `hyper_data_search_ui_components(query, kind)` | Discover valid dashboard/data app UI component and action names |
+| `hyper_data_build_dashboard(...)` | Create or update a dashboard or data app |
+| `hyper_data_list_dashboards()` | List existing dashboards |
+| `hyper_data_publish_dashboard(name, dashboard_ids)` | Publish dashboards as a shareable interface |
+| `hyper_data_update_interface(interface_id, ...)` | Edit a published interface (rename, add dashboards, set password) |
+
+## When to Use
+
+| Scenario | Action |
+|----------|--------|
+| User asks to save/store data | `hyper_data_save` |
+| Data needed for reusable analysis | `hyper_data_save` then query or build dashboard |
+| User asks for a visual dashboard or data app from provided/static data | Build the interface directly from the provided values; SQL is optional |
+| Full website scrape (30+ pages) | Create Knowledge Base, query it |
+
+## When NOT to Use
+
+**DO NOT save:**
+- Temporary test results or one-time tool verification outputs
+- Debug outputs or diagnostic checks
+- Results not explicitly requested by the user for storage
+- Transient data that won't be used for downstream analysis
+
+| Scenario | Why |
+|----------|-----|
+| Testing tool functionality | One-time verification, no need to persist |
+| Debug outputs | Transient diagnostic data |
+| Small result sets user can read | No benefit to database storage |
+| Results user didn't ask to save | Respect user intent, don't auto-save |
+
+## Safety Rules
+
+- Use `hyper_data_sql` for exploration and aggregation queries.
+- Use `hyper_data_sql` with `confirm_mutation=True` only for destructive
+  operations such as `DROP`, `TRUNCATE`, or broad `DELETE`.
+- ALWAYS confirm before DROP/DELETE/TRUNCATE operations
+- **System tables** (`*_insights_*`): Created by syncs - extra caution
+
+## Dashboard And Data App Work
+
+For requests to create, edit, publish, or visually improve dashboards or data
+apps, load
+`references/dashboard-building.md`.
+
+Do not load the dashboard/data app reference for normal SQL exploration, table
+listing, data saving, or one-off analysis.
+
+Dashboard/data app implementation details are internal. In user-facing
+responses, say "dashboard", "data app", "report", or "interactive view"; do not
+mention the underlying implementation argument unless the user asks how it is
+built.
+
+## Common Mistakes to Avoid
+
+- Saving temporary debug output or one-off verification data without user
+  intent.
+- Running destructive SQL without explicit confirmation.
+- Querying system tables casually; treat `*_insights_*` tables as generated
+  sync artifacts.
+- Using the dashboard/data app reference for normal database tasks.

--- a/skills/database/references/dashboard-building.md
+++ b/skills/database/references/dashboard-building.md
@@ -1,0 +1,130 @@
+# Building Dashboards And Data Apps
+
+A dashboard is a saved visual report in Hyper. A data app is the same idea, but
+it may include controls, refreshes, or tool-backed data.
+
+Hyper dashboards use Prefab. Prefab is the UI system that renders dashboard
+components such as cards, metrics, charts, tables, grids, rows, columns,
+buttons, and controls.
+
+You build a dashboard by writing Python source with `prefab_ui` components, then
+passing that source to `hyper_data_build_dashboard` as `prefab_python`. The
+dashboard tool runs that Python in its own renderer sandbox and saves the
+rendered dashboard.
+
+## The Tools To Use
+
+Use `hyper_data_build_dashboard` to create or update the dashboard.
+
+Always call `hyper_data_search_ui_components` before writing dashboard code. Use
+it to confirm component names and available dashboard UI primitives instead of
+assuming imports, component names, or props.
+
+`hyper_data_build_dashboard(name, prefab_python, description, sql_data_sources, tool_data_sources, dashboard_id)`
+
+Required:
+
+- `name`
+- `prefab_python`
+
+Optional:
+
+- `description`
+- `sql_data_sources` when reading Hyper Database tables
+- `tool_data_sources` when first calling another tool and caching its rows
+- `dashboard_id` when updating an existing dashboard
+
+## Choose The Data Source
+
+1. If the user gives numbers or asks for a static showcase:
+   Put small example data directly inside `prefab_python`.
+2. If the data is already in Hyper Database:
+   Use `sql_data_sources`. Each SQL source creates a Python variable used inside
+   `prefab_python`.
+3. If the data must come from another tool, such as Google Ads, Gmail, Slack, or
+   another provider:
+   Use `tool_data_sources` to call the tool and cache rows. Then use
+   `sql_data_sources` to shape those cached rows into dashboard variables.
+4. If editing an existing dashboard:
+   Pass the existing `dashboard_id` so the dashboard updates in place.
+
+## Build Workflow
+
+1. Pick the closest example below before writing code.
+2. Call `hyper_data_search_ui_components` for the components you plan to use,
+   such as `card`, `metric`, `chart`, `table`, or `select`.
+3. Write `prefab_python` using `prefab_ui`.
+4. Start with the page layout: `PrefabApp`, then `Column`, `Grid`, `Card`, and
+   `CardContent`.
+5. Add 3-4 headline `Metric` cards.
+6. Add one main chart and one supporting chart or table.
+7. Add detail rows or a `DataTable` when useful.
+8. Call `hyper_data_build_dashboard`.
+9. If the user needs a shareable link, call `hyper_data_publish_dashboard`.
+
+## Aesthetic Rules
+
+A good dashboard should look like an app, not a plain document.
+
+- Use a light gray page background and place white cards on top.
+- Put every KPI, chart, table, and detail section inside a `Card` with
+  `CardContent`.
+- Use `Column(gap=6, css_class="p-6 bg-muted/30 min-h-screen")` or a similar
+  page wrapper.
+- Use `Grid(columns=4, gap=4)` for KPI cards.
+- Use `Grid(columns=[2, 1], gap=6)` or `Grid(columns=[3, 1], gap=6)` for a main
+  chart plus a supporting section.
+- Keep chart titles small and muted inside cards.
+- Avoid floating charts, oversized headings inside cards, and bare white pages.
+
+## Basic Code Shape
+
+```python
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import ChartSeries, LineChart
+
+rows = [
+    {"date": "Jan", "revenue": 12000},
+    {"date": "Feb", "revenue": 18000},
+]
+
+with PrefabApp(title="Revenue Dashboard") as app:
+    with Column(gap=6, css_class="p-6 bg-muted/30 min-h-screen"):
+        Heading("Revenue Dashboard")
+        Muted("Static example data")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Revenue", value="$30K", delta="+12%", trend="up")
+
+        with Card():
+            with CardContent():
+                Text(
+                    "Revenue trend",
+                    css_class="text-sm font-medium text-muted-foreground mb-2",
+                )
+                LineChart(
+                    data=rows,
+                    x_axis="date",
+                    series=[ChartSeries(data_key="revenue", label="Revenue")],
+                )
+```
+
+## Which Example To Load
+
+- Static/user-provided data: `dashboard-examples/static-marketing-dashboard.md`
+- Hyper Database SQL dashboard: `dashboard-examples/sales-sql-dashboard.md`
+- Tool-backed dashboard:
+  `dashboard-examples/marketing-performance-dashboard.md`
+- Live data app with refresh/state:
+  `dashboard-examples/system-monitor-data-app.md`
+
+## If A Build Fails
+
+Fix the same `prefab_python` source and call `hyper_data_build_dashboard` again.
+
+Use `hyper_data_search_ui_components` and the closest example as the source of
+truth for component names, imports, and structure. Reduce the dashboard to a
+small working version, then add sections back one at a time.

--- a/skills/database/references/dashboard-examples/marketing-performance-dashboard.md
+++ b/skills/database/references/dashboard-examples/marketing-performance-dashboard.md
@@ -1,0 +1,120 @@
+# Marketing Performance Dashboard Example
+
+Use this when the dashboard requires data from another tool. The agent should
+declare `tool_data_sources` to call the tool and cache rows, then use
+`sql_data_sources` to shape dashboard variables from the cache table.
+
+```python
+hyper_data_build_dashboard(
+    name="Marketing Performance Dashboard",
+    description="Marketing dashboard backed by a tool cache table and SQL data sources",
+    tool_data_sources={
+        "raw_campaign_performance": {
+            "tool_name": "meta_ads_get_campaign_performance",
+            "tool_args": {
+                "date_preset": "last_30d",
+                "fields": ["campaign", "channel", "spend", "conversions", "revenue"],
+            },
+            "cache_table": "meta_campaign_performance_last_30d",
+            "mode": "replace",
+            "rows_path": "rows",
+        }
+    },
+    sql_data_sources={
+        "total_spend": {
+            "sql": "select '$' || to_char(sum(spend), 'FM999,999') from meta_campaign_performance_last_30d",
+            "shape": "scalar",
+        },
+        "total_conversions": {
+            "sql": "select sum(conversions) from meta_campaign_performance_last_30d",
+            "shape": "scalar",
+        },
+        "cost_per_acquisition": {
+            "sql": "select '$' || round(sum(spend) / nullif(sum(conversions), 0), 0) from meta_campaign_performance_last_30d",
+            "shape": "scalar",
+        },
+        "roas": {
+            "sql": "select round(sum(revenue) / nullif(sum(spend), 0), 1) || 'x' from meta_campaign_performance_last_30d",
+            "shape": "scalar",
+        },
+        "campaign_rows": {
+            "sql": "select campaign, spend, conversions, round(spend / nullif(conversions, 0), 0) as cpa, round(revenue / nullif(spend, 0), 1) as roas from meta_campaign_performance_last_30d order by spend desc",
+            "shape": "rows",
+        },
+        "channel_rows": {
+            "sql": "select channel, sum(spend) as spend, round(sum(revenue) / nullif(sum(spend), 0), 1) as roas from meta_campaign_performance_last_30d group by channel order by spend desc",
+            "shape": "rows",
+        },
+        "spend_delta": {"sql": "select '+12% vs prior period'", "shape": "scalar"},
+        "conversion_delta": {"sql": "select '+18% vs prior period'", "shape": "scalar"},
+        "cpa_delta": {"sql": "select '-9% vs prior period'", "shape": "scalar"},
+        "roas_delta": {"sql": "select '+0.4x vs prior period'", "shape": "scalar"},
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, Grid, Heading, Metric, Muted, Row, Separator, Text
+from prefab_ui.components.charts import BarChart, ChartSeries
+from prefab_ui.components.data_table import DataTable, DataTableColumn
+
+with PrefabApp(title="Marketing Performance Dashboard") as app:
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Marketing Performance Dashboard")
+            Muted("Tool rows cached first, then SQL shapes dashboard variables")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Spend", value=total_spend, delta=spend_delta, trend="up")
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=total_conversions, delta=conversion_delta, trend="up")
+            with Card():
+                with CardContent():
+                    Metric(label="CPA", value=cost_per_acquisition, delta=cpa_delta, trend="down")
+            with Card():
+                with CardContent():
+                    Metric(label="ROAS", value=roas, delta=roas_delta, trend="up")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Spend and conversions by campaign", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=campaign_rows,
+                        x_axis="campaign",
+                        series=[
+                            ChartSeries(data_key="spend", label="Spend"),
+                            ChartSeries(data_key="conversions", label="Conversions"),
+                        ],
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Channel mix", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        rows=channel_rows,
+                        columns=[
+                            DataTableColumn(key="channel", header="Channel"),
+                            DataTableColumn(key="spend", header="Spend"),
+                            DataTableColumn(key="roas", header="ROAS"),
+                        ],
+                    )
+
+        Separator()
+        Text("Campaign detail", css_class="text-lg font-semibold")
+        DataTable(
+            rows=campaign_rows,
+            columns=[
+                DataTableColumn(key="campaign", header="Campaign", sortable=True),
+                DataTableColumn(key="spend", header="Spend", sortable=True),
+                DataTableColumn(key="conversions", header="Conversions", sortable=True),
+                DataTableColumn(key="cpa", header="CPA", sortable=True),
+                DataTableColumn(key="roas", header="ROAS", sortable=True),
+            ],
+            search=True,
+            paginated=True,
+        )
+""",
+)
+```

--- a/skills/database/references/dashboard-examples/sales-sql-dashboard.md
+++ b/skills/database/references/dashboard-examples/sales-sql-dashboard.md
@@ -1,0 +1,133 @@
+# SQL Sales Dashboard Example
+
+Use this pattern when dashboard values should be queried from Hyper Database.
+Keep SQL in `sql_data_sources` and reference injected variables in the
+dashboard source.
+
+```python
+{
+  "name": "Sales Performance Dashboard",
+  "description": "Weekly sales analysis with headline metrics and trend detail",
+  "prefab_python": """
+from prefab_ui import PrefabApp
+from prefab_ui.components import (
+    Card,
+    CardContent,
+    Column,
+    DataTable,
+    DataTableColumn,
+    Grid,
+    Heading,
+    Metric,
+    Muted,
+    Row,
+    Separator,
+    Text,
+)
+from prefab_ui.components.charts import AreaChart, ChartSeries, PieChart
+
+with PrefabApp(title="Sales Performance Dashboard") as app:
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Sales Dashboard")
+            Muted("Current quarter performance")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(
+                        label="Revenue Last 7 Days",
+                        value=revenue_last_7_days,
+                        delta=revenue_delta,
+                        trend="up",
+                    )
+            with Card():
+                with CardContent():
+                    Metric(label="Active Customers", value=active_customers)
+            with Card():
+                with CardContent():
+                    Metric(label="Average Deal Size", value=avg_deal_size)
+            with Card():
+                with CardContent():
+                    Metric(label="Win Rate", value=win_rate)
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text(
+                        "Revenue Trend",
+                        css_class="text-sm font-medium text-muted-foreground mb-2",
+                    )
+                    AreaChart(
+                        data=daily_revenue,
+                        x_axis="date",
+                        series=[ChartSeries(data_key="revenue", label="Revenue")],
+                        height=300,
+                        y_axis_format="compact",
+                    )
+
+            with Card():
+                with CardContent():
+                    Text(
+                        "Revenue by Segment",
+                        css_class="text-sm font-medium text-muted-foreground mb-2",
+                    )
+                    PieChart(
+                        data=revenue_by_segment,
+                        data_key="revenue",
+                        name_key="segment",
+                        inner_radius=50,
+                        height=300,
+                    )
+
+        Separator()
+
+        Text("Top Accounts", css_class="text-lg font-semibold")
+        DataTable(
+            rows=top_accounts,
+            columns=[
+                DataTableColumn(key="account_name", header="Account", sortable=True),
+                DataTableColumn(key="revenue", header="Revenue", sortable=True),
+                DataTableColumn(key="owner", header="Owner", sortable=True),
+                DataTableColumn(key="stage", header="Stage", sortable=True),
+            ],
+            search=True,
+            paginated=True,
+        )
+""",
+  "sql_data_sources": {
+    "revenue_last_7_days": {
+      "sql": "select coalesce(sum(revenue), 0) from sales where date >= current_date - interval '7 days'",
+      "shape": "scalar"
+    },
+    "revenue_delta": {
+      "sql": "select '+18.2% YoY'",
+      "shape": "scalar"
+    },
+    "active_customers": {
+      "sql": "select count(distinct account_id) from sales where date >= current_date - interval '90 days'",
+      "shape": "scalar"
+    },
+    "avg_deal_size": {
+      "sql": "select coalesce(avg(revenue), 0) from sales where date >= current_date - interval '90 days'",
+      "shape": "scalar"
+    },
+    "win_rate": {
+      "sql": "select coalesce(round(100.0 * sum(case when stage = 'Closed Won' then 1 else 0 end) / nullif(count(*), 0), 1), 0) from opportunities",
+      "shape": "scalar"
+    },
+    "daily_revenue": {
+      "sql": "select date, sum(revenue) as revenue from sales group by date order by date",
+      "shape": "rows"
+    },
+    "revenue_by_segment": {
+      "sql": "select segment, sum(revenue) as revenue from sales group by segment order by revenue desc",
+      "shape": "rows"
+    },
+    "top_accounts": {
+      "sql": "select account_name, sum(revenue) as revenue, max(owner) as owner, max(stage) as stage from sales group by account_name order by revenue desc limit 10",
+      "shape": "rows"
+    }
+  }
+}
+```

--- a/skills/database/references/dashboard-examples/static-marketing-dashboard.md
+++ b/skills/database/references/dashboard-examples/static-marketing-dashboard.md
@@ -1,0 +1,105 @@
+# Static Marketing Dashboard Example
+
+Use this pattern when the user provides the data directly or the dataset is
+small enough to define inline. Do not require SQL for this case.
+
+```python
+hyper_data_build_dashboard(
+    name="Marketing Snapshot",
+    description="Static KPI dashboard from user-provided channel metrics",
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import (
+    Card,
+    CardContent,
+    Column,
+    DataTable,
+    DataTableColumn,
+    Grid,
+    Heading,
+    Metric,
+    Muted,
+    Row,
+    Separator,
+    Text,
+)
+from prefab_ui.components.charts import BarChart, ChartSeries
+
+channel_rows = [
+    {"channel": "Search", "leads": 124, "cost": 4200, "conversion": 7.8},
+    {"channel": "Social", "leads": 76, "cost": 3100, "conversion": 4.9},
+    {"channel": "Email", "leads": 42, "cost": 800, "conversion": 12.2},
+]
+
+total_leads = sum(row["leads"] for row in channel_rows)
+total_cost = sum(row["cost"] for row in channel_rows)
+cost_per_lead = round(total_cost / total_leads)
+best_channel = max(channel_rows, key=lambda row: row["conversion"])
+
+with PrefabApp(title="Marketing Snapshot") as app:
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Marketing Snapshot")
+            Muted("Static channel performance")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Total Leads", value=total_leads)
+            with Card():
+                with CardContent():
+                    Metric(label="Spend", value=f"${total_cost:,}")
+            with Card():
+                with CardContent():
+                    Metric(label="Cost per Lead", value=f"${cost_per_lead}")
+            with Card():
+                with CardContent():
+                    Metric(label="Best Channel", value=best_channel["channel"])
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text(
+                        "Leads by channel",
+                        css_class="text-sm font-medium text-muted-foreground mb-2",
+                    )
+                    BarChart(
+                        data=channel_rows,
+                        x_axis="channel",
+                        series=[ChartSeries(data_key="leads", label="Leads")],
+                        height=280,
+                    )
+
+            with Card():
+                with CardContent():
+                    Text(
+                        "Conversion leaders",
+                        css_class="text-sm font-medium text-muted-foreground mb-2",
+                    )
+                    with Column(gap=2):
+                        for row in sorted(
+                            channel_rows,
+                            key=lambda item: item["conversion"],
+                            reverse=True,
+                        ):
+                            with Row(justify="between", align="center"):
+                                Text(row["channel"])
+                                Muted(f"{row['conversion']}%")
+
+        Separator()
+
+        Text("Channel detail", css_class="text-lg font-semibold")
+        DataTable(
+            rows=channel_rows,
+            columns=[
+                DataTableColumn(key="channel", header="Channel", sortable=True),
+                DataTableColumn(key="leads", header="Leads", sortable=True),
+                DataTableColumn(key="cost", header="Cost", sortable=True),
+                DataTableColumn(key="conversion", header="Conversion", sortable=True),
+            ],
+            search=True,
+            paginated=False,
+        )
+""",
+)
+```

--- a/skills/database/references/dashboard-examples/system-monitor-data-app.md
+++ b/skills/database/references/dashboard-examples/system-monitor-data-app.md
@@ -1,0 +1,140 @@
+#  System Monitor Data App Example
+
+Use this pattern when a dashboard/data app depends on another tool. The agent
+should call `hyper_data_build_dashboard` with `tool_data_sources`; it should not
+write or launch a standalone MCP server.
+
+Tool sources populate cache tables. SQL sources then shape those cached rows
+into variables for the data app.
+
+```python
+hyper_data_build_dashboard(
+    name="System Monitor",
+    description=" operations dashboard with live host metrics",
+    tool_data_sources={
+        "system_stats": {
+            "tool_name": "system_monitor_snapshot",
+            "tool_args": {
+                "include_processes": True,
+                "history_points": 100,
+            },
+            "cache_table": "system_monitor_snapshot_latest",
+            "mode": "replace",
+            "rows_path": "rows",
+        }
+    },
+    sql_data_sources={
+        "cpu_pct": {
+            "sql": "select cpu_pct from system_monitor_snapshot_latest order by captured_at desc limit 1",
+            "shape": "scalar",
+        },
+        "memory_pct": {
+            "sql": "select memory_pct from system_monitor_snapshot_latest order by captured_at desc limit 1",
+            "shape": "scalar",
+        },
+        "disk_pct": {
+            "sql": "select disk_pct from system_monitor_snapshot_latest order by captured_at desc limit 1",
+            "shape": "scalar",
+        },
+        "uptime": {
+            "sql": "select uptime from system_monitor_snapshot_latest order by captured_at desc limit 1",
+            "shape": "scalar",
+        },
+        "host_label": {
+            "sql": "select hostname || ' · ' || platform from system_monitor_snapshot_latest order by captured_at desc limit 1",
+            "shape": "scalar",
+        },
+        "history_rows": {
+            "sql": "select captured_at as time, cpu_pct as cpu, memory_pct as memory from system_monitor_snapshot_latest order by captured_at",
+            "shape": "rows",
+        },
+        "top_process_rows": {
+            "sql": "select process_name, pid, cpu_pct, memory_pct from system_monitor_snapshot_latest where process_name is not null order by cpu_pct desc limit 8",
+            "shape": "rows",
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import (
+    Badge,
+    Card,
+    CardContent,
+    Column,
+    Grid,
+    Heading,
+    Metric,
+    Muted,
+    Progress,
+    Row,
+    Separator,
+    Text,
+)
+from prefab_ui.components.charts import AreaChart, ChartSeries
+from prefab_ui.components.data_table import DataTable, DataTableColumn
+
+with PrefabApp(title="System Monitor") as app:
+    with Column(gap=6, css_class="p-6"):
+        with Row(gap=3, align="center"):
+            Heading("System Monitor")
+            Badge(host_label, variant="outline")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="CPU", value=f"{cpu_pct}%")
+                    Progress(value=cpu_pct)
+            with Card():
+                with CardContent():
+                    Metric(label="Memory", value=f"{memory_pct}%")
+                    Progress(value=memory_pct)
+            with Card():
+                with CardContent():
+                    Metric(label="Disk", value=f"{disk_pct}%")
+                    Progress(value=disk_pct)
+            with Card():
+                with CardContent():
+                    Metric(label="Uptime", value=uptime)
+                    Muted("Latest tool snapshot")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("CPU & Memory", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    AreaChart(
+                        data=history_rows,
+                        series=[
+                            ChartSeries(data_key="cpu", label="CPU %"),
+                            ChartSeries(data_key="memory", label="Memory %"),
+                        ],
+                        x_axis="time",
+                        curve="smooth",
+                        show_legend=True,
+                        height=300,
+                        animate=False,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Top Processes", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        rows=top_process_rows,
+                        columns=[
+                            DataTableColumn(key="process_name", header="Process"),
+                            DataTableColumn(key="cpu_pct", header="CPU"),
+                            DataTableColumn(key="memory_pct", header="Memory"),
+                        ],
+                    )
+
+        Separator()
+        Text("Process detail", css_class="text-lg font-semibold")
+        DataTable(
+            rows=top_process_rows,
+            columns=[
+                DataTableColumn(key="process_name", header="Process", sortable=True),
+                DataTableColumn(key="pid", header="PID", sortable=True),
+                DataTableColumn(key="cpu_pct", header="CPU", sortable=True),
+                DataTableColumn(key="memory_pct", header="Memory", sortable=True),
+            ],
+        )
+""",
+)
+```

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: documents
+description: Generate professional PDF documents in the sandbox — reports, factsheets, invoices, proposals — and convert Markdown to styled PDFs. Use when the user wants a PDF report, invoice, proposal, factsheet, a markdown-to-PDF conversion, or a PDF deck for a LinkedIn document post.
+use_cases:
+  - Generate a PDF report from data
+  - Create a finance report with charts and tables
+  - Build a marketing performance report
+  - Generate a client proposal document
+  - Create an invoice with line items and payment details
+  - Generate a formal project proposal or RFP response
+  - Create a fund factsheet or KIID
+  - Produce a PDF with two-column layout
+  - Make a PDF with pie charts and bar charts
+  - Generate a PDF dashboard with KPI cards
+  - Create a professional document with cover page
+  - Convert structured data into a formatted PDF
+  - Convert a markdown file or string to a styled PDF
+  - Generate a PDF deck for a LinkedIn document or carousel post
+triggers:
+  - pdf
+  - markdown to pdf
+  - md to pdf
+  - report
+  - generate pdf
+  - pdf report
+  - document generation
+  - factsheet
+  - proposal
+  - invoice
+  - finance report
+  - marketing report
+  - reportlab
+  - linkedin carousel
+  - linkedin pdf
+requires_toolkits:
+  - sandbox
+suggested_toolkits:
+  - file_manager
+  - image_gen
+---
+
+# Documents
+
+Generate professional, well-designed PDF documents using ReportLab in the E2B sandbox.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Sandbox toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## ALWAYS Read First
+
+Before writing any PDF generation code, read `references/design-principles.md`. It defines the color palettes, typography scale, spacing system, and composition rules that separate professional output from generic slop. Every report you generate must follow these principles.
+
+## Routing Table
+
+Read the focused reference based on the task:
+
+| Need | Reference |
+|------|-----------|
+| Design rules, color palettes, typography, anti-patterns | `references/design-principles.md` |
+| ReportLab imports, page setup, styles, flowables | `references/reportlab-fundamentals.md` |
+| Two-column and multi-column page layouts | `references/two-column-layouts.md` |
+| Charts: pie, bar, line, heatmap, donut, KPI cards (matplotlib/seaborn preferred) | `references/charts-and-visualizations.md` |
+| Finance reports (P&L, revenue, expenses) | `references/finance-reports.md` |
+| Marketing reports (campaigns, funnel, ROI) | `references/marketing-reports.md` |
+| Client proposals (scope, pricing, timeline) | `references/client-proposals.md` |
+| Invoices (line items, tax, payment details) | `references/invoices.md` |
+| Document proposals (RFP, methodology, team, risk) | `references/document-proposals.md` |
+| Fund factsheets / KIID documents | `references/fund-factsheets.md` |
+| Editorial/guide documents (themes, logo, chapter graphics) | `references/editorial-documents.md` |
+| Markdown → PDF conversion (weasyprint or ReportLab pipeline) | `references/markdown-to-pdf.md` |
+
+When a request spans multiple areas, read references in this order:
+1. `references/design-principles.md` (always first)
+2. `references/reportlab-fundamentals.md` (if unfamiliar with ReportLab)
+3. The domain-specific reference (finance, marketing, proposal, or factsheet)
+4. `references/two-column-layouts.md` or `references/charts-and-visualizations.md` as needed
+
+## Ready-to-Run Scripts
+
+This skill includes complete, working scripts in `scripts/`. Use these as starting points — upload to the sandbox, edit the `DATA` dict, and run. **You can also edit or improve the scripts directly** when the DATA dict is not enough (e.g. add sections, change layout, extend themes).
+
+| Script | What it generates | Output path |
+|--------|-------------------|-------------|
+| `generate_invoice.py` | Professional invoice (Cool Slate palette) — line items, tax, payment details | `/home/user/invoice.pdf` |
+| `generate_finance_report.py` | Multi-page finance report (Corporate Navy) — KPIs, revenue chart, expense pie | `/home/user/finance_report.pdf` |
+| `generate_proposal.py` | Formal project proposal (Corporate Navy) — methodology, team, timeline, risk, budget | `/home/user/proposal.pdf` |
+| `generate_editorial.py` | Themable editorial PDF (12 themes, logo, chapter graphics) — landscape, two-column | `/home/user/editorial.pdf` |
+| `pdf_to_images.py` | Convert PDF pages to PNG images for preview/visibility | `/home/user/pdf_preview/` |
+
+### How to use a script
+
+1. Install dependencies:
+```python
+shell(command="pip install reportlab matplotlib seaborn")
+```
+
+2. Upload the script to the sandbox. The script content is available in the skill's `scripts` list — write it to a file:
+```python
+sandbox_write_file(path="/home/user/generate_invoice.py", content=SCRIPT_CONTENT)
+```
+
+3. Run the script:
+```python
+shell(command="cd /home/user && python generate_invoice.py")
+```
+
+4. Download the PDF:
+```python
+sandbox_download_file(path="/home/user/invoice.pdf")
+```
+
+### Customizing script data
+
+Each script has a `DATA` dict at the bottom with sample values. To customize:
+- Read the script content from the skill
+- Modify the `DATA` dict with the user's actual data (company name, line items, amounts, etc.)
+- Write the modified script to the sandbox and run it
+
+If the user needs a report type not covered by existing scripts, use the reference files to build a custom script following the same patterns.
+
+### Editorial PDF with logo and preview
+
+1. **Logo**: Use `nano_banana_image_generation` (model `nano_banana2`) with a prompt like: "Minimal logo for [org name], clean geometric design, white on transparent background, square format." Download the image and write it to the sandbox (e.g. `/home/user/logo.png`).
+
+2. **Generate**: Edit `generate_editorial.py` DATA — set `theme` (e.g. `ocean`, `corporate_navy`, `warm_editorial`), `title`, `subtitle`, `org_name`, `logo_path`. Run in sandbox.
+
+3. **Preview**: Run `pdf_to_images.py /home/user/editorial.pdf -o /home/user/pdf_preview` to convert pages to PNGs. Requires `pdf2image` and poppler (`apt-get install -y poppler-utils` in sandbox). Download the images for full visibility.
+
+## Core Workflow (From Scratch)
+
+When building a custom report (no matching script):
+
+1. Install dependencies:
+```python
+shell(command="pip install reportlab matplotlib seaborn")
+```
+
+2. Write the generation script — read `references/design-principles.md` first, then the domain-specific reference:
+```python
+python(code=script_content)
+```
+
+3. Download the PDF:
+```python
+sandbox_download_file(path="/home/user/report.pdf")
+```
+
+## LinkedIn Document and Carousel Use
+
+Use this skill when a LinkedIn workflow needs a PDF artifact, especially for document posts and PDF-backed carousels.
+
+Recommended routing:
+- If the user already has a finished PDF, post it with `linkedin_create_document_post`.
+- If the user wants a carousel generated from text, prefer `linkedin_create_carousel_from_text`.
+- If the user needs a custom-designed PDF deck first, generate it here, then hand the result to the LinkedIn posting flow.
+
+For the full LinkedIn posting workflow, also read the `linkedin` skill.
+
+## Sandbox Toolkit Reference
+
+| Tool | Use |
+|------|-----|
+| `shell(command)` | Install reportlab, run shell commands |
+| `python(code)` | Execute inline PDF generation code |
+| `sandbox_write_file(path, content)` | Write script files to sandbox filesystem |
+| `sandbox_download_file(path)` | Download generated PDF to permanent storage |
+
+## Best Practices
+
+1. Always define a color palette with semantic roles before writing any layout code.
+2. Use two-column Table layouts for professional documents — never stack everything single-column.
+3. Wrap all Table cell content in `Paragraph` with a defined style — never use raw strings.
+4. Use separate legend tables for pie charts — never put labels directly on small slices.
+5. Follow the 4pt spacing system: 4, 8, 16, 24, 32pt for consistent visual rhythm.
+6. Maximum 4 KPI cards per row, maximum 4 series per grouped bar chart.
+7. Use **matplotlib + seaborn** for data-heavy charts (bar, line, pie, heatmap, donut). Use ReportLab native drawings only for lightweight inline elements (KPI cards, sparklines, progress bars).
+8. Download the PDF with `sandbox_download_file` after generation.
+
+## Troubleshooting
+
+### ReportLab or matplotlib not installed
+If you see `ModuleNotFoundError`:
+```python
+shell(command="pip install reportlab matplotlib seaborn")
+```
+
+### Table cell content overflows
+Wrap all cell text in `Paragraph` objects with a style that sets `fontSize` and `leading`. Raw strings in tables do not wrap and will overflow the column width.
+
+### Pie chart labels overlap
+Never put labels directly on pie slices. Use a separate two-column legend table next to the pie chart (see `references/charts-and-visualizations.md`).
+
+### PDF is blank or has only one page
+Ensure `doc.build(elements)` is called with the full `elements` list. Check that `PageBreak()` is used between sections for multi-page reports.

--- a/skills/documents/references/charts-and-visualizations.md
+++ b/skills/documents/references/charts-and-visualizations.md
@@ -1,0 +1,583 @@
+---
+name: Charts and Visualizations
+description: Use this reference when adding charts to PDFs. Covers matplotlib/seaborn for high-quality charts and native ReportLab graphics for inline drawings. Includes embedding, styling, legends, and axis formatting.
+---
+
+## When to Use Which
+
+| Need | Use | Why |
+|------|-----|-----|
+| Bar, line, pie, heatmap, scatter, donut | **matplotlib + seaborn** | Anti-aliased rendering, rich styling, proper font handling, gradients |
+| KPI cards, sparklines, progress bars, inline indicators | **ReportLab Drawing** | Vector precision, no rasterization, lightweight |
+| Simple pie/bar in a lightweight report | Either | ReportLab native avoids extra dependency |
+
+Default to matplotlib/seaborn for any data-heavy chart. Use ReportLab native for small decorative drawings.
+
+---
+
+## Matplotlib + Seaborn Charts
+
+### Install in Sandbox
+
+```python
+shell(command="pip install reportlab matplotlib seaborn")
+```
+
+### Core Embedding Pattern
+
+Render any matplotlib figure to a high-DPI PNG in memory, then embed into ReportLab as an `Image` flowable.
+
+```python
+import io
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import seaborn as sns
+from reportlab.platypus import Image
+
+def fig_to_image(fig, width, dpi=200):
+    """Convert a matplotlib Figure to a ReportLab Image flowable."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight",
+                facecolor="white", edgecolor="none")
+    plt.close(fig)
+    buf.seek(0)
+
+    from PIL import Image as PILImage
+    img = PILImage.open(buf)
+    aspect = img.height / img.width
+    buf.seek(0)
+
+    return Image(buf, width=width, height=width * aspect)
+```
+
+If PIL is not available, calculate aspect from the figure dimensions instead:
+
+```python
+def fig_to_image_nopil(fig, width, dpi=200):
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight",
+                facecolor="white", edgecolor="none")
+    plt.close(fig)
+    buf.seek(0)
+    fig_w, fig_h = fig.get_size_inches()
+    aspect = fig_h / fig_w
+    return Image(buf, width=width, height=width * aspect)
+```
+
+### Theme Setup
+
+Set the seaborn theme once at the top of the script. Derive the palette from the document's color constants.
+
+```python
+CHART_PALETTE = ["#1a5276", "#2980b9", "#1e8449", "#d4ac0d", "#c0392b", "#7c3aed", "#be185d"]
+
+sns.set_theme(
+    style="whitegrid",
+    rc={
+        "axes.facecolor": "white",
+        "figure.facecolor": "white",
+        "grid.color": "#f3f4f6",
+        "grid.linewidth": 0.5,
+        "axes.edgecolor": "#d5d8dc",
+        "axes.linewidth": 0.5,
+        "font.family": "sans-serif",
+        "font.size": 9,
+        "axes.titlesize": 12,
+        "axes.titleweight": "bold",
+        "axes.labelsize": 9,
+        "xtick.labelsize": 8,
+        "ytick.labelsize": 8,
+    },
+)
+sns.set_palette(CHART_PALETTE)
+```
+
+### Palette Bridge
+
+Convert the skill's hex palette constants to matplotlib/seaborn palettes:
+
+```python
+from reportlab.lib import colors as rl_colors
+
+PRIMARY = rl_colors.HexColor("#0c2340")
+SECONDARY = rl_colors.HexColor("#1a5276")
+ACCENT = rl_colors.HexColor("#2980b9")
+SUCCESS = rl_colors.HexColor("#1e8449")
+DANGER = rl_colors.HexColor("#c0392b")
+WARNING = rl_colors.HexColor("#d4ac0d")
+
+CHART_PALETTE = [
+    PRIMARY.hexval(), SECONDARY.hexval(), ACCENT.hexval(),
+    SUCCESS.hexval(), WARNING.hexval(), DANGER.hexval(),
+]
+sns.set_palette(CHART_PALETTE)
+```
+
+### Sizing Rules
+
+| Target area | Figure size (inches) | DPI | ReportLab width |
+|-------------|---------------------|-----|-----------------|
+| Full-width chart | `(7, 3.5)` | 200 | `CONTENT_W` |
+| Half-width (two-col left) | `(4, 3)` | 200 | `LEFT_W` |
+| Half-width (two-col right) | `(3.5, 3)` | 200 | `RIGHT_W` |
+| Small inline chart | `(3, 2)` | 200 | 150-200pt |
+
+Always use `dpi=200` for sharp output. Never go below 150.
+
+### Bar Chart
+
+```python
+def make_bar_chart(categories, values, title="", palette=None, width=None):
+    w = width or CONTENT_W
+    fig, ax = plt.subplots(figsize=(7, 3.5))
+    colors = palette or CHART_PALETTE
+    bars = ax.bar(categories, values, color=colors[:len(categories)], edgecolor="none")
+    ax.set_title(title, pad=12)
+    ax.set_ylabel("")
+    ax.yaxis.grid(True)
+    ax.xaxis.grid(False)
+    ax.set_axisbelow(True)
+    sns.despine(left=True, bottom=True)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+Usage:
+
+```python
+elements.append(Paragraph("Revenue by Quarter", STYLES["subheading"]))
+elements.append(Spacer(1, TINY))
+elements.append(make_bar_chart(
+    ["Q1", "Q2", "Q3", "Q4"],
+    [120000, 145000, 138000, 162000],
+    title="",
+    width=CONTENT_W,
+))
+```
+
+### Line Chart
+
+```python
+def make_line_chart(x, y_series, labels, title="", width=None):
+    """y_series: list of y-value lists. labels: series names."""
+    w = width or CONTENT_W
+    fig, ax = plt.subplots(figsize=(7, 3.5))
+    for i, (y, label) in enumerate(zip(y_series, labels)):
+        ax.plot(x, y, marker="o", markersize=4, linewidth=2, label=label)
+    ax.set_title(title, pad=12)
+    ax.legend(frameon=False, fontsize=8)
+    ax.yaxis.grid(True)
+    ax.xaxis.grid(False)
+    ax.set_axisbelow(True)
+    sns.despine(left=True, bottom=True)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+### Pie Chart
+
+Use matplotlib's `pie` with a separate `legend` outside the chart. Never put labels on slices.
+
+```python
+def make_pie_chart(names, values, title="", width=None):
+    w = width or LEFT_W
+    fig, ax = plt.subplots(figsize=(4, 3.5))
+    wedges, _ = ax.pie(
+        values,
+        colors=CHART_PALETTE[:len(values)],
+        startangle=90,
+        wedgeprops={"edgecolor": "white", "linewidth": 1.5},
+    )
+    ax.legend(
+        wedges, [f"{n}  ({v/sum(values)*100:.1f}%)" for n, v in zip(names, values)],
+        loc="center left", bbox_to_anchor=(1, 0.5),
+        frameon=False, fontsize=8,
+    )
+    ax.set_title(title, pad=12)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+### Donut Chart
+
+```python
+def make_donut_chart(names, values, center_label="", title="", width=None):
+    w = width or LEFT_W
+    fig, ax = plt.subplots(figsize=(4, 3.5))
+    wedges, _ = ax.pie(
+        values,
+        colors=CHART_PALETTE[:len(values)],
+        startangle=90,
+        wedgeprops={"edgecolor": "white", "linewidth": 1.5, "width": 0.4},
+    )
+    ax.text(0, 0, center_label, ha="center", va="center", fontsize=14, fontweight="bold")
+    ax.legend(
+        wedges, [f"{n}  ({v/sum(values)*100:.1f}%)" for n, v in zip(names, values)],
+        loc="center left", bbox_to_anchor=(1, 0.5),
+        frameon=False, fontsize=8,
+    )
+    ax.set_title(title, pad=12)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+### Heatmap
+
+```python
+import numpy as np
+import pandas as pd
+
+def make_heatmap(data, row_labels, col_labels, title="", width=None, fmt=".1f"):
+    w = width or CONTENT_W
+    df = pd.DataFrame(data, index=row_labels, columns=col_labels)
+    fig, ax = plt.subplots(figsize=(7, max(3, len(row_labels) * 0.5 + 1)))
+    sns.heatmap(
+        df, annot=True, fmt=fmt, cmap="YlOrRd",
+        linewidths=0.5, linecolor="white",
+        cbar_kws={"shrink": 0.8},
+        ax=ax,
+    )
+    ax.set_title(title, pad=12)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+### Horizontal Bar Chart
+
+```python
+def make_horizontal_bar(categories, values, title="", width=None):
+    w = width or CONTENT_W
+    fig, ax = plt.subplots(figsize=(7, max(2.5, len(categories) * 0.4 + 1)))
+    y_pos = range(len(categories))
+    ax.barh(y_pos, values, color=CHART_PALETTE[0], edgecolor="none", height=0.6)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(categories)
+    ax.set_title(title, pad=12)
+    ax.xaxis.grid(True)
+    ax.yaxis.grid(False)
+    ax.set_axisbelow(True)
+    ax.invert_yaxis()
+    sns.despine(left=True, bottom=True)
+    fig.tight_layout()
+    return fig_to_image(fig, w)
+```
+
+### Adding Charts to Story
+
+Charts from matplotlib are `Image` flowables. Use them exactly like any other flowable:
+
+```python
+elements.append(Paragraph("Revenue Trend", STYLES["subheading"]))
+elements.append(Spacer(1, TINY))
+elements.append(make_line_chart(
+    x=months,
+    y_series=[revenue, costs],
+    labels=["Revenue", "Costs"],
+    width=LEFT_W,
+))
+elements.append(Spacer(1, MEDIUM))
+```
+
+For side-by-side charts, wrap two Image flowables in a Table:
+
+```python
+chart_left = make_pie_chart(names, values, width=LEFT_W)
+chart_right = make_bar_chart(categories, amounts, width=RIGHT_W)
+
+row = Table([[chart_left, chart_right]], colWidths=[LEFT_W, RIGHT_W])
+row.setStyle(TableStyle([
+    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+    ("LEFTPADDING", (0, 0), (-1, -1), 0),
+    ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+]))
+elements.append(row)
+```
+
+---
+
+## ReportLab Native Charts
+
+Use these for lightweight inline drawings (KPI cards, sparklines, progress bars) where vector precision matters and you want zero extra dependencies.
+
+### Chart Construction Pattern
+
+Every chart follows the same structure:
+
+```python
+from reportlab.graphics.shapes import Drawing, Rect, String
+from reportlab.graphics.charts.piecharts import Pie
+from reportlab.graphics.charts.barcharts import VerticalBarChart, HorizontalBarChart
+from reportlab.graphics.charts.lineplots import LinePlot
+from reportlab.graphics.widgets.markers import makeMarker
+from reportlab.lib import colors
+
+# 1. Title as Paragraph (NOT String inside Drawing)
+elements.append(Paragraph("Chart Title", STYLES["subheading"]))
+elements.append(Spacer(1, TINY))
+
+# 2. Drawing container
+d = Drawing(chart_width, chart_height)
+
+# 3. Add chart to Drawing
+chart = VerticalBarChart()
+chart.x = 40
+chart.y = 20
+chart.width = chart_width - 60
+chart.height = chart_height - 40
+d.add(chart)
+
+# 4. Add Drawing to story
+elements.append(d)
+```
+
+### Pie Charts
+
+CRITICAL: Never put labels directly on pie slices. Always use a separate legend table.
+
+#### Pie + Legend Table Pattern
+
+```python
+def pie_with_legend(data, chart_w, legend_w):
+    """Returns a two-column Table with pie chart left, legend right."""
+    names = [d["name"] for d in data]
+    values = [d["value"] for d in data]
+    pie_colors = [
+        colors.HexColor("#2563eb"),
+        colors.HexColor("#0891b2"),
+        colors.HexColor("#059669"),
+        colors.HexColor("#d97706"),
+        colors.HexColor("#dc2626"),
+        colors.HexColor("#7c3aed"),
+        colors.HexColor("#be185d"),
+    ]
+
+    # Pie drawing
+    d = Drawing(chart_w, 160)
+    pie = Pie()
+    pie.x = (chart_w - 130) / 2
+    pie.y = 10
+    pie.width = 130
+    pie.height = 130
+    pie.data = values
+    pie.labels = None  # NO labels on pie
+    pie.slices.strokeColor = colors.white
+    pie.slices.strokeWidth = 1.5
+    for i, clr in enumerate(pie_colors[:len(data)]):
+        pie.slices[i].fillColor = clr
+    d.add(pie)
+
+    # Legend table
+    total = sum(values)
+    legend_rows = [
+        [Paragraph("<b>Category</b>", STYLES["caption"]),
+         Paragraph("<b>Share</b>", STYLES["caption"])],
+    ]
+    for i, item in enumerate(data):
+        swatch = Drawing(8, 8)
+        swatch.add(Rect(0, 0, 8, 8, fillColor=pie_colors[i], strokeColor=None))
+        pct = item["value"] / total * 100 if total else 0
+        legend_rows.append([
+            Table([[swatch, Paragraph(item["name"], STYLES["body"])]],
+                  colWidths=[14, legend_w - 14 - legend_w * 0.30],
+                  style=TableStyle([
+                      ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                      ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                      ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                  ])),
+            Paragraph(f"{pct:.1f}%", STYLES["body_right"]),
+        ])
+
+    legend = Table(legend_rows, colWidths=[legend_w * 0.70, legend_w * 0.30])
+    legend.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 3),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+    ]))
+
+    # Combine side by side
+    combined = Table([[d, legend]], colWidths=[chart_w, legend_w])
+    combined.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    return combined
+```
+
+### Vertical Bar Charts
+
+#### Single Series
+
+```python
+def bar_chart(data, labels, chart_w, chart_h=180, bar_color=ACCENT):
+    d = Drawing(chart_w, chart_h)
+    bc = VerticalBarChart()
+    bc.x = 40
+    bc.y = 30
+    bc.width = chart_w - 60
+    bc.height = chart_h - 50
+    bc.data = [data]
+    bc.categoryAxis.categoryNames = labels
+    bc.categoryAxis.labels.fontSize = 7
+    bc.categoryAxis.labels.fontName = "Helvetica"
+    bc.categoryAxis.labels.fillColor = MUTED
+    bc.valueAxis.labels.fontSize = 7
+    bc.valueAxis.labels.fontName = "Helvetica"
+    bc.valueAxis.labels.fillColor = MUTED
+    bc.valueAxis.valueMin = 0
+    bc.valueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    bc.valueAxis.gridStrokeWidth = 0.5
+    bc.bars[0].fillColor = bar_color
+    bc.bars[0].strokeColor = None
+    bc.barWidth = min(20, (bc.width / len(data)) * 0.6)
+    d.add(bc)
+    return d
+```
+
+#### Grouped Bars (max 4 series)
+
+```python
+def grouped_bar_chart(series_data, labels, series_colors, chart_w, chart_h=180):
+    """series_data: list of lists. Max 4 series."""
+    assert len(series_data) <= 4, "Max 4 series in grouped bar charts"
+
+    d = Drawing(chart_w, chart_h)
+    bc = VerticalBarChart()
+    bc.x = 40
+    bc.y = 30
+    bc.width = chart_w - 60
+    bc.height = chart_h - 50
+    bc.data = series_data
+    bc.categoryAxis.categoryNames = labels
+    bc.categoryAxis.labels.fontSize = 7
+    bc.categoryAxis.labels.fontName = "Helvetica"
+    bc.categoryAxis.labels.fillColor = MUTED
+    bc.valueAxis.labels.fontSize = 7
+    bc.valueAxis.labels.fillColor = MUTED
+    bc.valueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    bc.valueAxis.gridStrokeWidth = 0.5
+    bc.groupSpacing = 8
+    bc.barSpacing = 2
+    for i, clr in enumerate(series_colors):
+        bc.bars[i].fillColor = clr
+        bc.bars[i].strokeColor = None
+    d.add(bc)
+    return d
+```
+
+### Line Charts
+
+```python
+def line_chart(series_data, x_labels, series_colors, chart_w, chart_h=180):
+    """
+    series_data: list of lists of (x, y) tuples.
+    x_labels: labels for x-axis positions.
+    """
+    d = Drawing(chart_w, chart_h)
+    lp = LinePlot()
+    lp.x = 40
+    lp.y = 30
+    lp.width = chart_w - 60
+    lp.height = chart_h - 50
+    lp.data = series_data
+
+    for i, clr in enumerate(series_colors):
+        lp.lines[i].strokeColor = clr
+        lp.lines[i].strokeWidth = 2
+        lp.lines[i].symbol = makeMarker("Circle")
+        lp.lines[i].symbol.size = 3
+        lp.lines[i].symbol.fillColor = clr
+
+    lp.xValueAxis.labels.fontSize = 7
+    lp.xValueAxis.labels.fontName = "Helvetica"
+    lp.xValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.labels.fontSize = 7
+    lp.yValueAxis.labels.fontName = "Helvetica"
+    lp.yValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    lp.yValueAxis.gridStrokeWidth = 0.5
+    d.add(lp)
+    return d
+```
+
+### KPI Cards Using Drawing
+
+For quick KPI indicators rendered as a single Drawing:
+
+```python
+def kpi_card_drawing(label, value, delta, card_w=110, card_h=70, accent=ACCENT):
+    d = Drawing(card_w, card_h)
+    # Background
+    d.add(Rect(0, 0, card_w, card_h, fillColor=BACKGROUND, strokeColor=BORDER, strokeWidth=0.5))
+    # Colored top strip
+    d.add(Rect(0, card_h - 14, card_w, 14, fillColor=accent, strokeColor=None))
+    # Label in strip
+    d.add(String(card_w / 2, card_h - 11, label,
+                 fontSize=7, fontName="Helvetica-Bold", fillColor=colors.white, textAnchor="middle"))
+    # Value
+    d.add(String(card_w / 2, card_h / 2 - 6, value,
+                 fontSize=16, fontName="Helvetica-Bold", fillColor=PRIMARY, textAnchor="middle"))
+    # Delta
+    delta_color = SUCCESS if delta.startswith("+") else DANGER if delta.startswith("-") else MUTED
+    d.add(String(card_w / 2, 8, delta,
+                 fontSize=7, fontName="Helvetica", fillColor=delta_color, textAnchor="middle"))
+    return d
+```
+
+### Chart Legends (Inline for Line/Bar)
+
+When a chart has multiple series, add a simple legend row below:
+
+```python
+def chart_legend(items, chart_w):
+    """items: list of (name, color) tuples."""
+    cells = []
+    for name, clr in items:
+        swatch = Drawing(8, 8)
+        swatch.add(Rect(0, 0, 8, 8, fillColor=clr, strokeColor=None))
+        cells.append(Table(
+            [[swatch, Paragraph(name, STYLES["caption"])]],
+            colWidths=[12, None],
+            style=TableStyle([
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]),
+        ))
+    row = Table([cells], hAlign="CENTER")
+    row.setStyle(TableStyle([
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    return row
+```
+
+---
+
+## Axis Formatting Rules
+
+These apply to both matplotlib and ReportLab charts:
+
+- X-axis labels: small size (7-8pt), muted color.
+- Y-axis labels: small size (7-8pt), muted color.
+- Grid lines: horizontal only, thin (0.5pt), very light (`#f3f4f6`).
+- No vertical grid lines.
+- `valueMin` / `ylim` should be 0 for bar charts (don't truncate bars).
+- Format large numbers: "$1.2M" not "$1,200,000".
+
+## Drawing / Image Size Guidelines
+
+| Chart Type | matplotlib fig size | ReportLab Drawing | ReportLab width |
+|------------|--------------------|--------------------|-----------------|
+| Full-width chart | `(7, 3.5)` | `CONTENT_W x 180-220` | `CONTENT_W` |
+| Half-width chart (two-col) | `(4, 3)` | `LEFT_W x 150-180` | `LEFT_W` or `RIGHT_W` |
+| Pie / donut chart | `(4, 3.5)` | `130-160 x 130-160` | 160-200pt |
+| KPI card | N/A | `110-120 x 65-75` | N/A |
+| Sparkline | `(3, 1)` | `80-100 x 30-40` | 80-100pt |

--- a/skills/documents/references/client-proposals.md
+++ b/skills/documents/references/client-proposals.md
@@ -1,0 +1,317 @@
+---
+name: Client Proposals
+description: Use this reference when generating client-facing proposals -- cover pages, executive summaries, scope tables, pricing, deliverable timelines. Uses the Warm Amber palette.
+---
+
+Client proposal patterns using the Warm Amber palette. All patterns follow `design-principles.md`.
+
+## Color Palette — Warm Amber
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#78350f")
+SECONDARY = colors.HexColor("#b45309")
+ACCENT = colors.HexColor("#d97706")
+SUCCESS = colors.HexColor("#15803d")
+DANGER = colors.HexColor("#b91c1c")
+WARNING = colors.HexColor("#ca8a04")
+BODY_TEXT = colors.HexColor("#292524")
+MUTED = colors.HexColor("#78716c")
+BORDER = colors.HexColor("#d6d3d1")
+ROW_ALT = colors.HexColor("#fffbeb")
+BACKGROUND = colors.HexColor("#fafaf9")
+```
+
+## Report Structure
+
+| Page | Content |
+|------|---------|
+| 1 | Cover page with client name, proposal title, company branding |
+| 2 | Executive summary with key metrics sidebar |
+| 3 | Scope of work table + deliverables timeline |
+| 4 | Pricing table with subtotals and total row + terms |
+
+## Cover Page
+
+```python
+def proposal_cover(elements, client_name, proposal_title, company_name, date, ref_number):
+    elements.append(Spacer(1, 80))
+
+    # Company name at top
+    elements.append(Paragraph(company_name.upper(), ParagraphStyle(
+        "Company", fontSize=12, fontName="Helvetica-Bold",
+        textColor=ACCENT, leading=16, spaceAfter=4, tracking=200,
+    )))
+
+    # Warm accent bar
+    d = Drawing(CONTENT_W, 6)
+    d.add(Rect(0, 0, CONTENT_W * 0.3, 6, fillColor=ACCENT, strokeColor=None))
+    d.add(Rect(CONTENT_W * 0.3, 0, CONTENT_W * 0.7, 6, fillColor=PRIMARY, strokeColor=None))
+    elements.append(d)
+    elements.append(Spacer(1, LARGE))
+
+    # Proposal title
+    elements.append(Paragraph(proposal_title, ParagraphStyle(
+        "Title", fontSize=24, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=30, spaceAfter=8,
+    )))
+
+    # "Prepared for"
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(Paragraph("Prepared for", ParagraphStyle(
+        "Prep", fontSize=9, fontName="Helvetica", textColor=MUTED, leading=13,
+    )))
+    elements.append(Paragraph(client_name, ParagraphStyle(
+        "Client", fontSize=16, fontName="Helvetica-Bold",
+        textColor=SECONDARY, leading=22, spaceAfter=16,
+    )))
+
+    # Metadata
+    elements.append(HRFlowable(width="40%", thickness=0.5, color=BORDER))
+    elements.append(Spacer(1, SMALL))
+    meta_style = ParagraphStyle("Meta", fontSize=9, fontName="Helvetica", textColor=MUTED, leading=13)
+    elements.append(Paragraph(f"Date: {date}", meta_style))
+    elements.append(Paragraph(f"Reference: {ref_number}", meta_style))
+    elements.append(PageBreak())
+```
+
+## Executive Summary + Metrics Sidebar
+
+```python
+def executive_summary(elements, summary_text, key_metrics):
+    """
+    summary_text: string with the executive summary.
+    key_metrics: list of (label, value) tuples for sidebar.
+    """
+    elements.append(Paragraph("Executive Summary", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    # Left: summary text
+    left = [Paragraph(summary_text, STYLES["body"])]
+
+    # Right: metrics card
+    metric_rows = []
+    for label, value in key_metrics:
+        metric_rows.append([
+            Paragraph(label, ParagraphStyle(
+                "ML", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10,
+            )),
+            Paragraph(f"<b>{value}</b>", ParagraphStyle(
+                "MV", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16,
+            )),
+        ])
+
+    metric_table = Table(metric_rows, colWidths=[RIGHT_W * 0.45, RIGHT_W * 0.55])
+    metric_table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("BACKGROUND", (0, 0), (-1, -1), BACKGROUND),
+        ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+        ("LINEBELOW", (0, 0), (-1, -2), 0.5, BORDER),
+        ("TOPPADDING", (0, 0), (-1, -1), 8),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+        ("LEFTPADDING", (0, 0), (-1, -1), 8),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+    ]))
+
+    right = [
+        Paragraph("Key Metrics", STYLES["subheading"]),
+        Spacer(1, TINY),
+        metric_table,
+    ]
+
+    two_col = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W])
+    two_col.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(two_col)
+```
+
+## Scope of Work Table
+
+```python
+def scope_table(elements, items):
+    """items: list of dicts with keys: phase, description, duration, deliverables."""
+    elements.append(Paragraph("Scope of Work", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    col_widths = [CONTENT_W * 0.15, CONTENT_W * 0.40, CONTENT_W * 0.15, CONTENT_W * 0.30]
+    header = [
+        Paragraph("<b>Phase</b>", STYLES["caption"]),
+        Paragraph("<b>Description</b>", STYLES["caption"]),
+        Paragraph("<b>Duration</b>", STYLES["caption"]),
+        Paragraph("<b>Deliverables</b>", STYLES["caption"]),
+    ]
+    rows = [header]
+    for item in items:
+        rows.append([
+            Paragraph(item["phase"], ParagraphStyle(
+                "Phase", fontSize=9, fontName="Helvetica-Bold", textColor=SECONDARY, leading=13,
+            )),
+            Paragraph(item["description"], STYLES["body"]),
+            Paragraph(item["duration"], ParagraphStyle(
+                "Dur", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_CENTER,
+            )),
+            Paragraph(item["deliverables"], STYLES["body"]),
+        ])
+
+    table = Table(rows, colWidths=col_widths)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (2, 0), (2, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    elements.append(table)
+```
+
+## Pricing Table
+
+```python
+def pricing_table(elements, line_items, tax_rate=0):
+    """
+    line_items: list of dicts with keys: description, quantity, unit_price.
+    """
+    elements.append(Paragraph("Investment", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    col_widths = [CONTENT_W * 0.45, CONTENT_W * 0.15, CONTENT_W * 0.18, CONTENT_W * 0.22]
+    header = [
+        Paragraph("<b>Description</b>", STYLES["caption"]),
+        Paragraph("<b>Qty</b>", STYLES["caption"]),
+        Paragraph("<b>Unit Price</b>", STYLES["caption"]),
+        Paragraph("<b>Total</b>", STYLES["caption"]),
+    ]
+    rows = [header]
+
+    subtotal = 0
+    for item in line_items:
+        total = item["quantity"] * item["unit_price"]
+        subtotal += total
+        rows.append([
+            Paragraph(item["description"], STYLES["body"]),
+            Paragraph(str(item["quantity"]), ParagraphStyle(
+                "Qty", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_CENTER,
+            )),
+            Paragraph(f"${item['unit_price']:,.2f}", STYLES["body_right"]),
+            Paragraph(f"${total:,.2f}", STYLES["body_right"]),
+        ])
+
+    # Subtotal row
+    bold_right = ParagraphStyle(
+        "BR", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13, alignment=TA_RIGHT,
+    )
+    rows.append([
+        Paragraph("", STYLES["body"]),
+        Paragraph("", STYLES["body"]),
+        Paragraph("<b>Subtotal</b>", bold_right),
+        Paragraph(f"<b>${subtotal:,.2f}</b>", bold_right),
+    ])
+
+    if tax_rate:
+        tax = subtotal * tax_rate
+        rows.append([
+            Paragraph("", STYLES["body"]),
+            Paragraph("", STYLES["body"]),
+            Paragraph(f"<b>Tax ({tax_rate*100:.0f}%)</b>", bold_right),
+            Paragraph(f"<b>${tax:,.2f}</b>", bold_right),
+        ])
+        grand_total = subtotal + tax
+    else:
+        grand_total = subtotal
+
+    rows.append([
+        Paragraph("", STYLES["body"]),
+        Paragraph("", STYLES["body"]),
+        Paragraph("<b>TOTAL</b>", ParagraphStyle(
+            "TotalLabel", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16, alignment=TA_RIGHT,
+        )),
+        Paragraph(f"<b>${grand_total:,.2f}</b>", ParagraphStyle(
+            "TotalVal", fontSize=12, fontName="Helvetica-Bold", textColor=ACCENT, leading=16, alignment=TA_RIGHT,
+        )),
+    ])
+
+    table = Table(rows, colWidths=col_widths)
+    total_row_idx = len(rows) - 1
+    subtotal_row_idx = total_row_idx - (2 if tax_rate else 1)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (1, -1), "CENTER"),
+        ("ALIGN", (2, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, subtotal_row_idx - 1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, subtotal_row_idx - 1), [colors.white, ROW_ALT]),
+        ("LINEABOVE", (2, subtotal_row_idx), (-1, subtotal_row_idx), 1, BORDER),
+        ("LINEABOVE", (2, total_row_idx), (-1, total_row_idx), 2, PRIMARY),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    elements.append(table)
+```
+
+## Terms & Conditions
+
+```python
+def terms_section(elements, terms):
+    """terms: list of strings."""
+    elements.append(Spacer(1, LARGE))
+    elements.append(Paragraph("Terms & Conditions", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    for i, term in enumerate(terms, 1):
+        elements.append(Paragraph(f"{i}. {term}", STYLES["body"]))
+        elements.append(Spacer(1, TINY))
+```
+
+## Data Structure Example
+
+```python
+data = {
+    "client_name": "GlobalTech Solutions",
+    "proposal_title": "Digital Transformation\nConsulting Engagement",
+    "company_name": "Apex Consulting Group",
+    "date": "December 15, 2024",
+    "ref_number": "PRO-2024-0847",
+    "summary": "We propose a comprehensive digital transformation...",
+    "key_metrics": [
+        ("Timeline", "12 weeks"),
+        ("Team Size", "6 specialists"),
+        ("ROI Target", "340%"),
+        ("Risk Level", "Low"),
+    ],
+    "scope": [
+        {"phase": "Discovery", "description": "Requirements gathering and stakeholder interviews",
+         "duration": "2 weeks", "deliverables": "Requirements doc, Stakeholder map"},
+        {"phase": "Design", "description": "Solution architecture and technical design",
+         "duration": "3 weeks", "deliverables": "Architecture doc, Wireframes"},
+        {"phase": "Build", "description": "Implementation and development",
+         "duration": "5 weeks", "deliverables": "Working system, Test results"},
+        {"phase": "Launch", "description": "Deployment, training, and handover",
+         "duration": "2 weeks", "deliverables": "Deployed system, Training materials"},
+    ],
+    "pricing": [
+        {"description": "Discovery & Strategy Phase", "quantity": 1, "unit_price": 15000},
+        {"description": "UX/UI Design", "quantity": 1, "unit_price": 22000},
+        {"description": "Development (per sprint)", "quantity": 5, "unit_price": 18000},
+        {"description": "Testing & QA", "quantity": 1, "unit_price": 12000},
+        {"description": "Deployment & Training", "quantity": 1, "unit_price": 8000},
+    ],
+    "terms": [
+        "Payment terms: 50% upon signing, 25% at mid-point, 25% upon delivery.",
+        "This proposal is valid for 30 days from the date of issue.",
+        "All prices are exclusive of applicable taxes.",
+        "Changes to scope will be handled via a change request process.",
+    ],
+}
+```

--- a/skills/documents/references/design-principles.md
+++ b/skills/documents/references/design-principles.md
@@ -1,0 +1,217 @@
+---
+name: Design Principles
+description: Use this reference FIRST before generating any PDF. Defines the opinionated design system -- color palettes, typography scale, spacing, composition rules, and anti-patterns -- that separates professional output from generic AI slop.
+---
+
+This reference defines the design system for all PDF generation. Read it before writing any code. Every rule here is non-negotiable.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a design direction:
+
+- **Purpose**: What is this document for? Who reads it? Board members need gravitas and restraint. Marketing teams need energy and data density. Finance needs precision and hierarchy. Clients need clarity and trust.
+- **Tone**: Pick and commit to one: corporate/institutional, modern/clean, editorial/magazine, data-dense/dashboard, warm/approachable. Do not mix tones.
+- **Differentiation**: What makes this PDF feel intentionally designed? Professional PDFs have a clear visual hierarchy, consistent rhythm, and deliberate use of whitespace. Generic PDFs stack elements top-to-bottom with no spatial relationship between them.
+
+**CRITICAL**: Choose a clear design direction and execute it with discipline. A restrained corporate report and an energetic marketing dashboard are both excellent -- the key is consistency and intention, not decoration.
+
+## Color Palettes
+
+Every PDF must use a defined palette with semantic roles. Pick one of these four or derive a custom one using the same structure.
+
+### Corporate Navy (finance, annual reports, board documents)
+```python
+PRIMARY = colors.HexColor("#0c2340")    # Headings, headers, rules
+SECONDARY = colors.HexColor("#1a5276") # Subheadings, chart primary
+ACCENT = colors.HexColor("#2980b9")    # Highlights, links, KPI values
+SUCCESS = colors.HexColor("#1e8449")   # Positive values, on-track status
+DANGER = colors.HexColor("#c0392b")    # Negative values, alerts
+WARNING = colors.HexColor("#d4ac0d")   # At-risk, caution indicators
+BODY_TEXT = colors.HexColor("#2c3e50") # Body paragraphs
+MUTED = colors.HexColor("#7f8c8d")     # Captions, footnotes, axis labels
+BORDER = colors.HexColor("#d5d8dc")    # Table borders, dividers
+ROW_ALT = colors.HexColor("#f2f4f4")   # Alternating table rows
+BACKGROUND = colors.HexColor("#fdfefe") # Card backgrounds
+```
+
+### Modern Teal (marketing, dashboards, product reports)
+```python
+PRIMARY = colors.HexColor("#0e4d64")
+SECONDARY = colors.HexColor("#0d9488")
+ACCENT = colors.HexColor("#14b8a6")
+SUCCESS = colors.HexColor("#059669")
+DANGER = colors.HexColor("#dc2626")
+WARNING = colors.HexColor("#f59e0b")
+BODY_TEXT = colors.HexColor("#1f2937")
+MUTED = colors.HexColor("#6b7280")
+BORDER = colors.HexColor("#d1d5db")
+ROW_ALT = colors.HexColor("#f0fdfa")
+BACKGROUND = colors.HexColor("#f9fafb")
+```
+
+### Warm Amber (proposals, client-facing, creative)
+```python
+PRIMARY = colors.HexColor("#78350f")
+SECONDARY = colors.HexColor("#b45309")
+ACCENT = colors.HexColor("#d97706")
+SUCCESS = colors.HexColor("#15803d")
+DANGER = colors.HexColor("#b91c1c")
+WARNING = colors.HexColor("#ca8a04")
+BODY_TEXT = colors.HexColor("#292524")
+MUTED = colors.HexColor("#78716c")
+BORDER = colors.HexColor("#d6d3d1")
+ROW_ALT = colors.HexColor("#fffbeb")
+BACKGROUND = colors.HexColor("#fafaf9")
+```
+
+### Cool Slate (factsheets, technical, regulatory)
+```python
+PRIMARY = colors.HexColor("#1e293b")
+SECONDARY = colors.HexColor("#334155")
+ACCENT = colors.HexColor("#3b82f6")
+SUCCESS = colors.HexColor("#16a34a")
+DANGER = colors.HexColor("#dc2626")
+WARNING = colors.HexColor("#eab308")
+BODY_TEXT = colors.HexColor("#334155")
+MUTED = colors.HexColor("#94a3b8")
+BORDER = colors.HexColor("#cbd5e1")
+ROW_ALT = colors.HexColor("#f8fafc")
+BACKGROUND = colors.HexColor("#ffffff")
+```
+
+### Rules
+- NEVER use random or unnamed colors. Every color must come from the palette.
+- NEVER use pure black (`#000000`) for text. Use `BODY_TEXT` from the palette.
+- NEVER mix warm and cool hues in the same palette unless you have a deliberate reason.
+- Build custom palettes from a single brand hue by varying HSL lightness: dark (10-20%) for text, medium (40-55%) for headings, light (90-96%) for backgrounds.
+- White space is a color. Use it deliberately.
+
+## Typography Scale
+
+Fixed semantic scale. Do not invent sizes.
+
+| Role | Size | Font | Leading | Use |
+|------|------|------|---------|-----|
+| Display | 24pt | Helvetica-Bold | 30pt | Cover page titles, hero text |
+| Heading | 16pt | Helvetica-Bold | 22pt | Section headings |
+| Subheading | 12pt | Helvetica-Bold | 16pt | Subsection headings, card labels |
+| Body | 9pt | Helvetica | 13pt | Paragraph text, table cells |
+| Caption | 7pt | Helvetica | 10pt | Footnotes, chart sources, axis labels |
+| Micro | 6pt | Helvetica | 8pt | Legal text, fine print, page numbers |
+
+### Rules
+- Only two font families: `Helvetica-Bold` for headings and labels, `Helvetica` for body and captions.
+- Leading (line height) = fontSize * 1.4, never less.
+- NEVER use more than 4 distinct font sizes on a single page.
+- NEVER use font sizes between the defined steps (no 10pt, no 13pt, no 20pt).
+
+```python
+STYLES = {
+    "display": ParagraphStyle("Display", fontSize=24, fontName="Helvetica-Bold", textColor=PRIMARY, leading=30, spaceAfter=16),
+    "heading": ParagraphStyle("Heading", fontSize=16, fontName="Helvetica-Bold", textColor=PRIMARY, leading=22, spaceAfter=8),
+    "subheading": ParagraphStyle("Subheading", fontSize=12, fontName="Helvetica-Bold", textColor=SECONDARY, leading=16, spaceAfter=4),
+    "body": ParagraphStyle("Body", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_JUSTIFY),
+    "caption": ParagraphStyle("Caption", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10),
+    "micro": ParagraphStyle("Micro", fontSize=6, fontName="Helvetica", textColor=MUTED, leading=8),
+}
+```
+
+## Spacing System
+
+4pt base unit. Use only these values.
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `TINY` | 4pt | Between label and value, within a card |
+| `SMALL` | 8pt | Between related elements (heading and body) |
+| `MEDIUM` | 16pt | Between sections within a group |
+| `LARGE` | 24pt | Between major sections |
+| `SECTION` | 32pt | Before a new page-level section |
+
+```python
+TINY, SMALL, MEDIUM, LARGE, SECTION = 4, 8, 16, 24, 32
+
+# Usage
+elements.append(Spacer(1, SMALL))   # After a heading
+elements.append(Spacer(1, LARGE))   # Before next section
+```
+
+### Rules
+- Use the same spacing value between all instances of the same structural element.
+- Section headers always get `SECTION` (32pt) spaceBefore and `SMALL` (8pt) spaceAfter.
+- Charts get `MEDIUM` (16pt) above and below.
+- NEVER use arbitrary values like `0.8*cm` or `1.2*cm`. Convert to the 4pt system.
+
+## Composition & Layout
+
+### Two-Column Default
+Professional documents use two-column layouts. Single-column stacking is for letters and simple memos, not reports.
+
+- Use `Table([[left_content, right_content]], colWidths=[...])` for two-column sections.
+- Left column: 55% width. Right column: 40% width. Gap: 5%.
+- Charts share horizontal space with legends, summaries, or key metrics.
+
+### KPI Cards
+- Maximum 4 cards per row on A4.
+- Minimum card width: 90pt.
+- Internal padding: at least 8pt on all sides.
+- Structure: colored header strip (12pt tall) with label, large value centered below, subtitle/delta at bottom.
+
+### Tables
+- ALWAYS wrap cell content in `Paragraph(text, style)`. Never pass raw strings to Table cells.
+- Left-align text columns. Right-align numeric columns. Center status/tag columns.
+- Header row: PRIMARY background, white text, Helvetica-Bold.
+- Alternating row backgrounds using `ROW_ALT`.
+- Border: 0.5pt `BORDER` color. Never heavy borders.
+
+### Pie Charts
+- NEVER put labels directly on pie slices. Labels overlap on small slices and `\n` renders as literal "n" in ReportLab.
+- ALWAYS use a separate legend table next to the pie chart, inside a two-column Table.
+- Pie + legend side by side: pie width 40-50%, legend table 50-60%.
+
+### Charts General
+- Use **matplotlib + seaborn** for data-heavy charts (bar, line, pie, heatmap). Use ReportLab Drawings only for inline indicators (KPI cards, sparklines).
+- Chart titles: use a `Paragraph` above the chart, not a `String()` inside a Drawing.
+- Maximum 4 data series in grouped bar charts. More than 4 makes bars unreadably thin.
+- Axis labels: use `Caption` style (7pt, muted color).
+- Grid lines: very light (`#f3f4f6`) horizontal only. No vertical grid.
+
+#### Palette Conversion for matplotlib/seaborn
+
+Keep chart colors consistent with the document palette by converting hex constants:
+
+```python
+import seaborn as sns
+
+CHART_PALETTE = [
+    PRIMARY.hexval(), SECONDARY.hexval(), ACCENT.hexval(),
+    SUCCESS.hexval(), WARNING.hexval(), DANGER.hexval(),
+]
+sns.set_palette(CHART_PALETTE)
+```
+
+If using raw hex strings instead of ReportLab color objects:
+
+```python
+CHART_PALETTE = ["#0c2340", "#1a5276", "#2980b9", "#1e8449", "#d4ac0d", "#c0392b"]
+sns.set_palette(CHART_PALETTE)
+```
+
+### Header & Footer
+- Footer on every page: thin rule line, company name left, page number right, `Micro` style.
+- Use `onFirstPage` and `onLaterPages` callbacks on `doc.build()`.
+
+## Anti-Patterns
+
+NEVER do any of these:
+
+1. **Single-column chart stacking** -- full-width charts stacked vertically with no spatial relationships. Use two-column layouts to pair charts with legends or summaries.
+2. **Pie slice labels with `\n`** -- `pie.labels = [f"{name}\n{pct}%"]` renders the newline as literal "n". Use a separate legend table.
+3. **Manual String() for chart titles** -- `d.add(String(x, y, "Title"))` with hardcoded coordinates drifts off-center. Use `Paragraph("Title", heading_style)` above the Drawing.
+4. **Hardcoded Drawing dimensions** -- `Drawing(WIDTH - 4*cm, 230)` regardless of content. Size Drawings to fit their content, not the page width.
+5. **6+ KPI cards in a row** -- at 6 cards the values are unreadable. Maximum 4.
+6. **5+ bar series in grouped charts** -- bars become 6-8pt wide and indistinguishable. Maximum 4 series.
+7. **Raw strings in Table cells** -- `rows.append(["text", "123"])` uses default font. Always use `Paragraph("text", style)`.
+8. **Random Spacer values** -- `Spacer(1, 0.7*cm)` has no relationship to other spacing. Use the 4pt system.
+9. **Misleading axis labels** -- cumulative index values (350) formatted as "350%" looks like 350 percent. Label axes accurately.
+10. **Tables wider than content width** -- column widths that sum to more than `WIDTH - leftMargin - rightMargin` cause overflow. Always calculate from `CONTENT_W = WIDTH - 2 * MARGIN`.

--- a/skills/documents/references/document-proposals.md
+++ b/skills/documents/references/document-proposals.md
@@ -1,0 +1,593 @@
+---
+name: Document Proposals
+description: Use this reference when generating formal project proposals, RFP responses, or capability documents — methodology, team qualifications, project timeline, risk matrix, case studies, and acceptance criteria. Uses the Corporate Navy palette for authority.
+---
+
+Formal document proposal patterns using the Corporate Navy palette. Distinct from `client-proposals.md` (which focuses on sales/pricing). This reference targets RFP responses, project bids, and capability statements. All patterns follow `design-principles.md`.
+
+## Color Palette — Corporate Navy
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#0c2340")
+SECONDARY = colors.HexColor("#1a5276")
+ACCENT = colors.HexColor("#2980b9")
+SUCCESS = colors.HexColor("#27ae60")
+WARNING = colors.HexColor("#f39c12")
+DANGER = colors.HexColor("#c0392b")
+BODY_TEXT = colors.HexColor("#2c3e50")
+MUTED = colors.HexColor("#7f8c8d")
+BORDER = colors.HexColor("#bdc3c7")
+ROW_ALT = colors.HexColor("#f0f4f8")
+BACKGROUND = colors.HexColor("#fafbfc")
+LIGHT_ACCENT = colors.HexColor("#ebf5fb")
+```
+
+## Proposal Structure — Multi-Page
+
+| Page | Content |
+|------|---------|
+| 1 | Cover page with project title, submitting org, date, confidentiality |
+| 2 | Executive summary + project snapshot sidebar |
+| 3 | Methodology — numbered phases with descriptions |
+| 4 | Team qualifications — two-column bios with role badges |
+| 5 | Project timeline — horizontal Gantt-style bar chart |
+| 6 | Risk matrix table + mitigation strategies |
+| 7 | Case studies — past project summaries with results |
+| 8 | Budget summary + acceptance and sign-off block |
+
+## Cover Page
+
+```python
+def proposal_cover(elements, title, subtitle, org_name, client_name, date, ref, confidential=True):
+    elements.append(Spacer(1, 60))
+
+    # Organisation name
+    elements.append(Paragraph(org_name.upper(), ParagraphStyle(
+        "OrgName", fontSize=10, fontName="Helvetica-Bold",
+        textColor=ACCENT, leading=14, tracking=300,
+    )))
+    elements.append(Spacer(1, MEDIUM))
+
+    # Thick navy bar
+    bar = Drawing(CONTENT_W, 8)
+    bar.add(Rect(0, 0, CONTENT_W, 8, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, LARGE))
+
+    # Title
+    elements.append(Paragraph(title, ParagraphStyle(
+        "Title", fontSize=28, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=34, spaceAfter=8,
+    )))
+
+    if subtitle:
+        elements.append(Paragraph(subtitle, ParagraphStyle(
+            "Subtitle", fontSize=14, fontName="Helvetica",
+            textColor=SECONDARY, leading=18, spaceAfter=16,
+        )))
+
+    # Thin accent bar
+    bar2 = Drawing(CONTENT_W * 0.4, 3)
+    bar2.add(Rect(0, 0, CONTENT_W * 0.4, 3, fillColor=ACCENT, strokeColor=None))
+    elements.append(bar2)
+    elements.append(Spacer(1, LARGE))
+
+    # Prepared for / by
+    meta_style = ParagraphStyle("CoverMeta", fontSize=9, fontName="Helvetica", textColor=MUTED, leading=13)
+    bold_style = ParagraphStyle("CoverBold", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16)
+
+    elements.append(Paragraph("Prepared for", meta_style))
+    elements.append(Paragraph(client_name, bold_style))
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(Paragraph("Submitted by", meta_style))
+    elements.append(Paragraph(org_name, bold_style))
+    elements.append(Spacer(1, SMALL))
+    elements.append(Paragraph(f"Date: {date}  |  Ref: {ref}", meta_style))
+
+    if confidential:
+        elements.append(Spacer(1, LARGE))
+        elements.append(HRFlowable(width="100%", thickness=0.5, color=BORDER))
+        elements.append(Spacer(1, SMALL))
+        elements.append(Paragraph(
+            "CONFIDENTIAL — This document contains proprietary information and is intended solely for the named recipient.",
+            ParagraphStyle("Conf", fontSize=7, fontName="Helvetica-Oblique", textColor=DANGER, leading=10),
+        ))
+
+    elements.append(PageBreak())
+```
+
+## Executive Summary + Project Snapshot
+
+```python
+def executive_summary(elements, summary_paras, snapshot):
+    """
+    summary_paras: list of paragraph strings.
+    snapshot: list of (label, value) tuples for sidebar.
+    """
+    elements.append(Paragraph("1. Executive Summary", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    left = []
+    for para in summary_paras:
+        left.append(Paragraph(para, STYLES["body"]))
+        left.append(Spacer(1, SMALL))
+
+    # Snapshot sidebar
+    snap_rows = [[
+        Paragraph("<b>PROJECT SNAPSHOT</b>", ParagraphStyle(
+            "SnapH", fontSize=7, fontName="Helvetica-Bold", textColor=colors.white, leading=10,
+        )),
+        Paragraph("", STYLES["body"]),
+    ]]
+    for label, value in snapshot:
+        snap_rows.append([
+            Paragraph(label, ParagraphStyle("SL", fontSize=7, fontName="Helvetica-Bold", textColor=MUTED, leading=10)),
+            Paragraph(f"<b>{value}</b>", ParagraphStyle("SV", fontSize=10, fontName="Helvetica-Bold", textColor=PRIMARY, leading=14)),
+        ])
+
+    snap_table = Table(snap_rows, colWidths=[RIGHT_W * 0.45, RIGHT_W * 0.55])
+    snap_table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("BACKGROUND", (0, 1), (-1, -1), LIGHT_ACCENT),
+        ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+        ("LINEBELOW", (0, 0), (-1, -1), 0.5, BORDER),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 8),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+    ]))
+
+    right = [snap_table]
+
+    two_col = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W])
+    two_col.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(two_col)
+```
+
+## Methodology — Numbered Phases
+
+```python
+def methodology_section(elements, phases):
+    """
+    phases: list of dicts with keys: name, description, activities (list of strings), duration.
+    """
+    elements.append(Paragraph("2. Methodology", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    for i, phase in enumerate(phases, 1):
+        # Phase header row: number badge + name + duration
+        badge = Paragraph(
+            f"<b>{i}</b>",
+            ParagraphStyle("Badge", fontSize=12, fontName="Helvetica-Bold", textColor=colors.white, leading=16, alignment=TA_CENTER),
+        )
+        badge_cell = Table([[badge]], colWidths=[28], rowHeights=[28])
+        badge_cell.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (0, 0), ACCENT),
+            ("VALIGN", (0, 0), (0, 0), "MIDDLE"),
+            ("ALIGN", (0, 0), (0, 0), "CENTER"),
+            ("ROUNDEDCORNERS", [4, 4, 4, 4]),
+        ]))
+
+        name_para = Paragraph(
+            f"<b>{phase['name']}</b>",
+            ParagraphStyle("PhaseName", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16),
+        )
+        dur_para = Paragraph(
+            phase["duration"],
+            ParagraphStyle("PhaseDur", fontSize=9, fontName="Helvetica", textColor=ACCENT, leading=13, alignment=TA_RIGHT),
+        )
+
+        header_row = Table([[badge_cell, name_para, dur_para]], colWidths=[36, CONTENT_W - 120, 84])
+        header_row.setStyle(TableStyle([
+            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+        ]))
+        elements.append(header_row)
+        elements.append(Spacer(1, TINY))
+
+        # Description
+        elements.append(Paragraph(phase["description"], STYLES["body"]))
+        elements.append(Spacer(1, TINY))
+
+        # Activities as bullet list
+        for activity in phase.get("activities", []):
+            elements.append(Paragraph(f"• {activity}", ParagraphStyle(
+                "Activity", fontSize=8, fontName="Helvetica", textColor=BODY_TEXT, leading=12,
+                leftIndent=16, spaceAfter=2,
+            )))
+
+        elements.append(Spacer(1, MEDIUM))
+```
+
+## Team Qualifications — Two-Column Bios
+
+```python
+def team_section(elements, team_members):
+    """
+    team_members: list of dicts with keys: name, role, bio, years_exp.
+    Renders in two-column grid, max 2 per row.
+    """
+    elements.append(Paragraph("3. Team Qualifications", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    card_w = LEFT_W - 4
+
+    def make_card(member):
+        role_badge = Paragraph(
+            f"<b>{member['role']}</b>",
+            ParagraphStyle("Role", fontSize=7, fontName="Helvetica-Bold", textColor=ACCENT, leading=10),
+        )
+        name_para = Paragraph(
+            f"<b>{member['name']}</b>",
+            ParagraphStyle("Name", fontSize=10, fontName="Helvetica-Bold", textColor=PRIMARY, leading=14),
+        )
+        bio_para = Paragraph(member["bio"], ParagraphStyle(
+            "Bio", fontSize=8, fontName="Helvetica", textColor=BODY_TEXT, leading=11,
+        ))
+        exp_para = Paragraph(
+            f"{member['years_exp']}+ years experience",
+            ParagraphStyle("Exp", fontSize=7, fontName="Helvetica-Oblique", textColor=MUTED, leading=10),
+        )
+
+        card_data = [[role_badge], [name_para], [Spacer(1, 2)], [bio_para], [Spacer(1, 2)], [exp_para]]
+        card = Table(card_data, colWidths=[card_w])
+        card.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), LIGHT_ACCENT),
+            ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+            ("TOPPADDING", (0, 0), (-1, -1), 6),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ("LEFTPADDING", (0, 0), (-1, -1), 8),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+        ]))
+        return card
+
+    # Pair members into rows of 2
+    pairs = [team_members[i:i+2] for i in range(0, len(team_members), 2)]
+    for pair in pairs:
+        if len(pair) == 2:
+            row = [[make_card(pair[0]), make_card(pair[1])]]
+            cols = [LEFT_W, RIGHT_W]
+        else:
+            row = [[make_card(pair[0]), Paragraph("", STYLES["body"])]]
+            cols = [LEFT_W, RIGHT_W]
+
+        grid = Table(row, colWidths=cols)
+        grid.setStyle(TableStyle([
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+        ]))
+        elements.append(grid)
+        elements.append(Spacer(1, SMALL))
+```
+
+## Project Timeline — Horizontal Bar Chart
+
+```python
+def timeline_chart(elements, phases):
+    """
+    phases: list of dicts with keys: name, start_week, end_week.
+    Renders a horizontal Gantt-style chart.
+    """
+    elements.append(Paragraph("4. Project Timeline", STYLES["heading"]))
+    bar_el = Drawing(CONTENT_W, 3)
+    bar_el.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar_el)
+    elements.append(Spacer(1, MEDIUM))
+
+    max_week = max(p["end_week"] for p in phases)
+    chart_w = CONTENT_W * 0.65
+    label_w = CONTENT_W * 0.30
+    row_h = 24
+    gap = 4
+    total_h = len(phases) * (row_h + gap) + 30
+
+    d = Drawing(CONTENT_W, total_h)
+    x_offset = label_w + 8
+    y = total_h - 20
+
+    # Week headers
+    for w in range(0, max_week + 1, 2):
+        x = x_offset + (w / max_week) * chart_w
+        d.add(String(x, y + 2, f"W{w}", fontSize=6, fontName="Helvetica", fillColor=MUTED))
+
+    y -= 10
+
+    phase_colors = [ACCENT, SECONDARY, PRIMARY, SUCCESS, WARNING]
+    for i, phase in enumerate(phases):
+        color = phase_colors[i % len(phase_colors)]
+        # Label
+        d.add(String(0, y + 6, phase["name"], fontSize=8, fontName="Helvetica-Bold", fillColor=BODY_TEXT))
+        # Bar
+        bar_x = x_offset + (phase["start_week"] / max_week) * chart_w
+        bar_w = ((phase["end_week"] - phase["start_week"]) / max_week) * chart_w
+        d.add(Rect(bar_x, y, bar_w, row_h - 4, fillColor=color, strokeColor=None, rx=3, ry=3))
+        # Duration label on bar
+        d.add(String(
+            bar_x + bar_w / 2 - 10, y + 6,
+            f"Wk {phase['start_week']}-{phase['end_week']}",
+            fontSize=6, fontName="Helvetica-Bold", fillColor=colors.white,
+        ))
+        y -= (row_h + gap)
+
+    elements.append(d)
+```
+
+## Risk Matrix
+
+```python
+def risk_matrix(elements, risks):
+    """
+    risks: list of dicts with keys: risk, likelihood (High/Med/Low),
+    impact (High/Med/Low), mitigation.
+    """
+    elements.append(Paragraph("5. Risk Assessment", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    risk_colors = {"High": DANGER, "Med": WARNING, "Low": SUCCESS}
+
+    def risk_badge(level):
+        clr = risk_colors.get(level, MUTED)
+        return Paragraph(
+            f"<b>{level}</b>",
+            ParagraphStyle("RiskBadge", fontSize=8, fontName="Helvetica-Bold", textColor=clr, leading=11, alignment=TA_CENTER),
+        )
+
+    col_widths = [CONTENT_W * 0.28, CONTENT_W * 0.12, CONTENT_W * 0.12, CONTENT_W * 0.48]
+    header = [
+        Paragraph("<b>Risk</b>", STYLES["caption_bold"]),
+        Paragraph("<b>Likelihood</b>", STYLES["caption_bold_center"]),
+        Paragraph("<b>Impact</b>", STYLES["caption_bold_center"]),
+        Paragraph("<b>Mitigation</b>", STYLES["caption_bold"]),
+    ]
+    rows = [header]
+
+    for risk in risks:
+        rows.append([
+            Paragraph(risk["risk"], STYLES["body"]),
+            risk_badge(risk["likelihood"]),
+            risk_badge(risk["impact"]),
+            Paragraph(risk["mitigation"], STYLES["body"]),
+        ])
+
+    table = Table(rows, colWidths=col_widths)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (2, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    elements.append(table)
+```
+
+## Case Studies
+
+```python
+def case_studies(elements, cases):
+    """
+    cases: list of dicts with keys: title, client, industry, challenge, solution, results (list of strings).
+    """
+    elements.append(Paragraph("6. Relevant Experience", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    for case in cases:
+        # Case header
+        elements.append(Paragraph(case["title"], STYLES["subheading"]))
+        elements.append(Paragraph(
+            f"{case['client']}  •  {case['industry']}",
+            ParagraphStyle("CaseMeta", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10),
+        ))
+        elements.append(Spacer(1, SMALL))
+
+        # Two-column: challenge + solution left, results right
+        left = [
+            Paragraph("<b>Challenge</b>", ParagraphStyle("CL", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10)),
+            Paragraph(case["challenge"], STYLES["body"]),
+            Spacer(1, SMALL),
+            Paragraph("<b>Solution</b>", ParagraphStyle("SL", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10)),
+            Paragraph(case["solution"], STYLES["body"]),
+        ]
+
+        result_rows = []
+        for r in case["results"]:
+            result_rows.append([Paragraph(f"✓ {r}", ParagraphStyle(
+                "Res", fontSize=8, fontName="Helvetica", textColor=SUCCESS, leading=11,
+            ))])
+        result_table = Table(result_rows, colWidths=[RIGHT_W - 8])
+        result_table.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), LIGHT_ACCENT),
+            ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+            ("TOPPADDING", (0, 0), (-1, -1), 4),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ("LEFTPADDING", (0, 0), (-1, -1), 8),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+        ]))
+
+        right = [
+            Paragraph("<b>Results</b>", ParagraphStyle("RL", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10)),
+            Spacer(1, TINY),
+            result_table,
+        ]
+
+        two_col = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W])
+        two_col.setStyle(TableStyle([
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+        ]))
+        elements.append(two_col)
+        elements.append(Spacer(1, MEDIUM))
+        elements.append(HRFlowable(width="100%", thickness=0.5, color=BORDER, spaceAfter=MEDIUM))
+```
+
+## Budget Summary + Sign-Off
+
+```python
+def budget_and_signoff(elements, budget_items, tax_rate, org_name, client_name):
+    """
+    budget_items: list of dicts with keys: category, amount.
+    """
+    elements.append(Paragraph("7. Budget Summary", STYLES["heading"]))
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+    col_widths = [CONTENT_W * 0.65, CONTENT_W * 0.35]
+    header = [
+        Paragraph("<b>Category</b>", STYLES["caption_bold"]),
+        Paragraph("<b>Amount</b>", STYLES["caption_bold"]),
+    ]
+    rows = [header]
+    subtotal = 0
+    for item in budget_items:
+        subtotal += item["amount"]
+        rows.append([
+            Paragraph(item["category"], STYLES["body"]),
+            Paragraph(f"${item['amount']:,.2f}", STYLES["body_right"]),
+        ])
+
+    tax = subtotal * tax_rate
+    total = subtotal + tax
+    bold_r = ParagraphStyle("BR", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13, alignment=TA_RIGHT)
+
+    rows.append([Paragraph("<b>Subtotal</b>", STYLES["body_bold"]), Paragraph(f"${subtotal:,.2f}", bold_r)])
+    rows.append([Paragraph(f"<b>Tax ({tax_rate*100:.0f}%)</b>", STYLES["body_bold"]), Paragraph(f"${tax:,.2f}", bold_r)])
+    rows.append([
+        Paragraph("<b>TOTAL INVESTMENT</b>", ParagraphStyle("TL", fontSize=11, fontName="Helvetica-Bold", textColor=PRIMARY, leading=15)),
+        Paragraph(f"<b>${total:,.2f}</b>", ParagraphStyle("TV", fontSize=11, fontName="Helvetica-Bold", textColor=ACCENT, leading=15, alignment=TA_RIGHT)),
+    ])
+
+    table = Table(rows, colWidths=col_widths)
+    total_idx = len(rows) - 1
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, total_idx - 3), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, total_idx - 3), [colors.white, ROW_ALT]),
+        ("LINEABOVE", (0, total_idx), (-1, total_idx), 2, PRIMARY),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 8),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+    ]))
+    elements.append(table)
+
+    # Sign-off block
+    elements.append(Spacer(1, LARGE))
+    elements.append(Paragraph("Acceptance", STYLES["subheading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=MEDIUM))
+
+    sig_style = ParagraphStyle("Sig", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13)
+    line_style = ParagraphStyle("SigLine", fontSize=9, fontName="Helvetica", textColor=BORDER, leading=13)
+
+    left_sig = [
+        Paragraph(f"For <b>{org_name}</b>", sig_style),
+        Spacer(1, 32),
+        HRFlowable(width="90%", thickness=0.5, color=PRIMARY),
+        Paragraph("Authorized Signature / Date", ParagraphStyle(
+            "SigLabel", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10,
+        )),
+    ]
+    right_sig = [
+        Paragraph(f"For <b>{client_name}</b>", sig_style),
+        Spacer(1, 32),
+        HRFlowable(width="90%", thickness=0.5, color=PRIMARY),
+        Paragraph("Authorized Signature / Date", ParagraphStyle(
+            "SigLabel2", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10,
+        )),
+    ]
+
+    sig_table = Table([[left_sig, right_sig]], colWidths=[LEFT_W, RIGHT_W])
+    sig_table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(sig_table)
+```
+
+## Data Structure Example
+
+```python
+data = {
+    "title": "Cloud Infrastructure\nModernization Program",
+    "subtitle": "Technical Proposal & Implementation Plan",
+    "org_name": "Meridian Technology Partners",
+    "client_name": "Atlas Financial Group",
+    "date": "January 15, 2026",
+    "ref": "PROP-2026-0012",
+    "summary": [
+        "Meridian Technology Partners proposes a comprehensive cloud modernization program to migrate Atlas Financial Group's legacy infrastructure to a scalable, secure, cloud-native architecture.",
+        "This proposal outlines our proven methodology, the dedicated team assigned to this engagement, a detailed timeline, risk mitigations, and the investment required to deliver measurable results within 16 weeks.",
+    ],
+    "snapshot": [
+        ("Duration", "16 weeks"),
+        ("Team", "8 specialists"),
+        ("Methodology", "Agile Sprints"),
+        ("SLA", "99.9% uptime"),
+    ],
+    "phases": [
+        {"name": "Assessment & Planning", "description": "Audit current infrastructure, identify migration candidates, define target architecture.", "activities": ["Infrastructure audit", "Dependency mapping", "Architecture design", "Migration roadmap"], "duration": "3 weeks", "start_week": 1, "end_week": 3},
+        {"name": "Foundation & Security", "description": "Establish cloud foundations — networking, IAM, security baselines, CI/CD pipelines.", "activities": ["VPC & networking setup", "IAM policies", "Security baseline", "CI/CD pipeline"], "duration": "3 weeks", "start_week": 3, "end_week": 6},
+        {"name": "Migration & Build", "description": "Migrate workloads in prioritized waves, refactor critical services for cloud-native operation.", "activities": ["Wave 1: Non-critical workloads", "Wave 2: Core services", "Wave 3: Data tier", "Performance testing"], "duration": "7 weeks", "start_week": 6, "end_week": 13},
+        {"name": "Optimization & Handover", "description": "Performance tuning, cost optimization, documentation, knowledge transfer, and production sign-off.", "activities": ["Performance tuning", "Cost optimization", "Documentation", "Team training", "Production sign-off"], "duration": "3 weeks", "start_week": 13, "end_week": 16},
+    ],
+    "team": [
+        {"name": "Sarah Chen", "role": "Program Director", "bio": "15 years leading enterprise cloud migrations for Fortune 500 clients. AWS & Azure certified architect.", "years_exp": 15},
+        {"name": "Marcus Williams", "role": "Lead Architect", "bio": "Specialist in distributed systems and microservices. Led 30+ cloud-native transformations.", "years_exp": 12},
+        {"name": "Priya Patel", "role": "Security Lead", "bio": "CISSP certified. Expert in cloud security posture management and zero-trust architectures.", "years_exp": 10},
+        {"name": "James O'Brien", "role": "DevOps Lead", "bio": "Kubernetes and Terraform specialist. Built CI/CD platforms for 50+ engineering teams.", "years_exp": 8},
+    ],
+    "risks": [
+        {"risk": "Legacy system dependencies block migration timeline", "likelihood": "Med", "impact": "High", "mitigation": "Early dependency mapping in Phase 1; parallel migration tracks for independent services."},
+        {"risk": "Data migration causes downtime exceeding SLA", "likelihood": "Low", "impact": "High", "mitigation": "Blue-green migration strategy with automatic rollback; off-peak migration windows."},
+        {"risk": "Team knowledge gaps in cloud-native patterns", "likelihood": "Med", "impact": "Med", "mitigation": "Embedded training throughout engagement; comprehensive runbooks and documentation."},
+        {"risk": "Cost overrun due to scope expansion", "likelihood": "Low", "impact": "Med", "mitigation": "Fixed-scope phases with formal change request process; weekly budget reviews."},
+    ],
+    "cases": [
+        {"title": "Global Bank Cloud Migration", "client": "Tier-1 Investment Bank", "industry": "Financial Services", "challenge": "Migrate 200+ legacy applications from on-premise data centers to AWS within 12 months while maintaining regulatory compliance.", "solution": "Phased migration using automated lift-and-shift for commodity workloads and targeted refactoring for performance-critical trading systems.", "results": ["40% reduction in infrastructure costs", "99.99% uptime achieved", "3x faster deployment cycles", "Full SOC 2 compliance maintained"]},
+        {"title": "InsurTech Platform Modernization", "client": "National Insurance Provider", "industry": "Insurance", "challenge": "Decompose a monolithic policy management system into microservices to support a new digital-first customer experience.", "solution": "Domain-driven decomposition with event-sourced architecture. Strangler fig pattern for incremental migration without service disruption.", "results": ["Policy issuance time reduced from 5 days to 4 hours", "60% fewer production incidents", "Team velocity increased 2.5x"]},
+    ],
+    "budget": [
+        {"category": "Assessment & Planning Phase", "amount": 45000},
+        {"category": "Foundation & Security Setup", "amount": 52000},
+        {"category": "Migration & Build (7 weeks)", "amount": 168000},
+        {"category": "Optimization & Handover", "amount": 38000},
+        {"category": "Project Management & Governance", "amount": 24000},
+        {"category": "Training & Documentation", "amount": 15000},
+    ],
+    "tax_rate": 0.0,
+}
+```

--- a/skills/documents/references/editorial-documents.md
+++ b/skills/documents/references/editorial-documents.md
@@ -1,0 +1,62 @@
+---
+name: Editorial Documents
+description: Themable editorial book-style PDFs — 12 palettes, logo support, chapter divider graphics. Landscape, two-column, clean white content pages.
+---
+
+# Editorial Documents
+
+Use `generate_editorial.py` for guide-style, presentation-quality PDFs. Landscape A4, color only on cover and chapter dividers, white content pages.
+
+## Themes (12 distinct palettes)
+
+Set `DATA["theme"]` to one of:
+
+| Theme | Hue |
+|-------|-----|
+| `terracotta` | Clay orange (default) |
+| `crimson` | Deep red |
+| `saffron` | Warm gold / yellow |
+| `coral` | Salmon pink-orange |
+| `plum` | Wine purple |
+| `olive` | Warm green |
+| `rose` | Dusty pink |
+| `espresso` | Rich dark brown |
+| `navy` | Warm blue |
+| `wine` | Dark burgundy |
+| `teal` | Warm teal green |
+| `aubergine` | Deep eggplant purple |
+
+## DATA dict
+
+```python
+DATA = {
+    "theme": "terracotta",
+    "title": "The Hyper\nPlatform Guide",
+    "subtitle": "Build intelligent agents...",
+    "org_name": "Hyper",
+    "logo_path": "/home/user/logo.png",  # or None for text logo
+    "output_path": "/home/user/editorial.pdf",
+}
+```
+
+## Logo
+
+- **Path**: `logo_path` must be a sandbox path to an image (PNG, JPG). Rendered on cover, max 40pt height.
+- **Generate**: Use `nano_banana_image_generation` with prompt: "Minimal logo for [org], clean geometric design, white on transparent, square."
+- **Fallback**: If `logo_path` is None or file missing, a 4-square text logo is used.
+
+## Chapter graphics
+
+Chapter divider pages have concentric arcs in the top-right corner, tinted from the chapter color. No configuration — built into the design.
+
+## PDF to images (preview)
+
+Run `pdf_to_images.py` after generating to convert pages to PNGs:
+
+```bash
+pip install pdf2image
+# In sandbox: apt-get install -y poppler-utils
+python pdf_to_images.py /home/user/editorial.pdf -o /home/user/pdf_preview
+```
+
+Download the PNGs for full visibility of the generated document.

--- a/skills/documents/references/finance-reports.md
+++ b/skills/documents/references/finance-reports.md
@@ -1,0 +1,301 @@
+---
+name: Finance Reports
+description: Use this reference when generating financial reports -- P&L tables, KPI dashboards, revenue trend lines, expense breakdowns. Uses the Corporate Navy palette.
+---
+
+Complete finance report structure using the Corporate Navy palette. All patterns follow `design-principles.md`.
+
+## Color Palette — Corporate Navy
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#0c2340")
+SECONDARY = colors.HexColor("#1a5276")
+ACCENT = colors.HexColor("#2980b9")
+SUCCESS = colors.HexColor("#1e8449")
+DANGER = colors.HexColor("#c0392b")
+WARNING = colors.HexColor("#d4ac0d")
+BODY_TEXT = colors.HexColor("#2c3e50")
+MUTED = colors.HexColor("#7f8c8d")
+BORDER = colors.HexColor("#d5d8dc")
+ROW_ALT = colors.HexColor("#f2f4f4")
+BACKGROUND = colors.HexColor("#fdfefe")
+```
+
+## Report Structure
+
+| Page | Content |
+|------|---------|
+| 1 | Cover page with title, subtitle, date, company name |
+| 2 | KPI dashboard (4 cards) + Revenue trend line with summary sidebar |
+| 3 | Profit & Loss table with grouped sections |
+| 4 | Expense analysis: pie chart + legend table side by side |
+
+## Cover Page
+
+```python
+def cover_page(elements, title, subtitle, company, period):
+    elements.append(Spacer(1, 120))
+
+    # Accent bar
+    d = Drawing(CONTENT_W, 4)
+    d.add(Rect(0, 0, CONTENT_W, 4, fillColor=ACCENT, strokeColor=None))
+    elements.append(d)
+    elements.append(Spacer(1, LARGE))
+
+    elements.append(Paragraph(title, ParagraphStyle(
+        "CoverTitle", fontSize=24, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=30,
+    )))
+    elements.append(Spacer(1, SMALL))
+    elements.append(Paragraph(subtitle, ParagraphStyle(
+        "CoverSub", fontSize=12, fontName="Helvetica",
+        textColor=MUTED, leading=16,
+    )))
+    elements.append(Spacer(1, LARGE))
+    elements.append(HRFlowable(width="100%", thickness=0.5, color=BORDER))
+    elements.append(Spacer(1, SMALL))
+    elements.append(Paragraph(company, ParagraphStyle(
+        "CoverCompany", fontSize=9, fontName="Helvetica-Bold",
+        textColor=SECONDARY, leading=13,
+    )))
+    elements.append(Paragraph(period, ParagraphStyle(
+        "CoverPeriod", fontSize=9, fontName="Helvetica",
+        textColor=MUTED, leading=13,
+    )))
+    elements.append(PageBreak())
+```
+
+## KPI Dashboard (4 Cards)
+
+```python
+def kpi_dashboard(elements, metrics):
+    """metrics: list of 4 dicts with keys: label, value, delta."""
+    elements.append(Paragraph("Key Financial Metrics", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    kpi_gap = 8
+    kpi_w = (CONTENT_W - 3 * kpi_gap) / 4
+    cards = []
+    for m in metrics[:4]:
+        card = Table(
+            [
+                [Paragraph(f"<b>{m['label']}</b>", ParagraphStyle(
+                    "KL", fontSize=7, fontName="Helvetica-Bold", textColor=colors.white, leading=10,
+                ))],
+                [Paragraph(f"<b>{m['value']}</b>", ParagraphStyle(
+                    "KV", fontSize=16, fontName="Helvetica-Bold", textColor=PRIMARY, leading=22, alignment=TA_CENTER,
+                ))],
+                [Paragraph(m["delta"], ParagraphStyle(
+                    "KD", fontSize=7, fontName="Helvetica",
+                    textColor=SUCCESS if m["delta"].startswith("+") else DANGER, leading=10, alignment=TA_CENTER,
+                ))],
+            ],
+            colWidths=[kpi_w],
+        )
+        card.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (0, 0), ACCENT),
+            ("BACKGROUND", (0, 1), (0, -1), BACKGROUND),
+            ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+            ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+            ("TOPPADDING", (0, 0), (-1, -1), 8),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+            ("LEFTPADDING", (0, 0), (-1, -1), 8),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+        ]))
+        cards.append(card)
+
+    row = Table([cards], colWidths=[kpi_w + kpi_gap] * 3 + [kpi_w])
+    row.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(row)
+    elements.append(Spacer(1, LARGE))
+```
+
+## Revenue Trend + Summary Sidebar (Two-Column)
+
+```python
+def revenue_section(elements, monthly_data, summary_data):
+    """
+    monthly_data: list of (month_index, revenue_value) tuples.
+    summary_data: list of (label, value) tuples for sidebar.
+    """
+    elements.append(Paragraph("Revenue Trend", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    # Line chart in left column
+    chart_w = LEFT_W
+    d = Drawing(chart_w, 180)
+    lp = LinePlot()
+    lp.x = 40
+    lp.y = 30
+    lp.width = chart_w - 60
+    lp.height = 130
+    lp.data = [monthly_data]
+    lp.lines[0].strokeColor = ACCENT
+    lp.lines[0].strokeWidth = 2
+    lp.lines[0].symbol = makeMarker("Circle")
+    lp.lines[0].symbol.size = 3
+    lp.lines[0].symbol.fillColor = ACCENT
+    lp.xValueAxis.labels.fontSize = 7
+    lp.xValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.labels.fontSize = 7
+    lp.yValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    lp.yValueAxis.gridStrokeWidth = 0.5
+    d.add(lp)
+
+    # Summary table in right column
+    summary_rows = [[
+        Paragraph("<b>Metric</b>", STYLES["caption"]),
+        Paragraph("<b>Value</b>", STYLES["caption"]),
+    ]]
+    for label, value in summary_data:
+        summary_rows.append([
+            Paragraph(label, STYLES["body"]),
+            Paragraph(f"<b>{value}</b>", STYLES["body_right"]),
+        ])
+    summary_table = Table(summary_rows, colWidths=[RIGHT_W * 0.55, RIGHT_W * 0.45])
+    summary_table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+
+    # Combine
+    two_col = Table([[d, [Paragraph("Revenue Summary", STYLES["subheading"]), Spacer(1, 4), summary_table]]],
+                    colWidths=[LEFT_W, RIGHT_W])
+    two_col.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(two_col)
+```
+
+## Profit & Loss Table
+
+```python
+def pnl_table(elements, sections):
+    """
+    sections: list of dicts:
+      {"title": "Revenue", "rows": [("Product Sales", 500000, 450000), ...], "is_total": False}
+    """
+    elements.append(Paragraph("Profit & Loss Statement", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    col_widths = [CONTENT_W * 0.45, CONTENT_W * 0.22, CONTENT_W * 0.22, CONTENT_W * 0.11]
+
+    all_rows = [[
+        Paragraph("<b>Item</b>", STYLES["caption"]),
+        Paragraph("<b>Current Period</b>", STYLES["caption"]),
+        Paragraph("<b>Prior Period</b>", STYLES["caption"]),
+        Paragraph("<b>Change</b>", STYLES["caption"]),
+    ]]
+    row_styles = []
+    row_idx = 1
+
+    for section in sections:
+        # Section header row
+        all_rows.append([
+            Paragraph(f"<b>{section['title']}</b>", ParagraphStyle(
+                "PLSec", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13,
+            )),
+            Paragraph("", STYLES["body"]),
+            Paragraph("", STYLES["body"]),
+            Paragraph("", STYLES["body"]),
+        ])
+        row_styles.append(("BACKGROUND", (0, row_idx), (-1, row_idx), colors.HexColor("#eaf2f8")))
+        row_idx += 1
+
+        for label, current, prior in section["rows"]:
+            change = ((current - prior) / prior * 100) if prior else 0
+            change_color = SUCCESS if change >= 0 else DANGER
+            style = STYLES["body"] if not section.get("is_total") else ParagraphStyle(
+                "PLTotal", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13,
+            )
+            right_style = STYLES["body_right"] if not section.get("is_total") else ParagraphStyle(
+                "PLTotalR", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13, alignment=TA_RIGHT,
+            )
+            all_rows.append([
+                Paragraph(label, style),
+                Paragraph(f"${current:,.0f}", right_style),
+                Paragraph(f"${prior:,.0f}", right_style),
+                Paragraph(f"{change:+.1f}%", ParagraphStyle(
+                    "PLChange", fontSize=9, fontName="Helvetica", textColor=change_color, leading=13, alignment=TA_RIGHT,
+                )),
+            ])
+            if section.get("is_total"):
+                row_styles.append(("LINEABOVE", (0, row_idx), (-1, row_idx), 1, PRIMARY))
+            row_idx += 1
+
+    table = Table(all_rows, colWidths=col_widths)
+    base_style = [
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]
+    table.setStyle(TableStyle(base_style + row_styles))
+    elements.append(table)
+```
+
+## Expense Breakdown: Pie + Legend Side by Side
+
+```python
+def expense_breakdown(elements, expenses):
+    """expenses: list of dicts with keys: name, amount."""
+    elements.append(Paragraph("Expense Analysis", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    total = sum(e["amount"] for e in expenses)
+    pie_data = [{"name": e["name"], "value": e["amount"] / total * 100} for e in expenses]
+
+    combined = pie_with_legend(pie_data, LEFT_W, RIGHT_W)
+    elements.append(combined)
+```
+
+## Data Structure Example
+
+```python
+data = {
+    "title": "Q4 2024 Financial Report",
+    "subtitle": "Quarterly Performance Review",
+    "company": "Acme Corporation",
+    "period": "October – December 2024",
+    "kpis": [
+        {"label": "Total Revenue", "value": "$2.4M", "delta": "+12.3% YoY"},
+        {"label": "Net Income", "value": "$480K", "delta": "+8.7% YoY"},
+        {"label": "Gross Margin", "value": "62.4%", "delta": "+2.1pp"},
+        {"label": "Operating Cash Flow", "value": "$320K", "delta": "-3.2% QoQ"},
+    ],
+    "monthly_revenue": [(0, 180), (1, 195), (2, 210), ...],
+    "pnl_sections": [
+        {"title": "Revenue", "rows": [("Product Sales", 1200000, 1050000), ...], "is_total": False},
+        {"title": "Total Revenue", "rows": [("Total", 2400000, 2100000)], "is_total": True},
+        ...
+    ],
+    "expenses": [
+        {"name": "Personnel", "amount": 480000},
+        {"name": "Marketing", "amount": 240000},
+        ...
+    ],
+}
+```

--- a/skills/documents/references/fund-factsheets.md
+++ b/skills/documents/references/fund-factsheets.md
@@ -1,0 +1,318 @@
+---
+name: Fund Factsheets
+description: Use this reference when generating fund factsheets, KIID documents, or investment summary sheets. Covers SRRI risk indicators, asset allocation pies, cumulative performance charts, and charges tables. Uses the Cool Slate palette.
+---
+
+Fund factsheet and KIID patterns using the Cool Slate palette. All patterns follow `design-principles.md`.
+
+## Color Palette — Cool Slate
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#1e293b")
+SECONDARY = colors.HexColor("#334155")
+ACCENT = colors.HexColor("#3b82f6")
+SUCCESS = colors.HexColor("#16a34a")
+DANGER = colors.HexColor("#dc2626")
+WARNING = colors.HexColor("#eab308")
+BODY_TEXT = colors.HexColor("#334155")
+MUTED = colors.HexColor("#94a3b8")
+BORDER = colors.HexColor("#cbd5e1")
+ROW_ALT = colors.HexColor("#f8fafc")
+BACKGROUND = colors.HexColor("#ffffff")
+```
+
+## Document Structure — Two Pages
+
+| Page | Left Column (55%) | Right Column (40%) |
+|------|------|---------|
+| 1 | Fund objectives, performance chart | SRRI risk indicator, fund facts table |
+| 2 | Charges table, past performance table | Asset allocation pie + legend, contact info |
+
+Fund factsheets are dense, two-column layouts. Use a Table-based two-column approach throughout.
+
+## SRRI Risk Indicator (1–7)
+
+```python
+def srri_indicator(risk_level, box_w=None):
+    """Renders a 1–7 risk scale with the current level highlighted."""
+    total_w = box_w or RIGHT_W
+    cell_w = total_w / 7
+    row = []
+    for i in range(1, 8):
+        if i == risk_level:
+            bg = ACCENT
+            text_clr = colors.white
+            font = "Helvetica-Bold"
+        elif i < risk_level:
+            bg = colors.HexColor("#bfdbfe")
+            text_clr = PRIMARY
+            font = "Helvetica"
+        else:
+            bg = colors.HexColor("#f1f5f9")
+            text_clr = MUTED
+            font = "Helvetica"
+        row.append(Paragraph(f"<b>{i}</b>" if i == risk_level else str(i), ParagraphStyle(
+            f"SRRI{i}", fontSize=9, fontName=font, textColor=text_clr,
+            leading=13, alignment=TA_CENTER,
+        )))
+
+    table = Table([row], colWidths=[cell_w] * 7)
+    table.setStyle(TableStyle([
+        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+        ("INNERGRID", (0, 0), (-1, -1), 0.5, BORDER),
+    ] + [
+        ("BACKGROUND", (i, 0), (i, 0),
+         ACCENT if i + 1 == risk_level else
+         colors.HexColor("#bfdbfe") if i + 1 < risk_level else
+         colors.HexColor("#f1f5f9"))
+        for i in range(7)
+    ]))
+
+    return [
+        Paragraph("Risk and Reward Profile", STYLES["subheading"]),
+        Spacer(1, TINY),
+        # Labels
+        Table(
+            [[Paragraph("Lower risk", STYLES["caption"]),
+              Paragraph("Higher risk", ParagraphStyle(
+                  "RR", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10, alignment=TA_RIGHT,
+              ))]],
+            colWidths=[total_w / 2, total_w / 2],
+            style=TableStyle([
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]),
+        ),
+        Spacer(1, 2),
+        table,
+        Spacer(1, 2),
+        Table(
+            [[Paragraph("Typically lower rewards", STYLES["caption"]),
+              Paragraph("Typically higher rewards", ParagraphStyle(
+                  "RR2", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10, alignment=TA_RIGHT,
+              ))]],
+            colWidths=[total_w / 2, total_w / 2],
+            style=TableStyle([
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]),
+        ),
+    ]
+```
+
+## Fund Facts Table
+
+```python
+def fund_facts_table(facts, col_w=None):
+    """
+    facts: list of (label, value) tuples.
+    E.g. [("ISIN", "NO0010123456"), ("NAV", "NOK 1,234.56"), ...]
+    """
+    w = col_w or RIGHT_W
+    rows = []
+    for label, value in facts:
+        rows.append([
+            Paragraph(label, ParagraphStyle(
+                "FL", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10,
+            )),
+            Paragraph(str(value), ParagraphStyle(
+                "FV", fontSize=7, fontName="Helvetica", textColor=BODY_TEXT, leading=10, alignment=TA_RIGHT,
+            )),
+        ])
+
+    table = Table(rows, colWidths=[w * 0.45, w * 0.55])
+    table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 0), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    return table
+```
+
+## Asset Allocation Pie + Legend
+
+```python
+def asset_allocation(elements, assets):
+    """assets: list of dicts with keys: name, weight (percentage)."""
+    elements.append(Paragraph("Asset Allocation", STYLES["subheading"]))
+    elements.append(Spacer(1, TINY))
+
+    pie_data = [{"name": a["name"], "value": a["weight"]} for a in assets]
+    combined = pie_with_legend(pie_data, LEFT_W, RIGHT_W)
+    elements.append(combined)
+```
+
+## Cumulative Performance Chart (Fund vs Index)
+
+```python
+def performance_chart(fund_data, index_data, chart_w, chart_h=180):
+    """
+    fund_data: list of (year_index, cumulative_value) tuples.
+    index_data: list of (year_index, cumulative_value) tuples.
+    """
+    d = Drawing(chart_w, chart_h)
+    lp = LinePlot()
+    lp.x = 40
+    lp.y = 30
+    lp.width = chart_w - 60
+    lp.height = chart_h - 50
+    lp.data = [fund_data, index_data]
+
+    lp.lines[0].strokeColor = ACCENT
+    lp.lines[0].strokeWidth = 2
+    lp.lines[0].symbol = makeMarker("Circle")
+    lp.lines[0].symbol.size = 3
+    lp.lines[0].symbol.fillColor = ACCENT
+
+    lp.lines[1].strokeColor = MUTED
+    lp.lines[1].strokeWidth = 1.5
+    lp.lines[1].symbol = makeMarker("Square")
+    lp.lines[1].symbol.size = 2
+    lp.lines[1].symbol.fillColor = MUTED
+
+    lp.xValueAxis.labels.fontSize = 7
+    lp.xValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.labels.fontSize = 7
+    lp.yValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    lp.yValueAxis.gridStrokeWidth = 0.5
+    d.add(lp)
+
+    legend = chart_legend([("Fund", ACCENT), ("Index", MUTED)], chart_w)
+    return [d, Spacer(1, TINY), legend]
+```
+
+## Charges Table
+
+```python
+def charges_table(charges, col_w=None):
+    """charges: list of (charge_type, value_string) tuples."""
+    w = col_w or CONTENT_W
+    header = [
+        Paragraph("<b>Charge Type</b>", STYLES["caption"]),
+        Paragraph("<b>Fee</b>", STYLES["caption"]),
+    ]
+    rows = [header]
+    for charge_type, value in charges:
+        rows.append([
+            Paragraph(charge_type, STYLES["body"]),
+            Paragraph(value, STYLES["body_right"]),
+        ])
+
+    table = Table(rows, colWidths=[w * 0.60, w * 0.40])
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    return table
+```
+
+## Past Performance Table
+
+```python
+def performance_table(years_data, col_w=None):
+    """
+    years_data: list of dicts with keys: year, fund_return, index_return.
+    """
+    w = col_w or CONTENT_W
+    header = [
+        Paragraph("<b>Year</b>", STYLES["caption"]),
+        Paragraph("<b>Fund</b>", STYLES["caption"]),
+        Paragraph("<b>Index</b>", STYLES["caption"]),
+        Paragraph("<b>Diff.</b>", STYLES["caption"]),
+    ]
+    rows = [header]
+    for yr in years_data:
+        diff = yr["fund_return"] - yr["index_return"]
+        diff_color = SUCCESS if diff >= 0 else DANGER
+        rows.append([
+            Paragraph(str(yr["year"]), ParagraphStyle(
+                "Yr", fontSize=9, fontName="Helvetica-Bold", textColor=SECONDARY, leading=13, alignment=TA_CENTER,
+            )),
+            Paragraph(f"{yr['fund_return']:+.1f}%", STYLES["body_right"]),
+            Paragraph(f"{yr['index_return']:+.1f}%", STYLES["body_right"]),
+            Paragraph(f"{diff:+.1f}pp", ParagraphStyle(
+                "Diff", fontSize=9, fontName="Helvetica-Bold", textColor=diff_color, leading=13, alignment=TA_RIGHT,
+            )),
+        ])
+
+    table = Table(rows, colWidths=[w * 0.20, w * 0.25, w * 0.25, w * 0.25])
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (0, 0), (0, -1), "CENTER"),
+        ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    return table
+```
+
+## Data Structure — JSON Template
+
+```python
+data = {
+    "fund_name": "NARF Global Value Fund",
+    "subtitle": "Key Investor Information Document",
+    "isin": "NO0010123456",
+    "nav": "NOK 1,234.56",
+    "aum": "NOK 2.8B",
+    "inception_date": "2010-03-15",
+    "currency": "NOK",
+    "benchmark": "MSCI World NTR",
+    "srri": 5,
+    "objectives": "The fund aims to achieve long-term capital growth by investing...",
+    "fund_facts": [
+        ("ISIN", "NO0010123456"),
+        ("Currency", "NOK"),
+        ("AUM", "NOK 2.8B"),
+        ("NAV", "NOK 1,234.56"),
+        ("Inception", "15 Mar 2010"),
+        ("Benchmark", "MSCI World NTR"),
+    ],
+    "assets": [
+        {"name": "Equities", "weight": 62.5},
+        {"name": "Fixed Income", "weight": 22.0},
+        {"name": "Alternatives", "weight": 8.5},
+        {"name": "Cash", "weight": 7.0},
+    ],
+    "performance": {
+        "fund": [(2015, 100), (2016, 108), (2017, 122), (2018, 115), (2019, 138), ...],
+        "index": [(2015, 100), (2016, 105), (2017, 118), (2018, 112), (2019, 130), ...],
+    },
+    "yearly_returns": [
+        {"year": 2024, "fund_return": 14.2, "index_return": 12.8},
+        {"year": 2023, "fund_return": 18.5, "index_return": 16.2},
+        ...
+    ],
+    "charges": [
+        ("Entry charge", "0.00%"),
+        ("Exit charge", "0.00%"),
+        ("Ongoing charge", "1.45%"),
+        ("Performance fee", "10% above benchmark"),
+    ],
+}
+```

--- a/skills/documents/references/invoices.md
+++ b/skills/documents/references/invoices.md
@@ -1,0 +1,406 @@
+---
+name: Invoices
+description: Use this reference when generating professional invoices -- company branding, client details, line items, tax calculations, payment terms, and bank details. Uses the Cool Slate palette for a clean, trustworthy look.
+---
+
+Professional invoice patterns using the Cool Slate palette. All patterns follow `design-principles.md`.
+
+## Color Palette — Cool Slate
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#1e293b")
+SECONDARY = colors.HexColor("#334155")
+ACCENT = colors.HexColor("#3b82f6")
+SUCCESS = colors.HexColor("#16a34a")
+DANGER = colors.HexColor("#dc2626")
+BODY_TEXT = colors.HexColor("#334155")
+MUTED = colors.HexColor("#94a3b8")
+BORDER = colors.HexColor("#cbd5e1")
+ROW_ALT = colors.HexColor("#f8fafc")
+BACKGROUND = colors.HexColor("#ffffff")
+```
+
+## Invoice Structure — Single Page (Preferred)
+
+| Section | Content |
+|---------|---------|
+| Header | Company logo/name (left), "INVOICE" label + number (right) |
+| Addresses | From (company) left, Bill To (client) right — two-column |
+| Meta | Invoice date, due date, payment terms, PO number |
+| Line Items | Description, quantity, unit price, amount — full-width table |
+| Totals | Subtotal, tax, discount, grand total — right-aligned block |
+| Payment | Bank details or payment instructions |
+| Footer | Notes, terms, thank-you message |
+
+## Header — Company + Invoice Label
+
+```python
+def invoice_header(elements, company, invoice_number):
+    """Two-column header: company name left, INVOICE label right."""
+    left = [
+        Paragraph(f"<b>{company['name']}</b>", ParagraphStyle(
+            "CompanyName", fontSize=16, fontName="Helvetica-Bold",
+            textColor=PRIMARY, leading=22,
+        )),
+        Paragraph(company.get("tagline", ""), ParagraphStyle(
+            "Tagline", fontSize=7, fontName="Helvetica",
+            textColor=MUTED, leading=10,
+        )),
+    ]
+
+    right = [
+        Paragraph("INVOICE", ParagraphStyle(
+            "InvLabel", fontSize=24, fontName="Helvetica-Bold",
+            textColor=ACCENT, leading=30, alignment=TA_RIGHT,
+        )),
+        Paragraph(f"#{invoice_number}", ParagraphStyle(
+            "InvNum", fontSize=12, fontName="Helvetica-Bold",
+            textColor=PRIMARY, leading=16, alignment=TA_RIGHT,
+        )),
+    ]
+
+    header = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W])
+    header.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(header)
+
+    # Accent bar below header
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=ACCENT, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+```
+
+## Address Block — From / Bill To
+
+```python
+def address_block(elements, company, client, invoice_meta):
+    """Two-column: company address left, client + meta right."""
+    addr_style = ParagraphStyle("Addr", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13)
+    label_style = ParagraphStyle("AddrLabel", fontSize=7, fontName="Helvetica-Bold", textColor=MUTED, leading=10)
+
+    left = [
+        Paragraph("FROM", label_style),
+        Spacer(1, TINY),
+        Paragraph(company["name"], ParagraphStyle("CN", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13)),
+        Paragraph(company["address"], addr_style),
+        Paragraph(company.get("email", ""), addr_style),
+        Paragraph(company.get("phone", ""), addr_style),
+    ]
+
+    right = [
+        Paragraph("BILL TO", label_style),
+        Spacer(1, TINY),
+        Paragraph(client["name"], ParagraphStyle("BN", fontSize=9, fontName="Helvetica-Bold", textColor=PRIMARY, leading=13)),
+        Paragraph(client["address"], addr_style),
+        Paragraph(client.get("email", ""), addr_style),
+        Spacer(1, SMALL),
+    ]
+
+    # Invoice metadata below the bill-to
+    meta_rows = []
+    for label, value in invoice_meta:
+        meta_rows.append([
+            Paragraph(f"<b>{label}</b>", ParagraphStyle("ML", fontSize=7, fontName="Helvetica-Bold", textColor=MUTED, leading=10)),
+            Paragraph(value, ParagraphStyle("MV", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_RIGHT)),
+        ])
+    meta_table = Table(meta_rows, colWidths=[RIGHT_W * 0.45, RIGHT_W * 0.55])
+    meta_table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LINEBELOW", (0, 0), (-1, -1), 0.5, BORDER),
+        ("TOPPADDING", (0, 0), (-1, -1), 3),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    right.append(meta_table)
+
+    two_col = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W])
+    two_col.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(two_col)
+    elements.append(Spacer(1, LARGE))
+```
+
+## Line Items Table
+
+```python
+def line_items_table(elements, items):
+    """
+    items: list of dicts with keys: description, quantity, unit_price.
+    Optional keys: details (secondary description text).
+    """
+    col_widths = [CONTENT_W * 0.45, CONTENT_W * 0.12, CONTENT_W * 0.18, CONTENT_W * 0.25]
+    header = [
+        Paragraph("<b>Description</b>", STYLES["caption_bold"]),
+        Paragraph("<b>Qty</b>", STYLES["caption_bold"]),
+        Paragraph("<b>Unit Price</b>", STYLES["caption_bold"]),
+        Paragraph("<b>Amount</b>", STYLES["caption_bold"]),
+    ]
+    rows = [header]
+
+    for item in items:
+        amount = item["quantity"] * item["unit_price"]
+        desc = Paragraph(item["description"], STYLES["body"])
+        if item.get("details"):
+            desc = [
+                Paragraph(item["description"], STYLES["body_bold"]),
+                Paragraph(item["details"], ParagraphStyle(
+                    "Detail", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10,
+                )),
+            ]
+        rows.append([
+            desc,
+            Paragraph(str(item["quantity"]), ParagraphStyle(
+                "Qty", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_CENTER,
+            )),
+            Paragraph(f"${item['unit_price']:,.2f}", STYLES["body_right"]),
+            Paragraph(f"${amount:,.2f}", STYLES["body_right"]),
+        ])
+
+    table = Table(rows, colWidths=col_widths)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (1, -1), "CENTER"),
+        ("ALIGN", (2, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    elements.append(table)
+```
+
+## Totals Block (Right-Aligned)
+
+```python
+def totals_block(elements, subtotal, tax_rate=0, discount=0):
+    """Right-aligned totals block beneath the line items table."""
+    tax = subtotal * tax_rate
+    discount_amt = subtotal * discount if discount else 0
+    grand_total = subtotal + tax - discount_amt
+
+    totals_w = CONTENT_W * 0.40
+    offset_w = CONTENT_W * 0.60
+
+    rows = [
+        [Paragraph("Subtotal", STYLES["body"]), Paragraph(f"${subtotal:,.2f}", STYLES["body_right"])],
+    ]
+    if tax_rate:
+        rows.append([
+            Paragraph(f"Tax ({tax_rate * 100:.0f}%)", STYLES["body"]),
+            Paragraph(f"${tax:,.2f}", STYLES["body_right"]),
+        ])
+    if discount:
+        rows.append([
+            Paragraph(f"Discount ({discount * 100:.0f}%)", STYLES["body"]),
+            Paragraph(f"-${discount_amt:,.2f}", ParagraphStyle(
+                "Disc", fontSize=9, fontName="Helvetica", textColor=SUCCESS, leading=13, alignment=TA_RIGHT,
+            )),
+        ])
+    rows.append([
+        Paragraph("<b>TOTAL DUE</b>", ParagraphStyle(
+            "TotalLabel", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16,
+        )),
+        Paragraph(f"<b>${grand_total:,.2f}</b>", ParagraphStyle(
+            "TotalVal", fontSize=12, fontName="Helvetica-Bold", textColor=ACCENT, leading=16, alignment=TA_RIGHT,
+        )),
+    ])
+
+    totals_table = Table(rows, colWidths=[totals_w * 0.55, totals_w * 0.45])
+    total_row_idx = len(rows) - 1
+    totals_table.setStyle(TableStyle([
+        ("LINEBELOW", (0, 0), (-1, total_row_idx - 1), 0.5, BORDER),
+        ("LINEABOVE", (0, total_row_idx), (-1, total_row_idx), 2, PRIMARY),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+
+    # Wrap in outer table to push right
+    wrapper = Table([[Paragraph("", STYLES["body"]), totals_table]], colWidths=[offset_w, totals_w])
+    wrapper.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(Spacer(1, SMALL))
+    elements.append(wrapper)
+```
+
+## Payment Details
+
+```python
+def payment_section(elements, payment_info):
+    """
+    payment_info: dict with keys like bank_name, account_name,
+    account_number, sort_code/routing, swift, reference.
+    """
+    elements.append(Spacer(1, LARGE))
+
+    # Light background card for payment details
+    pay_rows = []
+    for label, value in payment_info.items():
+        pay_rows.append([
+            Paragraph(f"<b>{label}</b>", ParagraphStyle(
+                "PayL", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10,
+            )),
+            Paragraph(value, ParagraphStyle(
+                "PayV", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13,
+            )),
+        ])
+
+    pay_table = Table(pay_rows, colWidths=[CONTENT_W * 0.25, CONTENT_W * 0.40])
+    pay_table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("BACKGROUND", (0, 0), (-1, -1), ROW_ALT),
+        ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+        ("LINEBELOW", (0, 0), (-1, -2), 0.5, BORDER),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 8),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+    ]))
+
+    # Two-column: payment label left, table right
+    left = [
+        Paragraph("Payment Details", STYLES["subheading"]),
+        Spacer(1, TINY),
+        Paragraph("Please reference the invoice number in your payment.", STYLES["caption"]),
+    ]
+
+    two_col = Table([[left, pay_table]], colWidths=[LEFT_W * 0.55, CONTENT_W * 0.65])
+    two_col.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    elements.append(two_col)
+```
+
+## Invoice Footer / Notes
+
+```python
+def invoice_footer_notes(elements, notes, terms):
+    """Add notes and terms below the payment section."""
+    elements.append(Spacer(1, LARGE))
+    elements.append(HRFlowable(width="100%", thickness=0.5, color=BORDER, spaceAfter=SMALL))
+
+    if notes:
+        elements.append(Paragraph("<b>Notes</b>", ParagraphStyle(
+            "NoteLabel", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10,
+        )))
+        elements.append(Paragraph(notes, STYLES["caption"]))
+        elements.append(Spacer(1, SMALL))
+
+    if terms:
+        elements.append(Paragraph("<b>Terms & Conditions</b>", ParagraphStyle(
+            "TermLabel", fontSize=7, fontName="Helvetica-Bold", textColor=SECONDARY, leading=10,
+        )))
+        elements.append(Paragraph(terms, STYLES["caption"]))
+
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(Paragraph("Thank you for your business.", ParagraphStyle(
+        "Thanks", fontSize=9, fontName="Helvetica-Oblique", textColor=MUTED, leading=13, alignment=TA_CENTER,
+    )))
+```
+
+## Status Badge (Paid / Unpaid / Overdue)
+
+```python
+def status_badge(status):
+    """Returns a colored Paragraph badge for invoice status."""
+    status_map = {
+        "paid": (SUCCESS, "PAID"),
+        "unpaid": (ACCENT, "UNPAID"),
+        "overdue": (DANGER, "OVERDUE"),
+        "draft": (MUTED, "DRAFT"),
+    }
+    clr, label = status_map.get(status.lower(), (MUTED, status.upper()))
+    return Paragraph(
+        f"<b>{label}</b>",
+        ParagraphStyle("Badge", fontSize=9, fontName="Helvetica-Bold", textColor=clr, leading=13, alignment=TA_RIGHT),
+    )
+```
+
+## Data Structure Example
+
+```python
+data = {
+    "invoice_number": "INV-2025-0042",
+    "status": "unpaid",
+    "company": {
+        "name": "Apex Consulting Group",
+        "tagline": "Strategy & Technology Advisory",
+        "address": "123 Innovation Drive, Suite 400<br/>San Francisco, CA 94105",
+        "email": "billing@apexconsulting.com",
+        "phone": "+1 (415) 555-0123",
+    },
+    "client": {
+        "name": "GlobalTech Solutions Ltd.",
+        "address": "456 Enterprise Boulevard<br/>London, EC2A 1NT, UK",
+        "email": "accounts@globaltech.co.uk",
+    },
+    "meta": [
+        ("Invoice Date", "December 1, 2025"),
+        ("Due Date", "December 31, 2025"),
+        ("Payment Terms", "Net 30"),
+        ("PO Number", "PO-GT-2025-189"),
+    ],
+    "items": [
+        {"description": "Strategy Consulting", "details": "Discovery phase — 40hrs @ senior rate", "quantity": 40, "unit_price": 250.00},
+        {"description": "Technical Architecture Review", "details": "Cloud migration assessment", "quantity": 1, "unit_price": 8500.00},
+        {"description": "Workshop Facilitation", "details": "2-day executive alignment workshop", "quantity": 2, "unit_price": 3500.00},
+        {"description": "Project Management", "details": "December 2025 — monthly retainer", "quantity": 1, "unit_price": 4000.00},
+    ],
+    "tax_rate": 0.20,
+    "discount": 0,
+    "payment": {
+        "Bank": "First National Bank",
+        "Account Name": "Apex Consulting Group LLC",
+        "Account Number": "12345678",
+        "Routing": "021000021",
+        "SWIFT": "FNBKUS33",
+        "Reference": "INV-2025-0042",
+    },
+    "notes": "Services rendered for the period of December 2025. All amounts in USD.",
+    "terms": "Payment is due within 30 days of invoice date. Late payments may incur a 1.5% monthly interest charge.",
+}
+```
+
+## Complete Invoice Assembly
+
+```python
+def generate_invoice(data, output_path):
+    doc = SimpleDocTemplate(
+        output_path, pagesize=A4,
+        leftMargin=MARGIN, rightMargin=MARGIN,
+        topMargin=MARGIN, bottomMargin=2 * cm,
+    )
+    elements = []
+
+    invoice_header(elements, data["company"], data["invoice_number"])
+    address_block(elements, data["company"], data["client"], data["meta"])
+    line_items_table(elements, data["items"])
+
+    subtotal = sum(i["quantity"] * i["unit_price"] for i in data["items"])
+    totals_block(elements, subtotal, data.get("tax_rate", 0), data.get("discount", 0))
+
+    payment_section(elements, data["payment"])
+    invoice_footer_notes(elements, data.get("notes", ""), data.get("terms", ""))
+
+    doc.build(elements, onFirstPage=add_footer, onLaterPages=add_footer)
+```

--- a/skills/documents/references/markdown-to-pdf.md
+++ b/skills/documents/references/markdown-to-pdf.md
@@ -1,0 +1,330 @@
+
+# Markdown to PDF Conversion
+
+Convert Markdown content to professional PDF documents in the E2B sandbox.
+
+## Approach 1: HTML Pipeline (Quick, CSS-Styled)
+
+Best for: documents where markdown formatting fidelity matters most. Preserves tables, code blocks, and nested lists faithfully.
+
+### Install
+
+```python
+shell(command="pip install markdown weasyprint")
+```
+
+### Conversion Script
+
+```python
+python(code="""
+import markdown
+from weasyprint import HTML
+
+MD_CONTENT = '''
+# Report Title
+
+## Summary
+
+This is a **professional** document converted from Markdown.
+
+### Key Metrics
+
+| Metric | Value | Change |
+|--------|-------|--------|
+| Revenue | $2.4M | +12% |
+| Users | 14,200 | +8% |
+
+### Code Example
+
+```python
+def hello():
+    print("Hello, World!")
+```
+
+> This is a blockquote with important information.
+'''
+
+CSS = '''
+@page {
+    size: A4;
+    margin: 2cm 2cm 2.5cm 2cm;
+    @bottom-left { content: "Company Name"; font-size: 6pt; color: #94a3b8; }
+    @bottom-right { content: "Page " counter(page); font-size: 6pt; color: #94a3b8; }
+}
+body {
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 9pt;
+    line-height: 1.4;
+    color: #334155;
+}
+h1 {
+    font-size: 24pt;
+    color: #1e293b;
+    border-bottom: 2px solid #3b82f6;
+    padding-bottom: 8pt;
+    margin-bottom: 16pt;
+}
+h2 {
+    font-size: 16pt;
+    color: #1e293b;
+    margin-top: 32pt;
+    margin-bottom: 8pt;
+}
+h3 {
+    font-size: 12pt;
+    color: #334155;
+    margin-top: 16pt;
+    margin-bottom: 4pt;
+}
+p { margin-bottom: 8pt; }
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16pt 0;
+    font-size: 9pt;
+}
+th {
+    background-color: #1e293b;
+    color: white;
+    font-weight: bold;
+    padding: 6pt;
+    text-align: left;
+}
+td {
+    padding: 4pt 6pt;
+    border-bottom: 0.5pt solid #cbd5e1;
+}
+tr:nth-child(even) td { background-color: #f8fafc; }
+code {
+    font-family: Courier, monospace;
+    font-size: 8pt;
+    background-color: #f1f5f9;
+    padding: 1pt 3pt;
+    border-radius: 2pt;
+}
+pre {
+    background-color: #f1f5f9;
+    border: 0.5pt solid #cbd5e1;
+    border-radius: 4pt;
+    padding: 8pt 12pt;
+    margin: 8pt 0 16pt 0;
+    font-size: 8pt;
+    line-height: 1.5;
+    overflow-x: auto;
+}
+pre code { background: none; padding: 0; }
+blockquote {
+    border-left: 3pt solid #3b82f6;
+    padding-left: 12pt;
+    margin-left: 0;
+    color: #64748b;
+    font-style: italic;
+}
+'''
+
+html_body = markdown.markdown(MD_CONTENT, extensions=["tables", "fenced_code"])
+full_html = f"<html><head><style>{CSS}</style></head><body>{html_body}</body></html>"
+
+HTML(string=full_html).write_pdf("/home/user/document.pdf")
+print("Done: /home/user/document.pdf")
+""")
+```
+
+## Approach 2: ReportLab Pipeline (Full Control)
+
+Best for: documents where precise typographic control, custom headers/footers, and brand styling are needed. More work but higher quality output.
+
+### Install
+
+```python
+shell(command="pip install reportlab markdown")
+```
+
+### Style Mapping
+
+Map Markdown elements to the typography scale from the pdf-generation design system:
+
+| Markdown | ReportLab Style | Size | Font |
+|----------|----------------|------|------|
+| `# H1` | Display | 24pt | Helvetica-Bold |
+| `## H2` | Heading | 16pt | Helvetica-Bold |
+| `### H3` | Subheading | 12pt | Helvetica-Bold |
+| Body text | Body | 9pt | Helvetica |
+| `> blockquote` | Body (italic, indented) | 9pt | Helvetica-Oblique |
+| `` `code` `` | Code (inline) | 8pt | Courier |
+| ```` ```code block``` ```` | Code (block) | 8pt | Courier |
+| Footnotes | Caption | 7pt | Helvetica |
+
+### Conversion Script
+
+```python
+python(code="""
+import re
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
+    HRFlowable, PageBreak, Preformatted, KeepTogether,
+)
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib import colors
+from reportlab.lib.units import cm
+from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_JUSTIFY
+
+WIDTH, HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+
+PRIMARY = colors.HexColor("#1e293b")
+SECONDARY = colors.HexColor("#334155")
+ACCENT = colors.HexColor("#3b82f6")
+BODY_TEXT = colors.HexColor("#334155")
+MUTED = colors.HexColor("#94a3b8")
+BORDER = colors.HexColor("#cbd5e1")
+ROW_ALT = colors.HexColor("#f8fafc")
+CODE_BG = colors.HexColor("#f1f5f9")
+
+STYLES = {
+    "h1": ParagraphStyle("H1", fontSize=24, fontName="Helvetica-Bold", textColor=PRIMARY, leading=30, spaceAfter=16),
+    "h2": ParagraphStyle("H2", fontSize=16, fontName="Helvetica-Bold", textColor=PRIMARY, leading=22, spaceBefore=32, spaceAfter=8),
+    "h3": ParagraphStyle("H3", fontSize=12, fontName="Helvetica-Bold", textColor=SECONDARY, leading=16, spaceBefore=16, spaceAfter=4),
+    "body": ParagraphStyle("Body", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13, alignment=TA_JUSTIFY),
+    "bold": ParagraphStyle("Bold", fontSize=9, fontName="Helvetica-Bold", textColor=BODY_TEXT, leading=13),
+    "quote": ParagraphStyle("Quote", fontSize=9, fontName="Helvetica-Oblique", textColor=MUTED, leading=13, leftIndent=12, borderPadding=0),
+    "code": ParagraphStyle("Code", fontSize=8, fontName="Courier", textColor=SECONDARY, leading=12, backColor=CODE_BG, borderPadding=6),
+    "caption": ParagraphStyle("Caption", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10),
+}
+
+def md_to_flowables(md_text):
+    elements = []
+    lines = md_text.strip().split("\\n")
+    in_code_block = False
+    code_buffer = []
+    in_table = False
+    table_rows = []
+
+    for line in lines:
+        # Code blocks
+        if line.strip().startswith("```"):
+            if in_code_block:
+                code_text = "\\n".join(code_buffer)
+                elements.append(Preformatted(code_text, STYLES["code"]))
+                elements.append(Spacer(1, 8))
+                code_buffer = []
+                in_code_block = False
+            else:
+                in_code_block = True
+            continue
+
+        if in_code_block:
+            code_buffer.append(line)
+            continue
+
+        # Table rows
+        if "|" in line and line.strip().startswith("|"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            if all(set(c) <= set("- :") for c in cells):
+                continue  # separator row
+            if not in_table:
+                in_table = True
+            table_rows.append(cells)
+            continue
+        elif in_table:
+            # Flush table
+            if table_rows:
+                elements.append(build_table(table_rows))
+                elements.append(Spacer(1, 8))
+            table_rows = []
+            in_table = False
+
+        # Headings
+        if line.startswith("### "):
+            elements.append(Paragraph(line[4:], STYLES["h3"]))
+        elif line.startswith("## "):
+            elements.append(Paragraph(line[3:], STYLES["h2"]))
+            elements.append(HRFlowable(width="100%", thickness=1, color=ACCENT, spaceAfter=8))
+        elif line.startswith("# "):
+            elements.append(Paragraph(line[2:], STYLES["h1"]))
+            elements.append(HRFlowable(width="100%", thickness=2, color=ACCENT, spaceAfter=16))
+        elif line.startswith("> "):
+            elements.append(Paragraph(line[2:], STYLES["quote"]))
+            elements.append(Spacer(1, 4))
+        elif line.strip() == "":
+            elements.append(Spacer(1, 4))
+        else:
+            # Inline formatting
+            text = line
+            text = re.sub(r"\\*\\*(.+?)\\*\\*", r"<b>\\1</b>", text)
+            text = re.sub(r"\\*(.+?)\\*", r"<i>\\1</i>", text)
+            text = re.sub(r"`(.+?)`", r'<font face="Courier" size="8">\\1</font>', text)
+            elements.append(Paragraph(text, STYLES["body"]))
+
+    if in_table and table_rows:
+        elements.append(build_table(table_rows))
+
+    return elements
+
+def build_table(rows):
+    col_count = max(len(r) for r in rows)
+    col_w = CONTENT_W / col_count
+    data = []
+    for i, row in enumerate(rows):
+        style = STYLES["caption"] if i == 0 else STYLES["body"]
+        data.append([Paragraph(cell, style) for cell in row])
+
+    table = Table(data, colWidths=[col_w] * col_count)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    return table
+
+def add_footer(canvas, doc):
+    canvas.saveState()
+    canvas.setStrokeColor(BORDER)
+    canvas.setLineWidth(0.5)
+    canvas.line(MARGIN, 1.5 * cm, WIDTH - MARGIN, 1.5 * cm)
+    canvas.setFont("Helvetica", 6)
+    canvas.setFillColor(MUTED)
+    canvas.drawRightString(WIDTH - MARGIN, 1 * cm, f"Page {doc.page}")
+    canvas.restoreState()
+
+MD_CONTENT = '''# Your Markdown Here'''
+
+doc = SimpleDocTemplate(
+    "/home/user/document.pdf", pagesize=A4,
+    leftMargin=MARGIN, rightMargin=MARGIN,
+    topMargin=MARGIN, bottomMargin=2.5 * cm,
+)
+elements = md_to_flowables(MD_CONTENT)
+doc.build(elements, onFirstPage=add_footer, onLaterPages=add_footer)
+print("Done: /home/user/document.pdf")
+""")
+```
+
+## When to Use Which
+
+| Feature | HTML Pipeline | ReportLab Pipeline |
+|---------|--------------|-------------------|
+| Setup complexity | Low | Medium |
+| Markdown fidelity | High | Medium |
+| Custom branding | CSS only | Full control |
+| Code blocks | Excellent | Good |
+| Tables | Excellent | Good |
+| Charts | Not supported | Supported |
+| Page headers/footers | CSS `@page` | Canvas callbacks |
+| Speed | Fast | Fast |
+
+**Default recommendation**: Use the HTML pipeline for straightforward markdown documents. Switch to ReportLab when you need charts, KPI cards, or precise branded layouts that CSS alone cannot achieve.
+
+## Workflow
+
+1. Install dependencies: `pip install markdown weasyprint` (or `pip install reportlab markdown`)
+2. Read or receive the markdown content
+3. Run the conversion script
+4. Download with `sandbox_download_file(path="/home/user/document.pdf")`

--- a/skills/documents/references/marketing-reports.md
+++ b/skills/documents/references/marketing-reports.md
@@ -1,0 +1,280 @@
+---
+name: Marketing Reports
+description: Use this reference when generating marketing performance reports -- campaign tables, funnel visualizations, channel ROI, lead source breakdowns. Uses the Modern Teal palette.
+---
+
+Marketing report patterns using the Modern Teal palette. All patterns follow `design-principles.md`.
+
+## Color Palette — Modern Teal
+
+```python
+from reportlab.lib import colors
+
+PRIMARY = colors.HexColor("#0e4d64")
+SECONDARY = colors.HexColor("#0d9488")
+ACCENT = colors.HexColor("#14b8a6")
+SUCCESS = colors.HexColor("#059669")
+DANGER = colors.HexColor("#dc2626")
+WARNING = colors.HexColor("#f59e0b")
+BODY_TEXT = colors.HexColor("#1f2937")
+MUTED = colors.HexColor("#6b7280")
+BORDER = colors.HexColor("#d1d5db")
+ROW_ALT = colors.HexColor("#f0fdfa")
+BACKGROUND = colors.HexColor("#f9fafb")
+```
+
+## Report Structure
+
+| Page | Content |
+|------|---------|
+| 1 | Cover page + Executive summary with 4 KPI cards |
+| 2 | Campaign performance table + Channel ROI bar chart |
+| 3 | Marketing funnel visualization + Conversion trend line |
+| 4 | Lead source pie chart + legend table side by side |
+
+## Campaign Performance Table
+
+```python
+def campaign_table(elements, campaigns):
+    """
+    campaigns: list of dicts with keys:
+      name, spend, impressions, clicks, conversions, cpa, status
+    """
+    elements.append(Paragraph("Campaign Performance", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    col_widths = [CONTENT_W * 0.22, CONTENT_W * 0.12, CONTENT_W * 0.14,
+                  CONTENT_W * 0.12, CONTENT_W * 0.12, CONTENT_W * 0.12, CONTENT_W * 0.14]
+
+    header = [
+        Paragraph("<b>Campaign</b>", STYLES["caption"]),
+        Paragraph("<b>Spend</b>", STYLES["caption"]),
+        Paragraph("<b>Impressions</b>", STYLES["caption"]),
+        Paragraph("<b>Clicks</b>", STYLES["caption"]),
+        Paragraph("<b>Conv.</b>", STYLES["caption"]),
+        Paragraph("<b>CPA</b>", STYLES["caption"]),
+        Paragraph("<b>Status</b>", STYLES["caption"]),
+    ]
+    rows = [header]
+
+    status_colors = {"Active": SUCCESS, "Paused": WARNING, "Ended": MUTED}
+    for c in campaigns:
+        status_clr = status_colors.get(c["status"], MUTED)
+        rows.append([
+            Paragraph(c["name"], STYLES["body"]),
+            Paragraph(f"${c['spend']:,.0f}", STYLES["body_right"]),
+            Paragraph(f"{c['impressions']:,.0f}", STYLES["body_right"]),
+            Paragraph(f"{c['clicks']:,.0f}", STYLES["body_right"]),
+            Paragraph(f"{c['conversions']:,.0f}", STYLES["body_right"]),
+            Paragraph(f"${c['cpa']:.2f}", STYLES["body_right"]),
+            Paragraph(f"<b>{c['status']}</b>", ParagraphStyle(
+                "Status", fontSize=9, fontName="Helvetica-Bold",
+                textColor=status_clr, leading=13, alignment=TA_CENTER,
+            )),
+        ])
+
+    table = Table(rows, colWidths=col_widths)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("ALIGN", (1, 0), (5, -1), "RIGHT"),
+        ("ALIGN", (6, 0), (6, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    elements.append(table)
+```
+
+## Marketing Funnel
+
+Graduated horizontal bars showing drop-off at each stage.
+
+```python
+def marketing_funnel(elements, stages):
+    """
+    stages: list of (stage_name, value) tuples, ordered top to bottom.
+    E.g. [("Visitors", 50000), ("Leads", 8000), ("MQLs", 3200), ("SQLs", 1200), ("Customers", 480)]
+    """
+    elements.append(Paragraph("Marketing Funnel", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    max_val = stages[0][1]
+    funnel_w = CONTENT_W * 0.7
+    bar_h = 28
+
+    d = Drawing(CONTENT_W, len(stages) * (bar_h + 8) + 10)
+    teal_shades = [
+        colors.HexColor("#0d9488"),
+        colors.HexColor("#14b8a6"),
+        colors.HexColor("#2dd4bf"),
+        colors.HexColor("#5eead4"),
+        colors.HexColor("#99f6e4"),
+    ]
+
+    for i, (name, val) in enumerate(stages):
+        y = d.height - (i + 1) * (bar_h + 8)
+        bar_width = (val / max_val) * funnel_w
+        x_offset = (funnel_w - bar_width) / 2
+
+        shade = teal_shades[min(i, len(teal_shades) - 1)]
+        d.add(Rect(x_offset, y, bar_width, bar_h, fillColor=shade, strokeColor=None, rx=4))
+
+        d.add(String(funnel_w / 2, y + bar_h / 2 - 4, f"{name}: {val:,}",
+                      fontSize=9, fontName="Helvetica-Bold", fillColor=PRIMARY, textAnchor="middle"))
+
+        if i > 0:
+            prev_val = stages[i - 1][1]
+            pct = val / prev_val * 100 if prev_val else 0
+            d.add(String(funnel_w + 16, y + bar_h / 2 - 4, f"{pct:.0f}%",
+                          fontSize=7, fontName="Helvetica", fillColor=MUTED, textAnchor="start"))
+
+    elements.append(d)
+```
+
+## Channel ROI Bar Chart
+
+```python
+def channel_roi_chart(elements, channels):
+    """channels: list of (channel_name, roi_pct) tuples."""
+    elements.append(Paragraph("Channel ROI", STYLES["subheading"]))
+    elements.append(Spacer(1, TINY))
+
+    d = Drawing(LEFT_W, 180)
+    bc = VerticalBarChart()
+    bc.x = 40
+    bc.y = 30
+    bc.width = LEFT_W - 60
+    bc.height = 130
+    bc.data = [[c[1] for c in channels]]
+    bc.categoryAxis.categoryNames = [c[0] for c in channels]
+    bc.categoryAxis.labels.fontSize = 7
+    bc.categoryAxis.labels.fillColor = MUTED
+    bc.categoryAxis.labels.fontName = "Helvetica"
+    bc.valueAxis.labels.fontSize = 7
+    bc.valueAxis.labels.fillColor = MUTED
+    bc.valueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    bc.valueAxis.gridStrokeWidth = 0.5
+    bc.bars[0].fillColor = ACCENT
+    bc.bars[0].strokeColor = None
+    bc.barWidth = 18
+    d.add(bc)
+    elements.append(d)
+```
+
+## Conversion Trend Line
+
+```python
+def conversion_trend(elements, monthly_data, chart_w=CONTENT_W):
+    """monthly_data: list of (month_idx, conversion_rate) tuples."""
+    elements.append(Paragraph("Monthly Conversion Rate", STYLES["subheading"]))
+    elements.append(Spacer(1, TINY))
+
+    d = Drawing(chart_w, 160)
+    lp = LinePlot()
+    lp.x = 40
+    lp.y = 30
+    lp.width = chart_w - 60
+    lp.height = 110
+    lp.data = [monthly_data]
+    lp.lines[0].strokeColor = SECONDARY
+    lp.lines[0].strokeWidth = 2
+    lp.lines[0].symbol = makeMarker("Circle")
+    lp.lines[0].symbol.size = 3
+    lp.lines[0].symbol.fillColor = SECONDARY
+    lp.xValueAxis.labels.fontSize = 7
+    lp.xValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.labels.fontSize = 7
+    lp.yValueAxis.labels.fillColor = MUTED
+    lp.yValueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    lp.yValueAxis.gridStrokeWidth = 0.5
+    d.add(lp)
+    elements.append(d)
+```
+
+## Lead Source Pie + Legend
+
+```python
+def lead_sources(elements, sources):
+    """sources: list of dicts with keys: name, count."""
+    elements.append(Paragraph("Lead Sources", STYLES["heading"]))
+    elements.append(HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8))
+
+    total = sum(s["count"] for s in sources)
+    pie_data = [{"name": s["name"], "value": s["count"] / total * 100} for s in sources]
+
+    # Use pie_with_legend from charts-and-visualizations.md
+    combined = pie_with_legend(pie_data, LEFT_W, RIGHT_W)
+    elements.append(combined)
+```
+
+## Budget Comparison (Grouped Bars, max 2 series)
+
+```python
+def budget_vs_actual(elements, categories, budget_vals, actual_vals):
+    """Compare budget vs actual spend per category."""
+    elements.append(Paragraph("Budget vs Actual", STYLES["subheading"]))
+    elements.append(Spacer(1, TINY))
+
+    d = Drawing(CONTENT_W, 180)
+    bc = VerticalBarChart()
+    bc.x = 40
+    bc.y = 30
+    bc.width = CONTENT_W - 60
+    bc.height = 130
+    bc.data = [budget_vals, actual_vals]
+    bc.categoryAxis.categoryNames = categories
+    bc.categoryAxis.labels.fontSize = 7
+    bc.categoryAxis.labels.fillColor = MUTED
+    bc.valueAxis.labels.fontSize = 7
+    bc.valueAxis.labels.fillColor = MUTED
+    bc.valueAxis.gridStrokeColor = colors.HexColor("#f3f4f6")
+    bc.valueAxis.gridStrokeWidth = 0.5
+    bc.groupSpacing = 10
+    bc.barSpacing = 2
+    bc.bars[0].fillColor = SECONDARY
+    bc.bars[0].strokeColor = None
+    bc.bars[1].fillColor = ACCENT
+    bc.bars[1].strokeColor = None
+    d.add(bc)
+
+    # Legend below chart
+    legend = chart_legend([("Budget", SECONDARY), ("Actual", ACCENT)], CONTENT_W)
+    elements.append(d)
+    elements.append(Spacer(1, TINY))
+    elements.append(legend)
+```
+
+## Data Structure Example
+
+```python
+data = {
+    "title": "Q4 2024 Marketing Report",
+    "subtitle": "Digital Marketing Performance Review",
+    "company": "TechCorp Inc.",
+    "period": "October – December 2024",
+    "kpis": [
+        {"label": "Total Spend", "value": "$124K", "delta": "+8.2% QoQ"},
+        {"label": "Total Leads", "value": "3,842", "delta": "+22.1% QoQ"},
+        {"label": "Avg. CPA", "value": "$32.28", "delta": "-5.4% QoQ"},
+        {"label": "ROAS", "value": "4.2x", "delta": "+0.8x QoQ"},
+    ],
+    "campaigns": [
+        {"name": "Brand Awareness", "spend": 35000, "impressions": 2800000,
+         "clicks": 42000, "conversions": 840, "cpa": 41.67, "status": "Active"},
+        ...
+    ],
+    "funnel": [("Visitors", 50000), ("Leads", 8000), ("MQLs", 3200),
+               ("SQLs", 1200), ("Customers", 480)],
+    "channel_roi": [("SEO", 380), ("PPC", 220), ("Email", 450), ("Social", 180)],
+    "lead_sources": [
+        {"name": "Organic Search", "count": 1400},
+        {"name": "Paid Search", "count": 980},
+        ...
+    ],
+}
+```

--- a/skills/documents/references/reportlab-fundamentals.md
+++ b/skills/documents/references/reportlab-fundamentals.md
@@ -1,0 +1,195 @@
+---
+name: ReportLab Fundamentals
+description: Use this reference for core ReportLab API patterns -- imports, page setup, styles, colors, flowable types, and header/footer callbacks.
+---
+
+Core ReportLab patterns for PDF generation in the E2B sandbox.
+
+## Setup
+
+Install in sandbox before use:
+```bash
+pip install reportlab
+```
+
+## Essential Imports
+
+```python
+from reportlab.platypus import (
+    SimpleDocTemplate, BaseDocTemplate, Frame, PageTemplate,
+    Paragraph, Spacer, Table, TableStyle, PageBreak,
+    HRFlowable, KeepTogether, Image,
+)
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib import colors
+from reportlab.lib.units import cm, mm
+from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER, TA_JUSTIFY
+from reportlab.graphics.shapes import Drawing, Rect, String, Line, Circle
+from reportlab.graphics.charts.barcharts import VerticalBarChart, HorizontalBarChart
+from reportlab.graphics.charts.lineplots import LinePlot
+from reportlab.graphics.charts.piecharts import Pie
+from reportlab.graphics.widgets.markers import makeMarker
+```
+
+## Page Setup
+
+```python
+WIDTH, HEIGHT = A4  # 595.27, 841.89 points
+MARGIN = 2 * cm     # 56.69 points
+CONTENT_W = WIDTH - 2 * MARGIN  # Usable content width
+
+doc = SimpleDocTemplate(
+    "/home/user/report.pdf",
+    pagesize=A4,
+    leftMargin=MARGIN,
+    rightMargin=MARGIN,
+    topMargin=MARGIN,
+    bottomMargin=2.5 * cm,  # Extra room for footer
+)
+```
+
+## Style Definitions
+
+Always define all styles upfront as a dict. Never create styles inline.
+
+```python
+PRIMARY = colors.HexColor("#0c2340")
+SECONDARY = colors.HexColor("#1a5276")
+BODY_TEXT = colors.HexColor("#2c3e50")
+MUTED = colors.HexColor("#7f8c8d")
+
+STYLES = {
+    "display": ParagraphStyle(
+        "Display", fontSize=24, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=30, spaceAfter=16,
+    ),
+    "heading": ParagraphStyle(
+        "Heading", fontSize=16, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=22, spaceBefore=32, spaceAfter=8,
+    ),
+    "subheading": ParagraphStyle(
+        "Subheading", fontSize=12, fontName="Helvetica-Bold",
+        textColor=SECONDARY, leading=16, spaceAfter=4,
+    ),
+    "body": ParagraphStyle(
+        "Body", fontSize=9, fontName="Helvetica",
+        textColor=BODY_TEXT, leading=13, alignment=TA_JUSTIFY,
+    ),
+    "body_right": ParagraphStyle(
+        "BodyRight", fontSize=9, fontName="Helvetica",
+        textColor=BODY_TEXT, leading=13, alignment=TA_RIGHT,
+    ),
+    "caption": ParagraphStyle(
+        "Caption", fontSize=7, fontName="Helvetica",
+        textColor=MUTED, leading=10,
+    ),
+    "micro": ParagraphStyle(
+        "Micro", fontSize=6, fontName="Helvetica",
+        textColor=MUTED, leading=8,
+    ),
+}
+```
+
+## Flowable Types
+
+| Flowable | Use |
+|----------|-----|
+| `Paragraph(text, style)` | Styled text with HTML-like markup (`<b>`, `<br/>`, `<i>`) |
+| `Spacer(width, height)` | Vertical spacing between elements |
+| `Table(data, colWidths)` | Data tables and layout grids |
+| `Drawing(width, height)` | Container for charts and shapes |
+| `HRFlowable(width, thickness, color)` | Horizontal rule |
+| `PageBreak()` | Force new page |
+| `KeepTogether(flowables)` | Prevent page break within a group |
+| `Image(path, width, height)` | Embed an image file |
+
+## Table Construction
+
+Always use Paragraph in cells. Never raw strings.
+
+```python
+BORDER = colors.HexColor("#d5d8dc")
+ROW_ALT = colors.HexColor("#f2f4f4")
+
+header = [
+    Paragraph("<b>Name</b>", STYLES["caption"]),
+    Paragraph("<b>Revenue</b>", STYLES["caption"]),
+    Paragraph("<b>Growth</b>", STYLES["caption"]),
+]
+rows = [header]
+for name, revenue, growth in data:
+    rows.append([
+        Paragraph(name, STYLES["body"]),
+        Paragraph(f"${revenue:,.0f}", STYLES["body_right"]),
+        Paragraph(f"{growth:+.1f}%", STYLES["body_right"]),
+    ])
+
+table = Table(rows, colWidths=[CONTENT_W * 0.40, CONTENT_W * 0.30, CONTENT_W * 0.25])
+table.setStyle(TableStyle([
+    ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+    ("FONTSIZE", (0, 0), (-1, -1), 9),
+    ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+    ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+    ("TOPPADDING", (0, 0), (-1, -1), 4),
+    ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ("LEFTPADDING", (0, 0), (-1, -1), 6),
+    ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+]))
+```
+
+## Header & Footer Callbacks
+
+```python
+def add_footer(canvas, doc):
+    canvas.saveState()
+    canvas.setStrokeColor(colors.HexColor("#d5d8dc"))
+    canvas.setLineWidth(0.5)
+    canvas.line(MARGIN, 1.5 * cm, WIDTH - MARGIN, 1.5 * cm)
+    canvas.setFont("Helvetica", 6)
+    canvas.setFillColor(colors.HexColor("#7f8c8d"))
+    canvas.drawString(MARGIN, 1 * cm, "Company Name — Document Title")
+    canvas.drawRightString(WIDTH - MARGIN, 1 * cm, f"Page {doc.page}")
+    canvas.restoreState()
+
+doc.build(elements, onFirstPage=add_footer, onLaterPages=add_footer)
+```
+
+## Section Header Pattern
+
+```python
+def section_header(text):
+    return KeepTogether([
+        Paragraph(text, STYLES["heading"]),
+        HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=8),
+    ])
+```
+
+## Color Definition
+
+Always use HexColor. Never use named colors like `colors.blue`.
+
+```python
+color = colors.HexColor("#0c2340")
+```
+
+For transparency (rare):
+```python
+color = colors.Color(0.05, 0.14, 0.25, alpha=0.8)
+```
+
+## Output
+
+Files are written to the sandbox filesystem. Use absolute paths:
+```python
+doc = SimpleDocTemplate("/home/user/report.pdf", ...)
+```
+
+After generation, download with:
+```python
+sandbox_download_file(path="/home/user/report.pdf")
+```

--- a/skills/documents/references/two-column-layouts.md
+++ b/skills/documents/references/two-column-layouts.md
@@ -1,0 +1,215 @@
+---
+name: Two-Column Layouts
+description: Use this reference when building multi-column page layouts in ReportLab. Covers Table-based layouts (simple, predictable) and Frame-based layouts (advanced, page-aware).
+---
+
+Two-column layouts are the default for professional documents. Single-column stacking is for letters and memos, not reports.
+
+## Approach 1: Table-Based Layout (Recommended)
+
+Use a `Table` with two cells per row. Simpler, more predictable, works with `SimpleDocTemplate`.
+
+### Constants
+
+```python
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import cm
+
+WIDTH, HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+COL_GAP = CONTENT_W * 0.05
+LEFT_W = CONTENT_W * 0.55
+RIGHT_W = CONTENT_W * 0.40
+```
+
+### Two-Column Section
+
+```python
+from reportlab.platypus import Table, TableStyle, Paragraph, Spacer
+from reportlab.lib import colors
+
+def two_col_section(left_flowables, right_flowables):
+    """Pack two columns of flowables side by side."""
+    left_cell = left_flowables if isinstance(left_flowables, list) else [left_flowables]
+    right_cell = right_flowables if isinstance(right_flowables, list) else [right_flowables]
+
+    table = Table(
+        [[left_cell, right_cell]],
+        colWidths=[LEFT_W, RIGHT_W],
+        hAlign="LEFT",
+    )
+    table.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 0),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+        ("TOPPADDING", (0, 0), (-1, -1), 0),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+    ]))
+    return table
+```
+
+### Example: Chart + Legend Side by Side
+
+```python
+# Build chart in left column
+chart_drawing = Drawing(LEFT_W, 180)
+# ... add chart to drawing ...
+
+# Build legend table in right column
+legend_rows = [
+    [Paragraph("<b>Category</b>", STYLES["caption"]),
+     Paragraph("<b>Value</b>", STYLES["caption"])],
+]
+for name, value, clr in legend_data:
+    swatch = Drawing(8, 8)
+    swatch.add(Rect(0, 0, 8, 8, fillColor=clr, strokeColor=None))
+    legend_rows.append([
+        [swatch, Paragraph(f"  {name}", STYLES["body"])],
+        Paragraph(f"{value:.1f}%", STYLES["body_right"]),
+    ])
+
+legend_table = Table(legend_rows, colWidths=[RIGHT_W * 0.65, RIGHT_W * 0.35])
+legend_table.setStyle(TableStyle([
+    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+    ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+    ("TOPPADDING", (0, 0), (-1, -1), 3),
+    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+]))
+
+# Combine
+elements.append(two_col_section(
+    [Paragraph("Revenue by Segment", STYLES["subheading"]), chart_drawing],
+    [Paragraph("Breakdown", STYLES["subheading"]), Spacer(1, 4), legend_table],
+))
+```
+
+### Example: KPI Cards Row
+
+```python
+def kpi_card(label, value, delta, card_w, accent_color):
+    """A single KPI card as a Table with colored header strip."""
+    header_row = [Paragraph(f"<b>{label}</b>", ParagraphStyle(
+        "KPILabel", fontSize=7, fontName="Helvetica-Bold",
+        textColor=colors.white, leading=10,
+    ))]
+    value_row = [Paragraph(f"<b>{value}</b>", ParagraphStyle(
+        "KPIValue", fontSize=16, fontName="Helvetica-Bold",
+        textColor=PRIMARY, leading=22, alignment=TA_CENTER,
+    ))]
+    delta_row = [Paragraph(delta, ParagraphStyle(
+        "KPIDelta", fontSize=7, fontName="Helvetica",
+        textColor=MUTED, leading=10, alignment=TA_CENTER,
+    ))]
+
+    card = Table(
+        [header_row, value_row, delta_row],
+        colWidths=[card_w],
+    )
+    card.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (0, 0), accent_color),
+        ("BACKGROUND", (0, 1), (0, -1), BACKGROUND),
+        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 8),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+        ("LEFTPADDING", (0, 0), (-1, -1), 8),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+        ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+    ]))
+    return card
+
+# Build 4 KPI cards in a row
+cards = [kpi_card("Revenue", "$2.4M", "+12.3% YoY", kw, ACCENT) for kw in [...]]
+kpi_gap = 8
+kpi_w = (CONTENT_W - 3 * kpi_gap) / 4
+
+card_list = [kpi_card(lbl, val, delta, kpi_w, ACCENT) for lbl, val, delta in kpi_data]
+kpi_row = Table([card_list], colWidths=[kpi_w] * 4)
+kpi_row.setStyle(TableStyle([
+    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+    ("LEFTPADDING", (0, 0), (-1, -1), 2),
+    ("RIGHTPADDING", (0, 0), (-1, -1), 2),
+]))
+elements.append(kpi_row)
+```
+
+## Approach 2: Frame-Based Layout (Advanced)
+
+Uses `BaseDocTemplate` with `PageTemplate` and multiple `Frame` objects. Useful when content must flow continuously across columns on the same page.
+
+### Setup
+
+```python
+from reportlab.platypus import BaseDocTemplate, Frame, PageTemplate
+
+left_frame = Frame(
+    MARGIN, MARGIN + 1 * cm,
+    LEFT_W, HEIGHT - 2 * MARGIN - 1 * cm,
+    id="left",
+    leftPadding=0, rightPadding=8,
+    topPadding=0, bottomPadding=0,
+)
+right_frame = Frame(
+    MARGIN + LEFT_W + COL_GAP, MARGIN + 1 * cm,
+    RIGHT_W, HEIGHT - 2 * MARGIN - 1 * cm,
+    id="right",
+    leftPadding=8, rightPadding=0,
+    topPadding=0, bottomPadding=0,
+)
+
+doc = BaseDocTemplate(
+    "/home/user/report.pdf",
+    pagesize=A4,
+    leftMargin=MARGIN,
+    rightMargin=MARGIN,
+    topMargin=MARGIN,
+    bottomMargin=2.5 * cm,
+)
+
+doc.addPageTemplates([
+    PageTemplate(id="TwoCol", frames=[left_frame, right_frame], onPage=add_footer),
+])
+```
+
+### When to Use Which
+
+| Feature | Table-Based | Frame-Based |
+|---------|-------------|-------------|
+| Complexity | Low | High |
+| DocTemplate | SimpleDocTemplate | BaseDocTemplate |
+| Column independence | Content per cell | Content flows across frames |
+| Per-section control | Each row is independent | All content flows |
+| Best for | Most reports | Newsletter-style continuous text |
+
+**Recommendation**: Use Table-based layouts for reports. Frame-based is for rare cases where body text needs to flow across columns like a newspaper.
+
+## Layout Patterns
+
+### 60/40 Split (Default)
+```python
+LEFT_W = CONTENT_W * 0.55
+RIGHT_W = CONTENT_W * 0.40
+# 5% implicit gap
+```
+
+### 50/50 Split
+```python
+HALF_W = (CONTENT_W - COL_GAP) / 2
+```
+
+### Three Columns
+```python
+COL3_GAP = 8
+COL3_W = (CONTENT_W - 2 * COL3_GAP) / 3
+```
+
+### Full Width Fallback
+For elements that span both columns (section headers, wide tables):
+```python
+elements.append(section_header("Financial Overview"))  # Full width
+elements.append(two_col_section(left, right))          # Two column
+elements.append(Spacer(1, LARGE))
+elements.append(wide_table)                            # Full width again
+```

--- a/skills/documents/scripts/generate_editorial.py
+++ b/skills/documents/scripts/generate_editorial.py
@@ -1,0 +1,868 @@
+"""
+Editorial Book-Style PDF Generator (Landscape, Themable).
+
+Landscape A4. Color backgrounds ONLY on cover and chapter divider pages.
+All text/content pages are clean white. Supports 12 themes, logo, chapter graphics.
+
+Usage:
+    python generate_editorial.py
+
+Customization:
+    Edit the DATA dict at the bottom. Set theme, title, subtitle, org_name,
+    logo_path (sandbox path to image), and chapters. You can also edit the
+    script directly to add sections, change layout, or extend themes.
+
+Agent workflow:
+    1. Edit DATA dict (or the script) with user content
+    2. For logo: use nano_banana_image_generation, save image to sandbox, set logo_path
+    3. Run in sandbox: pip install reportlab && python generate_editorial.py
+    4. Download PDF, optionally run pdf_to_images for preview
+"""
+
+import os
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_JUSTIFY, TA_RIGHT
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    KeepTogether,
+    NextPageTemplate,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+# ── Page geometry (landscape A4) ──────────────────────────────
+PAGE_SIZE = landscape(A4)
+WIDTH, HEIGHT = PAGE_SIZE
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+COL_GAP = 28
+COL_W = (CONTENT_W - COL_GAP) / 2
+
+SMALL, MEDIUM, LARGE = 8, 16, 28
+
+# ── Theme definitions (12 distinct warm palettes) ───────────────
+# Each palette uses a DIFFERENT hue family. Warm = warm undertone, not "brown."
+THEMES: dict[str, dict] = {
+    "terracotta": {
+        "cover_bg": "#c4704b",
+        "chapter_colors": ["#c4704b", "#9e5a6e", "#7a6e52", "#8c5c3e"],
+        "title_color": "white",
+        "code_bg": "#f5f0e8",
+        "muted": "#999999",
+        "rule": "#d4d4d4",
+    },
+    "crimson": {
+        "cover_bg": "#9b1b30",
+        "chapter_colors": ["#9b1b30", "#7a3b4a", "#a04050", "#6b2838"],
+        "title_color": "white",
+        "code_bg": "#fdf0f0",
+        "muted": "#8b6f6f",
+        "rule": "#d4c4c4",
+    },
+    "saffron": {
+        "cover_bg": "#b8860b",
+        "chapter_colors": ["#b8860b", "#8b6914", "#d4a017", "#7a6020"],
+        "title_color": "white",
+        "code_bg": "#fdf8e8",
+        "muted": "#7a7060",
+        "rule": "#d8d2c0",
+    },
+    "coral": {
+        "cover_bg": "#d06050",
+        "chapter_colors": ["#d06050", "#b85a58", "#c47868", "#a85048"],
+        "title_color": "white",
+        "code_bg": "#fef0ee",
+        "muted": "#8b7070",
+        "rule": "#e0d0ce",
+    },
+    "plum": {
+        "cover_bg": "#6b2148",
+        "chapter_colors": ["#6b2148", "#8b3a5a", "#5a2850", "#9e4868"],
+        "title_color": "white",
+        "code_bg": "#fdf4f8",
+        "muted": "#8b6b7a",
+        "rule": "#e0d0d8",
+    },
+    "olive": {
+        "cover_bg": "#556b2f",
+        "chapter_colors": ["#556b2f", "#6b7a3a", "#4a5e28", "#7a8a48"],
+        "title_color": "white",
+        "code_bg": "#f5f7ee",
+        "muted": "#6b7a5a",
+        "rule": "#d0d8c4",
+    },
+    "rose": {
+        "cover_bg": "#b5617a",
+        "chapter_colors": ["#b5617a", "#9a5068", "#c87a90", "#8a4860"],
+        "title_color": "white",
+        "code_bg": "#fdf2f5",
+        "muted": "#8b7078",
+        "rule": "#e0d0d5",
+    },
+    "espresso": {
+        "cover_bg": "#3c2415",
+        "chapter_colors": ["#3c2415", "#5a3a28", "#4e3020", "#6b4a35"],
+        "title_color": "white",
+        "code_bg": "#faf5f0",
+        "muted": "#78706a",
+        "rule": "#d6cec6",
+    },
+    "navy": {
+        "cover_bg": "#2c3e6b",
+        "chapter_colors": ["#2c3e6b", "#3a4f7a", "#4a3a68", "#354878"],
+        "title_color": "white",
+        "code_bg": "#f0f2f8",
+        "muted": "#6a7090",
+        "rule": "#c8cee0",
+    },
+    "wine": {
+        "cover_bg": "#722f37",
+        "chapter_colors": ["#722f37", "#5a3040", "#8b3a4a", "#683848"],
+        "title_color": "white",
+        "code_bg": "#faf0f0",
+        "muted": "#8b6f6f",
+        "rule": "#d4c4c4",
+    },
+    "teal": {
+        "cover_bg": "#2a6b5e",
+        "chapter_colors": ["#2a6b5e", "#3a7a6a", "#1e5a50", "#488a78"],
+        "title_color": "white",
+        "code_bg": "#f0f7f5",
+        "muted": "#5a7a72",
+        "rule": "#c4d8d2",
+    },
+    "aubergine": {
+        "cover_bg": "#4a2050",
+        "chapter_colors": ["#4a2050", "#5a3060", "#402848", "#6a3870"],
+        "title_color": "white",
+        "code_bg": "#f8f0fa",
+        "muted": "#7a6a80",
+        "rule": "#d4c8da",
+    },
+}
+
+# Resolved at runtime from DATA["theme"]
+COVER_BG: colors.HexColor = colors.HexColor("#c4704b")
+CHAPTER_COLORS: list[colors.HexColor] = []
+TEXT_DARK = colors.HexColor("#1a1a1a")
+TEXT_WHITE = colors.HexColor("#ffffff")
+MUTED = colors.HexColor("#999999")
+CODE_BG = colors.HexColor("#f5f0e8")
+RULE_CLR = colors.HexColor("#d4d4d4")
+TITLE_COLOR: colors.HexColor = TEXT_WHITE
+
+_chapter_color_stack: list[colors.HexColor] = []
+_cover_data: dict = {}
+
+
+def resolve_theme(theme_name: str) -> None:
+    """Apply theme; sets module-level color variables."""
+    global COVER_BG, CHAPTER_COLORS, MUTED, CODE_BG, RULE_CLR, TITLE_COLOR
+    t = THEMES.get(theme_name, THEMES["terracotta"])
+    COVER_BG = colors.HexColor(t["cover_bg"])
+    CHAPTER_COLORS = [colors.HexColor(h) for h in t["chapter_colors"]]
+    MUTED = colors.HexColor(t["muted"])
+    CODE_BG = colors.HexColor(t["code_bg"])
+    RULE_CLR = colors.HexColor(t["rule"])
+    TITLE_COLOR = TEXT_WHITE if t["title_color"] == "white" else TEXT_DARK
+
+
+def _build_styles() -> dict:
+    """Build paragraph styles from current theme."""
+    return {
+        "cover_title": ParagraphStyle(
+            "CoverTitle",
+            fontSize=48,
+            fontName="Helvetica-Bold",
+            textColor=TITLE_COLOR,
+            leading=56,
+            spaceAfter=14,
+        ),
+        "cover_sub": ParagraphStyle(
+            "CoverSub",
+            fontSize=15,
+            fontName="Helvetica",
+            textColor=TITLE_COLOR,
+            leading=22,
+        ),
+        "cover_logo": ParagraphStyle(
+            "CoverLogo",
+            fontSize=14,
+            fontName="Helvetica-Bold",
+            textColor=TITLE_COLOR,
+            leading=18,
+        ),
+        "chapter_label": ParagraphStyle(
+            "ChapterLabel",
+            fontSize=11,
+            fontName="Helvetica",
+            textColor=TITLE_COLOR,
+            leading=15,
+        ),
+        "chapter_title": ParagraphStyle(
+            "ChapterTitle",
+            fontSize=42,
+            fontName="Helvetica-Bold",
+            textColor=TITLE_COLOR,
+            leading=50,
+        ),
+        "toc_title": ParagraphStyle(
+            "TocTitle",
+            fontSize=36,
+            fontName="Helvetica-Bold",
+            textColor=TEXT_DARK,
+            leading=44,
+            spaceAfter=36,
+        ),
+        "toc_entry": ParagraphStyle(
+            "TocEntry",
+            fontSize=14,
+            fontName="Helvetica",
+            textColor=TEXT_DARK,
+            leading=20,
+        ),
+        "toc_page": ParagraphStyle(
+            "TocPage",
+            fontSize=14,
+            fontName="Helvetica-Bold",
+            textColor=TEXT_DARK,
+            leading=20,
+            alignment=TA_RIGHT,
+        ),
+        "heading": ParagraphStyle(
+            "Heading",
+            fontSize=22,
+            fontName="Helvetica-Bold",
+            textColor=TEXT_DARK,
+            leading=28,
+            spaceAfter=10,
+        ),
+        "subheading": ParagraphStyle(
+            "Subheading",
+            fontSize=13,
+            fontName="Helvetica-Bold",
+            textColor=TEXT_DARK,
+            leading=18,
+            spaceAfter=6,
+        ),
+        "body": ParagraphStyle(
+            "Body",
+            fontSize=11,
+            fontName="Helvetica",
+            textColor=TEXT_DARK,
+            leading=16,
+            alignment=TA_JUSTIFY,
+        ),
+        "code": ParagraphStyle(
+            "Code",
+            fontSize=9.5,
+            fontName="Courier",
+            textColor=TEXT_DARK,
+            leading=14,
+            backColor=CODE_BG,
+            borderPadding=10,
+            spaceBefore=6,
+            spaceAfter=6,
+        ),
+        "bullet": ParagraphStyle(
+            "Bullet",
+            fontSize=11,
+            fontName="Helvetica",
+            textColor=TEXT_DARK,
+            leading=16,
+            leftIndent=14,
+            bulletIndent=0,
+            spaceAfter=4,
+        ),
+    }
+
+
+# ── Canvas callbacks ──────────────────────────────────────────
+def _draw_chapter_graphic(canvas, bg_color: colors.HexColor) -> None:
+    """Concentric quarter-circle arcs in top-right corner."""
+    import colorsys
+
+    r, g, b = bg_color.red, bg_color.green, bg_color.blue
+    h, s, v = colorsys.rgb_to_hsv(r, g, b)
+    tr, tg, tb = colorsys.hsv_to_rgb(h, max(s * 0.3, 0.05), min(1, v + 0.25))
+    tint = colors.Color(tr, tg, tb, alpha=0.35)
+    cx, cy = WIDTH, HEIGHT
+    for radius in [100, 170, 240, 310]:
+        canvas.setStrokeColor(tint)
+        canvas.setLineWidth(3)
+        canvas.arc(cx - radius, cy - radius, cx + radius, cy + radius, 180, 90)
+
+
+def _draw_cover_logo(canvas) -> None:
+    """Draw org logo at bottom-left of cover page via canvas."""
+    logo_path = _cover_data.get("logo_path")
+    org_name = _cover_data.get("org_name", "Hyper")
+    x, y = MARGIN, MARGIN + 10
+
+    if logo_path and os.path.isfile(logo_path):
+        try:
+            canvas.drawImage(logo_path, x, y, width=28, height=28, mask="auto")
+            canvas.setFont("Helvetica-Bold", 14)
+            canvas.setFillColor(TITLE_COLOR)
+            canvas.drawString(x + 34, y + 8, org_name)
+            return
+        except Exception:
+            pass
+
+    sq = 5
+    gap = 2
+    canvas.setFillColor(TITLE_COLOR)
+    canvas.rect(x, y + sq + gap, sq, sq, stroke=0, fill=1)
+    canvas.rect(x + sq + gap, y + sq + gap, sq, sq, stroke=0, fill=1)
+    canvas.rect(x, y, sq, sq, stroke=0, fill=1)
+    canvas.rect(x + sq + gap, y, sq, sq, stroke=0, fill=1)
+    canvas.setFont("Helvetica-Bold", 14)
+    canvas.setFillColor(TITLE_COLOR)
+    canvas.drawString(x + 2 * sq + 2 * gap + 6, y + 2, org_name)
+
+
+def on_cover(canvas, doc):
+    canvas.saveState()
+    canvas.setFillColor(COVER_BG)
+    canvas.rect(0, 0, WIDTH, HEIGHT, stroke=0, fill=1)
+    _draw_cover_logo(canvas)
+    canvas.restoreState()
+
+
+def on_white(canvas, doc):
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(MUTED)
+    canvas.drawRightString(WIDTH - MARGIN, MARGIN - 14, str(doc.page))
+    canvas.restoreState()
+
+
+def on_chapter(canvas, doc):
+    canvas.saveState()
+    bg = _chapter_color_stack[-1] if _chapter_color_stack else COVER_BG
+    canvas.setFillColor(bg)
+    canvas.rect(0, 0, WIDTH, HEIGHT, stroke=0, fill=1)
+    _draw_chapter_graphic(canvas, bg)
+    canvas.restoreState()
+
+
+# ── Helpers ───────────────────────────────────────────────────
+def _two_col(left_els, right_els, S):
+    t = Table([[left_els, right_els]], colWidths=[COL_W, COL_W])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (0, -1), 0),
+                ("RIGHTPADDING", (0, 0), (0, -1), COL_GAP // 2),
+                ("LEFTPADDING", (1, 0), (1, -1), COL_GAP // 2),
+                ("RIGHTPADDING", (1, 0), (1, -1), 0),
+                ("TOPPADDING", (0, 0), (-1, -1), 0),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    return t
+
+
+def _code_block(code_text, S):
+    return Paragraph(
+        code_text.replace("\n", "<br/>").replace("  ", "&nbsp;&nbsp;"),
+        S["code"],
+    )
+
+
+def _bullet(text, S):
+    return Paragraph(f"\u2022&nbsp;&nbsp;{text}", S["bullet"])
+
+
+def _rule(S):
+    return HRFlowable(width="100%", thickness=0.5, color=RULE_CLR, spaceAfter=MEDIUM)
+
+
+# ── Page builders (take S and data) ─────────────────────────────
+def build_cover(elements, data: dict, S: dict) -> None:
+    title = data.get("title", "The Hyper<br/>Platform Guide").replace("\n", "<br/>")
+    subtitle = data.get("subtitle", "Build intelligent agents...")
+
+    cover_block = [
+        Spacer(1, 80),
+        Paragraph(title, S["cover_title"]),
+        Spacer(1, 10),
+        Paragraph(subtitle.replace("\n", "<br/>"), S["cover_sub"]),
+    ]
+    elements.append(KeepTogether(cover_block))
+
+    elements.append(NextPageTemplate("white"))
+    elements.append(PageBreak())
+
+
+def build_toc(elements, chapters: list[tuple[str, str]], S: dict) -> None:
+    elements.append(Paragraph("Contents", S["toc_title"]))
+    elements.append(Spacer(1, LARGE))
+    for title, page in chapters:
+        row = Table(
+            [[Paragraph(title, S["toc_entry"]), Paragraph(page, S["toc_page"])]],
+            colWidths=[CONTENT_W * 0.82, CONTENT_W * 0.18],
+        )
+        row.setStyle(
+            TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "BOTTOM"),
+                    ("LINEBELOW", (0, 0), (-1, -1), 0.5, colors.HexColor("#e0e0e0")),
+                    ("TOPPADDING", (0, 0), (-1, -1), 16),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 16),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                ]
+            )
+        )
+        elements.append(row)
+    elements.append(NextPageTemplate("white"))
+    elements.append(PageBreak())
+
+
+def build_chapter_divider(elements, title: str, color_idx: int, S: dict) -> None:
+    _chapter_color_stack.append(CHAPTER_COLORS[color_idx % len(CHAPTER_COLORS)])
+    elements.append(NextPageTemplate("chapter"))
+    elements.append(PageBreak())
+
+    max_spacer = HEIGHT - 2 * MARGIN - 120
+    divider_block = [
+        Spacer(1, min(310, max_spacer)),
+        Paragraph(f"Chapter {color_idx + 1}", S["chapter_label"]),
+        Spacer(1, MEDIUM),
+        Paragraph(title, S["chapter_title"]),
+    ]
+    elements.append(KeepTogether(divider_block))
+
+    elements.append(NextPageTemplate("white"))
+    elements.append(PageBreak())
+
+
+# ── Content (hardcoded sample; agent edits DATA or script) ──────
+def build_intro_content(elements, S: dict) -> None:
+    left = [
+        Paragraph(
+            "Hyper is a platform for building, deploying, and managing intelligent AI agents. "
+            "It provides a comprehensive framework that handles the complexity of agent orchestration, "
+            "tool management, memory systems, and multi-step workflows — so you can focus on building "
+            "applications that deliver real value.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "Whether you're building a customer support agent, a research assistant, or a complex "
+            "data pipeline, Hyper gives you the building blocks to move from prototype to production "
+            "with confidence.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "This guide covers everything you need to know — from architecture and tools to "
+            "workflows and deployment. Each chapter builds on the previous one, but you can "
+            "jump to any section.",
+            S["body"],
+        ),
+        Spacer(1, LARGE),
+        Paragraph("What you'll learn", S["subheading"]),
+        _bullet("How agents process tasks and use tools", S),
+        _bullet("Building workflows with the graph system", S),
+        _bullet("Managing memory and conversation state", S),
+        _bullet("Deploying and monitoring in production", S),
+    ]
+    right = [
+        Paragraph("Two paths through this guide", S["subheading"]),
+        Spacer(1, SMALL),
+        Paragraph(
+            "<b>Building from scratch?</b> Start with Getting Started and work through "
+            "each chapter sequentially. By the end you'll have a fully functional agent "
+            "deployed to production.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Extending an existing setup?</b> Jump directly to Agents &amp; Workflows "
+            "or Tools &amp; Integrations. Each chapter is self-contained.",
+            S["body"],
+        ),
+        Spacer(1, LARGE),
+        Paragraph("Who this is for", S["subheading"]),
+        Spacer(1, SMALL),
+        _bullet("Developers building AI-powered applications", S),
+        _bullet("Teams standardizing agent workflows", S),
+        _bullet("Architects designing multi-agent systems", S),
+        _bullet("Product engineers adding AI capabilities", S),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Introduction", S["heading"]),
+                _rule(S),
+                _two_col(left, right, S),
+            ]
+        )
+    )
+
+
+def build_chapter1_content(elements, S: dict) -> None:
+    left = [
+        Paragraph(
+            "Get started with the Hyper CLI in under five minutes. The CLI handles environment "
+            "setup, database provisioning, and service configuration automatically.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        _code_block(
+            "pip install hyper-seti\nhyper init my-project\ncd my-project\nhyper dev", S
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "This starts the development server with hot-reload, a local PostgreSQL instance "
+            "with pgvector, and Redis for caching.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Project structure", S["subheading"]),
+        Spacer(1, SMALL),
+        _code_block(
+            "my-project/\n\u251c\u2500\u2500 agents/\n\u251c\u2500\u2500 tools/\n"
+            "\u251c\u2500\u2500 workflows/\n\u2514\u2500\u2500 config.yml",
+            S,
+        ),
+    ]
+    right = [
+        Paragraph("Your first agent", S["subheading"]),
+        Spacer(1, SMALL),
+        Paragraph(
+            "Create an agent that can search the web and summarize results.", S["body"]
+        ),
+        Spacer(1, MEDIUM),
+        _code_block(
+            'from seti import Agent\n\nagent = Agent(name="researcher", model="claude-4", '
+            'tools=["web_search"], memory="persistent")\nresult = await agent.run("Find AI news")\nprint(result.content)',
+            S,
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Next steps", S["subheading"]),
+        _bullet("Add custom tools for your domain", S),
+        _bullet("Configure persistent memory", S),
+        _bullet("Build multi-agent workflows", S),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Installation", S["heading"]),
+                _rule(S),
+                _two_col(left, right, S),
+            ]
+        )
+    )
+
+    left2 = [
+        Paragraph(
+            "<b>Agents</b> are intelligent entities that process user requests.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Graphs</b> orchestrate the flow of operations across nodes.", S["body"]
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Tools</b> are capabilities agents use to interact with the world.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Memory</b> persists information across conversations.", S["body"]
+        ),
+    ]
+    right2 = [
+        Paragraph("<b>Threads</b> represent conversation sessions.", S["body"]),
+        Spacer(1, MEDIUM),
+        Paragraph("<b>Skills</b> are reusable task-specific guides.", S["body"]),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Integrations</b> connect agents to external services.", S["body"]
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph(
+            "<b>Traces</b> provide full observability into execution.", S["body"]
+        ),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Key concepts", S["heading"]),
+                _rule(S),
+                _two_col(left2, right2, S),
+            ]
+        )
+    )
+
+
+def build_chapter2_content(elements, S: dict) -> None:
+    left = [
+        Paragraph(
+            "Every agent follows a structured execution loop. When a user sends a message, "
+            "the agent evaluates its tools, plans an action sequence, executes tools, "
+            "and formulates a response.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Execution loop", S["subheading"]),
+        Spacer(1, SMALL),
+        _bullet("Receive user message and context", S),
+        _bullet("Evaluate available tools", S),
+        _bullet("Plan action sequence", S),
+        _bullet("Execute each action, observe results", S),
+        _bullet("Synthesize observations into response", S),
+        Spacer(1, MEDIUM),
+        Paragraph("Agents support delegation to specialized agents.", S["body"]),
+    ]
+    right = [
+        Paragraph("Configuration", S["subheading"]),
+        Spacer(1, SMALL),
+        _code_block(
+            'agent = Agent(name="analyst", model="claude-4", system_prompt="...", '
+            'tools=["sql_query","chart_builder"], memory=MemoryConfig(backend="postgres"), max_turns=10)',
+            S,
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("<b>system_prompt</b> — Persona and constraints.", S["body"]),
+        Spacer(1, SMALL),
+        Paragraph("<b>tools</b> — List of tool IDs.", S["body"]),
+        Spacer(1, SMALL),
+        Paragraph("<b>memory</b> — ephemeral, persistent, or vector.", S["body"]),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Agent architecture", S["heading"]),
+                _rule(S),
+                _two_col(left, right, S),
+            ]
+        )
+    )
+
+    left2 = [
+        Paragraph(
+            "Workflows are built using the graph system. A graph defines a directed flow "
+            "of operations — from input, through processing nodes, to output.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Node types", S["subheading"]),
+        Spacer(1, SMALL),
+        Paragraph(
+            "<b>AgentNode</b> — Runs an agent with a prompt and tools.", S["body"]
+        ),
+        Spacer(1, SMALL),
+        Paragraph("<b>ToolNode</b> — Executes a single tool.", S["body"]),
+        Spacer(1, SMALL),
+        Paragraph("<b>ConditionNode</b> — Routes flow based on a boolean.", S["body"]),
+        Spacer(1, SMALL),
+        Paragraph(
+            "<b>ParallelNode</b> — Runs multiple branches concurrently.", S["body"]
+        ),
+    ]
+    right2 = [
+        Paragraph("Example workflow", S["subheading"]),
+        Spacer(1, SMALL),
+        _code_block(
+            'from seti.graph import Graph\nfrom seti.graph.nodes import *\n\ng = Graph(name="research")\n'
+            'g.add_node(AgentNode(id="researcher", agent="web_researcher"))\n'
+            'g.add_node(AgentNode(id="writer", agent="report_writer"))\ng.add_edge("researcher","writer")',
+            S,
+        ),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Building workflows", S["heading"]),
+                _rule(S),
+                _two_col(left2, right2, S),
+            ]
+        )
+    )
+
+
+def build_chapter3_content(elements, S: dict) -> None:
+    left = [
+        Paragraph(
+            "Tools are the bridge between agents and the external world. Hyper provides "
+            "centralized registration, namespace isolation, and execution tracing.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Built-in tools", S["subheading"]),
+        Spacer(1, SMALL),
+        _tool_table(
+            [
+                ("Web &amp; Search", "web_search, web_scrape"),
+                ("Files &amp; Storage", "file_read, file_write"),
+                ("Code Execution", "python, bash, sandbox"),
+                ("Data &amp; Database", "sql_query, vector_search"),
+                ("Communication", "email_send, slack_post"),
+                ("Image &amp; Media", "image_generate, image_analyze"),
+            ],
+            S,
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Tools are scoped per workspace for strict isolation.", S["body"]),
+    ]
+    right = [
+        Paragraph("Creating custom tools", S["subheading"]),
+        Spacer(1, SMALL),
+        Paragraph(
+            "Define tools as Python functions with type annotations. Hyper generates "
+            "the JSON schema automatically.",
+            S["body"],
+        ),
+        Spacer(1, MEDIUM),
+        _code_block(
+            'from seti.tools import tool\n\n@tool(name="get_weather")\nasync def get_weather(city: str) -> dict:\n  return (await fetch(f"/api/weather/{city}")).json()',
+            S,
+        ),
+        Spacer(1, MEDIUM),
+        Paragraph("Integration patterns", S["subheading"]),
+        Spacer(1, SMALL),
+        _bullet("OAuth providers for Google, Slack, GitHub", S),
+        _bullet("Pipedream Connect for webhooks", S),
+        _bullet("MCP protocol for external tool servers", S),
+    ]
+    elements.append(
+        KeepTogether(
+            [
+                Paragraph("Tool system", S["heading"]),
+                _rule(S),
+                _two_col(left, right, S),
+            ]
+        )
+    )
+
+
+def _tool_table(rows: list[tuple[str, str]], S: dict) -> Table:
+    data = []
+    for category, tools in rows:
+        data.append(
+            [
+                Paragraph(
+                    f"<b>{category}</b>",
+                    ParagraphStyle(
+                        "TC",
+                        fontSize=9.5,
+                        fontName="Helvetica-Bold",
+                        textColor=TEXT_DARK,
+                        leading=13,
+                    ),
+                ),
+                Paragraph(
+                    tools,
+                    ParagraphStyle(
+                        "TT",
+                        fontSize=9,
+                        fontName="Courier",
+                        textColor=MUTED,
+                        leading=13,
+                    ),
+                ),
+            ]
+        )
+    t = Table(data, colWidths=[COL_W * 0.40, COL_W * 0.60])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LINEBELOW", (0, 0), (-1, -2), 0.5, colors.HexColor("#e8e8e8")),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+            ]
+        )
+    )
+    return t
+
+
+# ── Main ──────────────────────────────────────────────────────
+def generate(data: dict | None = None) -> str:
+    global _cover_data
+    data = data or DATA
+    _cover_data = data
+    resolve_theme(data.get("theme", "warm_editorial"))
+    S = _build_styles()
+
+    output_path = data.get("output_path")
+    if not output_path:
+        output_dir = os.path.join(os.path.dirname(__file__), "output")
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, "editorial.pdf")
+
+    cover_frame = Frame(MARGIN, MARGIN, CONTENT_W, HEIGHT - 2 * MARGIN, id="cover")
+    white_frame = Frame(MARGIN, MARGIN, CONTENT_W, HEIGHT - 2 * MARGIN, id="white")
+    chapter_frame = Frame(MARGIN, MARGIN, CONTENT_W, HEIGHT - 2 * MARGIN, id="chapter")
+
+    doc = BaseDocTemplate(
+        output_path,
+        pagesize=PAGE_SIZE,
+        leftMargin=MARGIN,
+        rightMargin=MARGIN,
+        topMargin=MARGIN,
+        bottomMargin=MARGIN,
+    )
+    doc.addPageTemplates(
+        [
+            PageTemplate(id="cover", frames=[cover_frame], onPage=on_cover),
+            PageTemplate(id="white", frames=[white_frame], onPage=on_white),
+            PageTemplate(id="chapter", frames=[chapter_frame], onPage=on_chapter),
+        ]
+    )
+
+    elements = []
+    build_cover(elements, data, S)
+    build_toc(
+        elements,
+        [
+            ("Introduction", "3"),
+            ("Getting Started", "5"),
+            ("Agents &amp; Workflows", "8"),
+            ("Tools &amp; Integrations", "11"),
+        ],
+        S,
+    )
+    build_intro_content(elements, S)
+    build_chapter_divider(elements, "Getting Started", 0, S)
+    build_chapter1_content(elements, S)
+    build_chapter_divider(elements, "Agents &amp; Workflows", 1, S)
+    build_chapter2_content(elements, S)
+    build_chapter_divider(elements, "Tools &amp; Integrations", 2, S)
+    build_chapter3_content(elements, S)
+
+    doc.build(elements)
+    size = os.path.getsize(output_path)
+    print(f"Generated: {output_path} ({size:,} bytes)")
+    return output_path
+
+
+# ── DATA: Edit this (or the script) to customize ────────────────
+DATA = {
+    "theme": "terracotta",
+    "title": "The Hyper\nPlatform Guide",
+    "subtitle": "Build intelligent agents, orchestrate workflows,\nand deploy AI-powered applications at scale.",
+    "org_name": "Hyper",
+    "logo_path": None,
+    "output_path": None,
+}
+
+if __name__ == "__main__":
+    generate()

--- a/skills/documents/scripts/generate_finance_report.py
+++ b/skills/documents/scripts/generate_finance_report.py
@@ -1,0 +1,526 @@
+"""Generate a professional finance report PDF with KPIs, charts, and P&L table.
+
+Uses the Corporate Navy palette. Produces a multi-page finance report with
+cover page, KPI dashboard, revenue trend chart, and profit & loss breakdown.
+Outputs to /home/user/finance_report.pdf.
+
+Usage:
+    python generate_finance_report.py
+
+Customization:
+    Edit the DATA dict at the bottom. Supports monthly revenue/expense
+    arrays, expense category breakdowns, and P&L line items.
+"""
+
+import calendar
+
+from reportlab.graphics.charts.lineplots import LinePlot
+from reportlab.graphics.charts.piecharts import Pie
+from reportlab.graphics.shapes import Drawing, Rect
+from reportlab.graphics.widgets.markers import makeMarker
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_JUSTIFY, TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    HRFlowable,
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+# ── Page setup ────────────────────────────────────────────────
+WIDTH, HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+LEFT_W = CONTENT_W * 0.55
+RIGHT_W = CONTENT_W * 0.40
+COL_GAP = CONTENT_W * 0.05
+
+# ── Corporate Navy palette ───────────────────────────────────
+PRIMARY = colors.HexColor("#0c2340")
+SECONDARY = colors.HexColor("#1a5276")
+ACCENT = colors.HexColor("#2980b9")
+SUCCESS = colors.HexColor("#1e8449")
+DANGER = colors.HexColor("#c0392b")
+BODY_TEXT = colors.HexColor("#2c3e50")
+MUTED = colors.HexColor("#7f8c8d")
+BORDER = colors.HexColor("#d5d8dc")
+ROW_ALT = colors.HexColor("#f2f4f4")
+
+PIE_COLORS = [
+    colors.HexColor("#2563eb"),
+    colors.HexColor("#0891b2"),
+    colors.HexColor("#059669"),
+    colors.HexColor("#d97706"),
+    colors.HexColor("#dc2626"),
+    colors.HexColor("#7c3aed"),
+]
+
+TINY, SMALL, MEDIUM, LARGE, SECTION = 4, 8, 16, 24, 32
+
+S = {
+    "display": ParagraphStyle(
+        "D", fontSize=24, fontName="Helvetica-Bold", textColor=PRIMARY, leading=30
+    ),
+    "heading": ParagraphStyle(
+        "H",
+        fontSize=16,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=22,
+        spaceAfter=8,
+    ),
+    "subheading": ParagraphStyle(
+        "SH",
+        fontSize=12,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=16,
+        spaceAfter=4,
+    ),
+    "body": ParagraphStyle(
+        "B",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_JUSTIFY,
+    ),
+    "body_bold": ParagraphStyle(
+        "BB", fontSize=9, fontName="Helvetica-Bold", textColor=BODY_TEXT, leading=13
+    ),
+    "body_right": ParagraphStyle(
+        "BR",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_RIGHT,
+    ),
+    "caption": ParagraphStyle(
+        "C", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10
+    ),
+}
+
+
+def _footer(canvas, doc):
+    canvas.saveState()
+    canvas.setFont("Helvetica", 7)
+    canvas.setFillColor(MUTED)
+    canvas.drawRightString(WIDTH - MARGIN, 1.2 * cm, f"Page {doc.page}")
+    canvas.restoreState()
+
+
+def _kpi_card(label, value, change=None, w=None):
+    w = w or (CONTENT_W - 3 * SMALL) / 4
+    parts = [
+        [
+            Paragraph(
+                label,
+                ParagraphStyle(
+                    "KL",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                ),
+            )
+        ],
+        [
+            Paragraph(
+                f"<b>{value}</b>",
+                ParagraphStyle(
+                    "KV",
+                    fontSize=16,
+                    fontName="Helvetica-Bold",
+                    textColor=PRIMARY,
+                    leading=20,
+                ),
+            )
+        ],
+    ]
+    if change:
+        clr = SUCCESS if change.startswith("+") else DANGER
+        parts.append(
+            [
+                Paragraph(
+                    change,
+                    ParagraphStyle(
+                        "KC",
+                        fontSize=8,
+                        fontName="Helvetica-Bold",
+                        textColor=clr,
+                        leading=11,
+                    ),
+                )
+            ]
+        )
+
+    card = Table(parts, colWidths=[w - 16])
+    card.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), ROW_ALT),
+                ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+                ("TOPPADDING", (0, 0), (-1, -1), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    return card
+
+
+def _cover(elements, data):
+    elements.append(Spacer(1, 80))
+    elements.append(
+        Paragraph(
+            data["company"].upper(),
+            ParagraphStyle(
+                "CO",
+                fontSize=10,
+                fontName="Helvetica-Bold",
+                textColor=ACCENT,
+                leading=14,
+            ),
+        )
+    )
+    elements.append(Spacer(1, MEDIUM))
+    bar = Drawing(CONTENT_W, 6)
+    bar.add(Rect(0, 0, CONTENT_W, 6, fillColor=PRIMARY, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, LARGE))
+    elements.append(Paragraph(data["title"], S["display"]))
+    elements.append(Spacer(1, SMALL))
+    elements.append(
+        Paragraph(
+            data["period"],
+            ParagraphStyle(
+                "P", fontSize=12, fontName="Helvetica", textColor=SECONDARY, leading=16
+            ),
+        )
+    )
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(HRFlowable(width="30%", thickness=0.5, color=BORDER))
+    elements.append(Spacer(1, SMALL))
+    elements.append(Paragraph(f"Prepared: {data['date']}", S["caption"]))
+    elements.append(PageBreak())
+
+
+def _kpi_dashboard(elements, kpis):
+    elements.append(Paragraph("Financial Highlights", S["heading"]))
+    elements.append(
+        HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=MEDIUM)
+    )
+    cards = [_kpi_card(k["label"], k["value"], k.get("change")) for k in kpis[:4]]
+    row = Table([cards], colWidths=[(CONTENT_W - 3 * SMALL) / 4] * 4)
+    row.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), SMALL),
+            ]
+        )
+    )
+    elements.append(row)
+    elements.append(Spacer(1, SECTION))
+
+
+def _revenue_chart(elements, months, revenue, expenses):
+    elements.append(Paragraph("Revenue & Expenses Trend", S["heading"]))
+    elements.append(
+        HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=MEDIUM)
+    )
+
+    chart_w = LEFT_W - 20
+    chart_h = 160
+    d = Drawing(chart_w + 20, chart_h + 30)
+
+    lp = LinePlot()
+    lp.x = 30
+    lp.y = 20
+    lp.width = chart_w - 40
+    lp.height = chart_h - 20
+    lp.data = [list(enumerate(revenue)), list(enumerate(expenses))]
+    lp.lines[0].strokeColor = ACCENT
+    lp.lines[0].strokeWidth = 2
+    lp.lines[0].symbol = makeMarker("FilledCircle")
+    lp.lines[0].symbol.fillColor = ACCENT
+    lp.lines[0].symbol.size = 4
+    lp.lines[1].strokeColor = DANGER
+    lp.lines[1].strokeWidth = 2
+    lp.lines[1].symbol = makeMarker("FilledSquare")
+    lp.lines[1].symbol.fillColor = DANGER
+    lp.lines[1].symbol.size = 4
+    lp.xValueAxis.valueSteps = list(range(len(months)))
+    lp.xValueAxis.labelTextFormat = (
+        lambda x: months[int(x)][:3] if 0 <= int(x) < len(months) else ""
+    )
+    lp.xValueAxis.labels.fontSize = 6
+    lp.yValueAxis.labelTextFormat = lambda x: f"${x / 1000:.0f}k"
+    lp.yValueAxis.labels.fontSize = 6
+    d.add(lp)
+
+    # Summary sidebar
+    total_rev = sum(revenue)
+    total_exp = sum(expenses)
+    profit = total_rev - total_exp
+    margin_pct = (profit / total_rev * 100) if total_rev else 0
+
+    summary_data = [
+        ("Total Revenue", f"${total_rev:,.0f}"),
+        ("Total Expenses", f"${total_exp:,.0f}"),
+        ("Net Profit", f"${profit:,.0f}"),
+        ("Profit Margin", f"{margin_pct:.1f}%"),
+    ]
+    summary_rows = [
+        [
+            Paragraph(
+                f"<b>{label}</b>",
+                ParagraphStyle(
+                    "SL",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                ),
+            ),
+            Paragraph(
+                value,
+                ParagraphStyle(
+                    "SV",
+                    fontSize=9,
+                    fontName="Helvetica-Bold",
+                    textColor=PRIMARY,
+                    leading=13,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+        ]
+        for label, value in summary_data
+    ]
+    st = Table(summary_rows, colWidths=[RIGHT_W * 0.5, RIGHT_W * 0.5])
+    st.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("BACKGROUND", (0, 0), (-1, -1), ROW_ALT),
+                ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+                ("LINEBELOW", (0, 0), (-1, -2), 0.5, BORDER),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    right = [Paragraph("Summary", S["subheading"]), Spacer(1, TINY), st]
+
+    two_col = Table([[[d], right]], colWidths=[LEFT_W, RIGHT_W + COL_GAP])
+    two_col.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(two_col)
+    elements.append(Spacer(1, SECTION))
+
+
+def _expense_pie(elements, categories):
+    elements.append(Paragraph("Expense Breakdown", S["heading"]))
+    elements.append(
+        HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=MEDIUM)
+    )
+
+    total = sum(c["amount"] for c in categories)
+    d = Drawing(LEFT_W - 20, 160)
+    pie = Pie()
+    pie.x = (LEFT_W - 20) / 2 - 60
+    pie.y = 10
+    pie.width = 120
+    pie.height = 120
+    pie.data = [c["amount"] for c in categories]
+    pie.labels = None
+    for i in range(len(categories)):
+        pie.slices[i].fillColor = PIE_COLORS[i % len(PIE_COLORS)]
+        pie.slices[i].strokeColor = colors.white
+        pie.slices[i].strokeWidth = 1
+    d.add(pie)
+
+    legend_rows = [
+        [
+            Paragraph(
+                "<b>Category</b>",
+                ParagraphStyle(
+                    "LH",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                ),
+            ),
+            Paragraph(
+                "<b>Amount</b>",
+                ParagraphStyle(
+                    "LH2",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+            Paragraph(
+                "<b>%</b>",
+                ParagraphStyle(
+                    "LH3",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+        ]
+    ]
+    for i, c in enumerate(categories):
+        pct = c["amount"] / total * 100 if total else 0
+        clr = PIE_COLORS[i % len(PIE_COLORS)]
+        swatch = Drawing(10, 10)
+        swatch.add(Rect(0, 0, 10, 10, fillColor=clr, strokeColor=None))
+        legend_rows.append(
+            [
+                Table(
+                    [
+                        [
+                            swatch,
+                            Paragraph(
+                                c["name"],
+                                ParagraphStyle(
+                                    "LN",
+                                    fontSize=8,
+                                    fontName="Helvetica",
+                                    textColor=BODY_TEXT,
+                                    leading=11,
+                                ),
+                            ),
+                        ]
+                    ],
+                    colWidths=[14, RIGHT_W * 0.55],
+                ),
+                Paragraph(
+                    f"${c['amount']:,.0f}",
+                    ParagraphStyle(
+                        "LA",
+                        fontSize=8,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=11,
+                        alignment=TA_RIGHT,
+                    ),
+                ),
+                Paragraph(
+                    f"{pct:.1f}%",
+                    ParagraphStyle(
+                        "LP",
+                        fontSize=8,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=11,
+                        alignment=TA_RIGHT,
+                    ),
+                ),
+            ]
+        )
+
+    lt = Table(legend_rows, colWidths=[RIGHT_W * 0.55, RIGHT_W * 0.25, RIGHT_W * 0.20])
+    lt.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LINEBELOW", (0, 0), (-1, 0), 0.5, BORDER),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+
+    two_col = Table(
+        [[[d], [Spacer(1, TINY), lt]]], colWidths=[LEFT_W, RIGHT_W + COL_GAP]
+    )
+    two_col.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(two_col)
+
+
+def generate_finance_report(
+    data: dict, output_path: str = "/home/user/finance_report.pdf"
+) -> str:
+    doc = SimpleDocTemplate(
+        output_path,
+        pagesize=A4,
+        leftMargin=MARGIN,
+        rightMargin=MARGIN,
+        topMargin=MARGIN,
+        bottomMargin=2 * cm,
+    )
+    elements = []
+
+    _cover(elements, data)
+    _kpi_dashboard(elements, data["kpis"])
+    _revenue_chart(elements, data["months"], data["revenue"], data["expenses"])
+    elements.append(PageBreak())
+    _expense_pie(elements, data["expense_categories"])
+
+    doc.build(elements, onFirstPage=_footer, onLaterPages=_footer)
+    print(f"Generated: {output_path}")
+    return output_path
+
+
+# ── Sample data — edit this to generate your report ──────────
+DATA = {
+    "company": "Apex Consulting Group",
+    "title": "Financial Performance Report",
+    "period": "Q4 2025 — October to December",
+    "date": "January 10, 2026",
+    "kpis": [
+        {"label": "Total Revenue", "value": "$2.4M", "change": "+12.3%"},
+        {"label": "Net Profit", "value": "$680K", "change": "+8.7%"},
+        {"label": "Operating Margin", "value": "28.3%", "change": "+2.1pp"},
+        {"label": "Cash Position", "value": "$1.8M", "change": "+15.2%"},
+    ],
+    "months": list(calendar.month_name[10:13]),  # Oct, Nov, Dec
+    "revenue": [780000, 820000, 850000],
+    "expenses": [540000, 570000, 590000],
+    "expense_categories": [
+        {"name": "Personnel", "amount": 980000},
+        {"name": "Technology", "amount": 280000},
+        {"name": "Marketing", "amount": 180000},
+        {"name": "Facilities", "amount": 120000},
+        {"name": "Professional Services", "amount": 95000},
+        {"name": "Other", "amount": 45000},
+    ],
+}
+
+if __name__ == "__main__":
+    generate_finance_report(DATA)

--- a/skills/documents/scripts/generate_invoice.py
+++ b/skills/documents/scripts/generate_invoice.py
@@ -1,0 +1,629 @@
+"""Generate a professional invoice PDF with line items, tax, and payment details.
+
+Uses the Cool Slate palette. Produces a single-page invoice suitable for
+consulting, freelance, or B2B billing. Outputs to /home/user/invoice.pdf.
+
+Usage:
+    python generate_invoice.py
+
+Customization:
+    Edit the DATA dict at the bottom to change company, client, line items,
+    tax rate, discount, and payment details. All amounts are in USD.
+"""
+
+from reportlab.graphics.shapes import Drawing, Rect
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    HRFlowable,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+# ── Page setup ────────────────────────────────────────────────
+WIDTH, HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+LEFT_W = CONTENT_W * 0.48
+RIGHT_W = CONTENT_W * 0.48
+COL_GAP = CONTENT_W * 0.04
+
+# ── Cool Slate palette ───────────────────────────────────────
+PRIMARY = colors.HexColor("#1e293b")
+SECONDARY = colors.HexColor("#334155")
+ACCENT = colors.HexColor("#3b82f6")
+SUCCESS = colors.HexColor("#16a34a")
+DANGER = colors.HexColor("#dc2626")
+BODY_TEXT = colors.HexColor("#334155")
+MUTED = colors.HexColor("#94a3b8")
+BORDER = colors.HexColor("#cbd5e1")
+ROW_ALT = colors.HexColor("#f8fafc")
+
+TINY, SMALL, MEDIUM, LARGE = 4, 8, 16, 24
+
+S = {
+    "heading": ParagraphStyle(
+        "H",
+        fontSize=16,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=22,
+        spaceAfter=8,
+    ),
+    "subheading": ParagraphStyle(
+        "SH",
+        fontSize=12,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=16,
+        spaceAfter=4,
+    ),
+    "body": ParagraphStyle(
+        "B",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_JUSTIFY,
+    ),
+    "body_bold": ParagraphStyle(
+        "BB", fontSize=9, fontName="Helvetica-Bold", textColor=BODY_TEXT, leading=13
+    ),
+    "body_right": ParagraphStyle(
+        "BR",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_RIGHT,
+    ),
+    "caption": ParagraphStyle(
+        "C", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10
+    ),
+}
+
+
+def _footer(canvas, doc):
+    canvas.saveState()
+    canvas.setFont("Helvetica", 7)
+    canvas.setFillColor(MUTED)
+    canvas.drawRightString(WIDTH - MARGIN, 1.2 * cm, f"Page {doc.page}")
+    canvas.restoreState()
+
+
+def _header(elements, company, inv_number, status):
+    left = [
+        Paragraph(
+            f"<b>{company['name']}</b>",
+            ParagraphStyle(
+                "CN",
+                fontSize=16,
+                fontName="Helvetica-Bold",
+                textColor=PRIMARY,
+                leading=22,
+            ),
+        ),
+        Paragraph(
+            company.get("tagline", ""),
+            ParagraphStyle(
+                "Tag", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10
+            ),
+        ),
+    ]
+    status_clr = {
+        "paid": SUCCESS,
+        "unpaid": ACCENT,
+        "overdue": DANGER,
+        "draft": MUTED,
+    }.get(status.lower(), MUTED)
+    right = [
+        Paragraph(
+            "INVOICE",
+            ParagraphStyle(
+                "IL",
+                fontSize=24,
+                fontName="Helvetica-Bold",
+                textColor=ACCENT,
+                leading=30,
+                alignment=TA_RIGHT,
+            ),
+        ),
+        Paragraph(
+            f"#{inv_number}",
+            ParagraphStyle(
+                "IN",
+                fontSize=12,
+                fontName="Helvetica-Bold",
+                textColor=PRIMARY,
+                leading=16,
+                alignment=TA_RIGHT,
+            ),
+        ),
+        Spacer(1, TINY),
+        Paragraph(
+            f"<b>{status.upper()}</b>",
+            ParagraphStyle(
+                "St",
+                fontSize=9,
+                fontName="Helvetica-Bold",
+                textColor=status_clr,
+                leading=13,
+                alignment=TA_RIGHT,
+            ),
+        ),
+    ]
+    t = Table([[left, right]], colWidths=[LEFT_W + COL_GAP / 2, RIGHT_W + COL_GAP / 2])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(t)
+    bar = Drawing(CONTENT_W, 3)
+    bar.add(Rect(0, 0, CONTENT_W, 3, fillColor=ACCENT, strokeColor=None))
+    elements.append(bar)
+    elements.append(Spacer(1, MEDIUM))
+
+
+def _addresses(elements, company, client, meta):
+    a = ParagraphStyle(
+        "A", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13
+    )
+    lbl = ParagraphStyle(
+        "L",
+        fontSize=7,
+        fontName="Helvetica-Bold",
+        textColor=MUTED,
+        leading=10,
+        spaceAfter=2,
+    )
+
+    left = [
+        Paragraph("FROM", lbl),
+        Paragraph(f"<b>{company['name']}</b>", S["body_bold"]),
+        Paragraph(company["address"], a),
+        Paragraph(company.get("email", ""), a),
+        Paragraph(company.get("phone", ""), a),
+    ]
+    right = [
+        Paragraph("BILL TO", lbl),
+        Paragraph(f"<b>{client['name']}</b>", S["body_bold"]),
+        Paragraph(client["address"], a),
+        Paragraph(client.get("email", ""), a),
+    ]
+
+    meta_rows = [
+        [
+            Paragraph(
+                f"<b>{k}</b>",
+                ParagraphStyle(
+                    "ML",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=MUTED,
+                    leading=10,
+                ),
+            ),
+            Paragraph(
+                v,
+                ParagraphStyle(
+                    "MV",
+                    fontSize=9,
+                    fontName="Helvetica",
+                    textColor=BODY_TEXT,
+                    leading=13,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+        ]
+        for k, v in meta
+    ]
+    mt = Table(meta_rows, colWidths=[RIGHT_W * 0.45, RIGHT_W * 0.55])
+    mt.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LINEBELOW", (0, 0), (-1, -1), 0.5, BORDER),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    right += [Spacer(1, SMALL), mt]
+
+    t = Table([[left, right]], colWidths=[LEFT_W, RIGHT_W + COL_GAP])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(t)
+    elements.append(Spacer(1, LARGE))
+
+
+def _line_items(elements, items):
+    cw = [CONTENT_W * 0.44, CONTENT_W * 0.12, CONTENT_W * 0.20, CONTENT_W * 0.24]
+    th = ParagraphStyle(
+        "TH", fontSize=8, fontName="Helvetica-Bold", textColor=colors.white, leading=11
+    )
+    rows = [
+        [
+            Paragraph("<b>Description</b>", th),
+            Paragraph(
+                "<b>Qty</b>", ParagraphStyle("TH2", parent=th, alignment=TA_CENTER)
+            ),
+            Paragraph(
+                "<b>Unit Price</b>",
+                ParagraphStyle("TH3", parent=th, alignment=TA_RIGHT),
+            ),
+            Paragraph(
+                "<b>Amount</b>", ParagraphStyle("TH4", parent=th, alignment=TA_RIGHT)
+            ),
+        ]
+    ]
+
+    for item in items:
+        amt = item["quantity"] * item["unit_price"]
+        desc = [Paragraph(item["description"], S["body_bold"])]
+        if item.get("details"):
+            desc.append(
+                Paragraph(
+                    item["details"],
+                    ParagraphStyle(
+                        "D",
+                        fontSize=7,
+                        fontName="Helvetica",
+                        textColor=MUTED,
+                        leading=10,
+                    ),
+                )
+            )
+        rows.append(
+            [
+                desc,
+                Paragraph(
+                    str(item["quantity"]),
+                    ParagraphStyle(
+                        "Q",
+                        fontSize=9,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=13,
+                        alignment=TA_CENTER,
+                    ),
+                ),
+                Paragraph(f"${item['unit_price']:,.2f}", S["body_right"]),
+                Paragraph(f"${amt:,.2f}", S["body_right"]),
+            ]
+        )
+
+    t = Table(rows, colWidths=cw)
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("ALIGN", (1, 0), (1, -1), "CENTER"),
+                ("ALIGN", (2, 0), (-1, -1), "RIGHT"),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    elements.append(t)
+
+
+def _totals(elements, subtotal, tax_rate=0, discount=0):
+    tax = subtotal * tax_rate
+    disc = subtotal * discount if discount else 0
+    total = subtotal + tax - disc
+    tw = CONTENT_W * 0.40
+    ow = CONTENT_W * 0.60
+
+    rows = [
+        [
+            Paragraph("Subtotal", S["body"]),
+            Paragraph(f"${subtotal:,.2f}", S["body_right"]),
+        ]
+    ]
+    if tax_rate:
+        rows.append(
+            [
+                Paragraph(f"Tax ({tax_rate * 100:.0f}%)", S["body"]),
+                Paragraph(f"${tax:,.2f}", S["body_right"]),
+            ]
+        )
+    if discount:
+        rows.append(
+            [
+                Paragraph(f"Discount ({discount * 100:.0f}%)", S["body"]),
+                Paragraph(
+                    f"-${disc:,.2f}",
+                    ParagraphStyle(
+                        "Dc",
+                        fontSize=9,
+                        fontName="Helvetica",
+                        textColor=SUCCESS,
+                        leading=13,
+                        alignment=TA_RIGHT,
+                    ),
+                ),
+            ]
+        )
+    rows.append(
+        [
+            Paragraph(
+                "<b>TOTAL DUE</b>",
+                ParagraphStyle(
+                    "TL",
+                    fontSize=12,
+                    fontName="Helvetica-Bold",
+                    textColor=PRIMARY,
+                    leading=16,
+                ),
+            ),
+            Paragraph(
+                f"<b>${total:,.2f}</b>",
+                ParagraphStyle(
+                    "TV",
+                    fontSize=12,
+                    fontName="Helvetica-Bold",
+                    textColor=ACCENT,
+                    leading=16,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+        ]
+    )
+
+    tt = Table(rows, colWidths=[tw * 0.55, tw * 0.45])
+    n = len(rows) - 1
+    tt.setStyle(
+        TableStyle(
+            [
+                ("LINEBELOW", (0, 0), (-1, n - 1), 0.5, BORDER),
+                ("LINEABOVE", (0, n), (-1, n), 2, PRIMARY),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+
+    w = Table([[Paragraph("", S["body"]), tt]], colWidths=[ow, tw])
+    w.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(Spacer(1, SMALL))
+    elements.append(w)
+
+
+def _payment(elements, info):
+    elements.append(Spacer(1, LARGE))
+    rows = [
+        [
+            Paragraph(
+                f"<b>{k}</b>",
+                ParagraphStyle(
+                    "PL",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=SECONDARY,
+                    leading=10,
+                ),
+            ),
+            Paragraph(
+                v,
+                ParagraphStyle(
+                    "PV",
+                    fontSize=9,
+                    fontName="Helvetica",
+                    textColor=BODY_TEXT,
+                    leading=13,
+                ),
+            ),
+        ]
+        for k, v in info.items()
+    ]
+    pt = Table(rows, colWidths=[CONTENT_W * 0.22, CONTENT_W * 0.38])
+    pt.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("BACKGROUND", (0, 0), (-1, -1), ROW_ALT),
+                ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+                ("LINEBELOW", (0, 0), (-1, -2), 0.5, BORDER),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    left = [
+        Paragraph("Payment Details", S["subheading"]),
+        Spacer(1, TINY),
+        Paragraph("Please reference the invoice number in your payment.", S["caption"]),
+    ]
+    t = Table([[left, pt]], colWidths=[LEFT_W * 0.5, CONTENT_W * 0.6 + COL_GAP])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(t)
+
+
+def _notes(elements, notes, terms):
+    elements.append(Spacer(1, LARGE))
+    elements.append(
+        HRFlowable(width="100%", thickness=0.5, color=BORDER, spaceAfter=SMALL)
+    )
+    if notes:
+        elements.append(
+            Paragraph(
+                "<b>Notes</b>",
+                ParagraphStyle(
+                    "NL",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=SECONDARY,
+                    leading=10,
+                ),
+            )
+        )
+        elements.append(Paragraph(notes, S["caption"]))
+        elements.append(Spacer(1, SMALL))
+    if terms:
+        elements.append(
+            Paragraph(
+                "<b>Terms & Conditions</b>",
+                ParagraphStyle(
+                    "TL",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=SECONDARY,
+                    leading=10,
+                ),
+            )
+        )
+        elements.append(Paragraph(terms, S["caption"]))
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(
+        Paragraph(
+            "Thank you for your business.",
+            ParagraphStyle(
+                "Thx",
+                fontSize=9,
+                fontName="Helvetica-Oblique",
+                textColor=MUTED,
+                leading=13,
+                alignment=TA_CENTER,
+            ),
+        )
+    )
+
+
+def generate_invoice(data: dict, output_path: str = "/home/user/invoice.pdf") -> str:
+    doc = SimpleDocTemplate(
+        output_path,
+        pagesize=A4,
+        leftMargin=MARGIN,
+        rightMargin=MARGIN,
+        topMargin=MARGIN,
+        bottomMargin=2 * cm,
+    )
+    elements = []
+
+    _header(
+        elements, data["company"], data["invoice_number"], data.get("status", "unpaid")
+    )
+    _addresses(elements, data["company"], data["client"], data["meta"])
+    _line_items(elements, data["items"])
+
+    subtotal = sum(i["quantity"] * i["unit_price"] for i in data["items"])
+    _totals(elements, subtotal, data.get("tax_rate", 0), data.get("discount", 0))
+    _payment(elements, data["payment"])
+    _notes(elements, data.get("notes", ""), data.get("terms", ""))
+
+    doc.build(elements, onFirstPage=_footer, onLaterPages=_footer)
+    print(f"Generated: {output_path}")
+    return output_path
+
+
+# ── Sample data — edit this to generate your invoice ─────────
+DATA = {
+    "invoice_number": "INV-2025-0042",
+    "status": "unpaid",
+    "company": {
+        "name": "Apex Consulting Group",
+        "tagline": "Strategy & Technology Advisory",
+        "address": "123 Innovation Drive, Suite 400<br/>San Francisco, CA 94105",
+        "email": "billing@apexconsulting.com",
+        "phone": "+1 (415) 555-0123",
+    },
+    "client": {
+        "name": "GlobalTech Solutions Ltd.",
+        "address": "456 Enterprise Boulevard<br/>London, EC2A 1NT, UK",
+        "email": "accounts@globaltech.co.uk",
+    },
+    "meta": [
+        ("Invoice Date", "December 1, 2025"),
+        ("Due Date", "December 31, 2025"),
+        ("Payment Terms", "Net 30"),
+        ("PO Number", "PO-GT-2025-189"),
+    ],
+    "items": [
+        {
+            "description": "Strategy Consulting",
+            "details": "Discovery phase — 40hrs @ senior rate",
+            "quantity": 40,
+            "unit_price": 250.00,
+        },
+        {
+            "description": "Technical Architecture Review",
+            "details": "Cloud migration assessment",
+            "quantity": 1,
+            "unit_price": 8500.00,
+        },
+        {
+            "description": "Workshop Facilitation",
+            "details": "2-day executive alignment workshop",
+            "quantity": 2,
+            "unit_price": 3500.00,
+        },
+        {
+            "description": "Project Management",
+            "details": "December 2025 — monthly retainer",
+            "quantity": 1,
+            "unit_price": 4000.00,
+        },
+    ],
+    "tax_rate": 0.20,
+    "discount": 0.05,
+    "payment": {
+        "Bank": "First National Bank",
+        "Account Name": "Apex Consulting Group LLC",
+        "Account Number": "12345678",
+        "Routing": "021000021",
+        "SWIFT": "FNBKUS33",
+        "Reference": "INV-2025-0042",
+    },
+    "notes": "Services rendered for December 2025. All amounts in USD.",
+    "terms": "Payment due within 30 days. Late payments incur 1.5% monthly interest.",
+}
+
+if __name__ == "__main__":
+    generate_invoice(DATA)

--- a/skills/documents/scripts/generate_proposal.py
+++ b/skills/documents/scripts/generate_proposal.py
@@ -1,0 +1,852 @@
+"""Generate a formal project proposal PDF with methodology, team, timeline, and budget.
+
+Uses the Corporate Navy palette. Produces a multi-page RFP response or project
+bid with cover page, executive summary, numbered methodology phases, team bios,
+Gantt timeline, risk matrix, case studies, and budget sign-off.
+Outputs to /home/user/proposal.pdf.
+
+Usage:
+    python generate_proposal.py
+
+Customization:
+    Edit the DATA dict at the bottom. Supports arbitrary phases, team members,
+    risks, case studies, and budget line items.
+"""
+
+from reportlab.graphics.shapes import Drawing, Rect, String
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    HRFlowable,
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+# ── Page setup ────────────────────────────────────────────────
+WIDTH, HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_W = WIDTH - 2 * MARGIN
+LEFT_W = CONTENT_W * 0.55
+RIGHT_W = CONTENT_W * 0.40
+COL_GAP = CONTENT_W * 0.05
+
+# ── Corporate Navy palette ───────────────────────────────────
+PRIMARY = colors.HexColor("#0c2340")
+SECONDARY = colors.HexColor("#1a5276")
+ACCENT = colors.HexColor("#2980b9")
+SUCCESS = colors.HexColor("#27ae60")
+WARNING = colors.HexColor("#f39c12")
+DANGER = colors.HexColor("#c0392b")
+BODY_TEXT = colors.HexColor("#2c3e50")
+MUTED = colors.HexColor("#7f8c8d")
+BORDER = colors.HexColor("#bdc3c7")
+ROW_ALT = colors.HexColor("#f0f4f8")
+LIGHT_ACCENT = colors.HexColor("#ebf5fb")
+
+TINY, SMALL, MEDIUM, LARGE, SECTION = 4, 8, 16, 24, 32
+
+S = {
+    "heading": ParagraphStyle(
+        "H",
+        fontSize=16,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=22,
+        spaceAfter=8,
+    ),
+    "subheading": ParagraphStyle(
+        "SH",
+        fontSize=12,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=16,
+        spaceAfter=4,
+    ),
+    "body": ParagraphStyle(
+        "B",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_JUSTIFY,
+    ),
+    "body_bold": ParagraphStyle(
+        "BB", fontSize=9, fontName="Helvetica-Bold", textColor=BODY_TEXT, leading=13
+    ),
+    "body_right": ParagraphStyle(
+        "BR",
+        fontSize=9,
+        fontName="Helvetica",
+        textColor=BODY_TEXT,
+        leading=13,
+        alignment=TA_RIGHT,
+    ),
+    "caption": ParagraphStyle(
+        "C", fontSize=7, fontName="Helvetica", textColor=MUTED, leading=10
+    ),
+}
+
+
+def _footer(canvas, doc):
+    canvas.saveState()
+    canvas.setFont("Helvetica", 7)
+    canvas.setFillColor(MUTED)
+    canvas.drawString(MARGIN, 1.2 * cm, "CONFIDENTIAL")
+    canvas.drawRightString(WIDTH - MARGIN, 1.2 * cm, f"Page {doc.page}")
+    canvas.restoreState()
+
+
+def _bar(elements, w=None, h=3, clr=None):
+    w = w or CONTENT_W
+    clr = clr or PRIMARY
+    d = Drawing(w, h)
+    d.add(Rect(0, 0, w, h, fillColor=clr, strokeColor=None))
+    elements.append(d)
+
+
+def _cover(elements, d):
+    elements.append(Spacer(1, 60))
+    elements.append(
+        Paragraph(
+            d["org"].upper(),
+            ParagraphStyle(
+                "O",
+                fontSize=10,
+                fontName="Helvetica-Bold",
+                textColor=ACCENT,
+                leading=14,
+            ),
+        )
+    )
+    elements.append(Spacer(1, MEDIUM))
+    _bar(elements, h=8)
+    elements.append(Spacer(1, LARGE))
+    elements.append(
+        Paragraph(
+            d["title"],
+            ParagraphStyle(
+                "T",
+                fontSize=28,
+                fontName="Helvetica-Bold",
+                textColor=PRIMARY,
+                leading=34,
+                spaceAfter=8,
+            ),
+        )
+    )
+    if d.get("subtitle"):
+        elements.append(
+            Paragraph(
+                d["subtitle"],
+                ParagraphStyle(
+                    "ST",
+                    fontSize=14,
+                    fontName="Helvetica",
+                    textColor=SECONDARY,
+                    leading=18,
+                    spaceAfter=16,
+                ),
+            )
+        )
+    _bar(elements, w=CONTENT_W * 0.4, clr=ACCENT)
+    elements.append(Spacer(1, LARGE))
+    m = ParagraphStyle(
+        "M", fontSize=9, fontName="Helvetica", textColor=MUTED, leading=13
+    )
+    b = ParagraphStyle(
+        "MB", fontSize=12, fontName="Helvetica-Bold", textColor=PRIMARY, leading=16
+    )
+    elements.append(Paragraph("Prepared for", m))
+    elements.append(Paragraph(d["client"], b))
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(Paragraph("Submitted by", m))
+    elements.append(Paragraph(d["org"], b))
+    elements.append(Spacer(1, SMALL))
+    elements.append(Paragraph(f"Date: {d['date']}  |  Ref: {d['ref']}", m))
+    elements.append(Spacer(1, LARGE))
+    elements.append(HRFlowable(width="100%", thickness=0.5, color=BORDER))
+    elements.append(Spacer(1, SMALL))
+    elements.append(
+        Paragraph(
+            "CONFIDENTIAL — Proprietary information for named recipient only.",
+            ParagraphStyle(
+                "CF",
+                fontSize=7,
+                fontName="Helvetica-Oblique",
+                textColor=DANGER,
+                leading=10,
+            ),
+        )
+    )
+    elements.append(PageBreak())
+
+
+def _exec_summary(elements, paras, snapshot):
+    elements.append(Paragraph("1. Executive Summary", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    left = []
+    for p in paras:
+        left += [Paragraph(p, S["body"]), Spacer(1, SMALL)]
+    snap_rows = [
+        [
+            Paragraph(
+                "<b>PROJECT SNAPSHOT</b>",
+                ParagraphStyle(
+                    "SH2",
+                    fontSize=7,
+                    fontName="Helvetica-Bold",
+                    textColor=colors.white,
+                    leading=10,
+                ),
+            ),
+            Paragraph("", S["body"]),
+        ]
+    ]
+    for label, val in snapshot:
+        snap_rows.append(
+            [
+                Paragraph(
+                    label,
+                    ParagraphStyle(
+                        "SL",
+                        fontSize=7,
+                        fontName="Helvetica-Bold",
+                        textColor=MUTED,
+                        leading=10,
+                    ),
+                ),
+                Paragraph(
+                    f"<b>{val}</b>",
+                    ParagraphStyle(
+                        "SV",
+                        fontSize=10,
+                        fontName="Helvetica-Bold",
+                        textColor=PRIMARY,
+                        leading=14,
+                    ),
+                ),
+            ]
+        )
+    st = Table(snap_rows, colWidths=[RIGHT_W * 0.45, RIGHT_W * 0.55])
+    st.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+                ("BACKGROUND", (0, 1), (-1, -1), LIGHT_ACCENT),
+                ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+                ("LINEBELOW", (0, 0), (-1, -1), 0.5, BORDER),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    t = Table([[left, [st]]], colWidths=[LEFT_W, RIGHT_W + COL_GAP])
+    t.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(t)
+    elements.append(Spacer(1, SECTION))
+
+
+def _methodology(elements, phases):
+    elements.append(Paragraph("2. Methodology", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    for i, ph in enumerate(phases, 1):
+        badge = Paragraph(
+            f"<b>{i}</b>",
+            ParagraphStyle(
+                "BG",
+                fontSize=12,
+                fontName="Helvetica-Bold",
+                textColor=colors.white,
+                leading=16,
+                alignment=TA_CENTER,
+            ),
+        )
+        bc = Table([[badge]], colWidths=[28], rowHeights=[28])
+        bc.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (0, 0), ACCENT),
+                    ("VALIGN", (0, 0), (0, 0), "MIDDLE"),
+                    ("ALIGN", (0, 0), (0, 0), "CENTER"),
+                ]
+            )
+        )
+        nm = Paragraph(
+            f"<b>{ph['name']}</b>",
+            ParagraphStyle(
+                "PN",
+                fontSize=12,
+                fontName="Helvetica-Bold",
+                textColor=PRIMARY,
+                leading=16,
+            ),
+        )
+        dr = Paragraph(
+            ph["duration"],
+            ParagraphStyle(
+                "PD",
+                fontSize=9,
+                fontName="Helvetica",
+                textColor=ACCENT,
+                leading=13,
+                alignment=TA_RIGHT,
+            ),
+        )
+        hr = Table([[bc, nm, dr]], colWidths=[36, CONTENT_W - 120, 84])
+        hr.setStyle(
+            TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                ]
+            )
+        )
+        elements.append(hr)
+        elements.append(Spacer(1, TINY))
+        elements.append(Paragraph(ph["description"], S["body"]))
+        elements.append(Spacer(1, TINY))
+        for act in ph.get("activities", []):
+            elements.append(
+                Paragraph(
+                    f"\u2022 {act}",
+                    ParagraphStyle(
+                        "AC",
+                        fontSize=8,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=12,
+                        leftIndent=16,
+                        spaceAfter=2,
+                    ),
+                )
+            )
+        elements.append(Spacer(1, MEDIUM))
+
+
+def _team(elements, members):
+    elements.append(PageBreak())
+    elements.append(Paragraph("3. Team", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    cw = LEFT_W - 8
+
+    def card(m):
+        rows = [
+            [
+                Paragraph(
+                    f"<b>{m['role']}</b>",
+                    ParagraphStyle(
+                        "R",
+                        fontSize=7,
+                        fontName="Helvetica-Bold",
+                        textColor=ACCENT,
+                        leading=10,
+                    ),
+                )
+            ],
+            [
+                Paragraph(
+                    f"<b>{m['name']}</b>",
+                    ParagraphStyle(
+                        "N",
+                        fontSize=10,
+                        fontName="Helvetica-Bold",
+                        textColor=PRIMARY,
+                        leading=14,
+                    ),
+                )
+            ],
+            [Spacer(1, 2)],
+            [
+                Paragraph(
+                    m["bio"],
+                    ParagraphStyle(
+                        "BI",
+                        fontSize=8,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=11,
+                    ),
+                )
+            ],
+            [Spacer(1, 2)],
+            [
+                Paragraph(
+                    f"{m['years_exp']}+ years experience",
+                    ParagraphStyle(
+                        "EX",
+                        fontSize=7,
+                        fontName="Helvetica-Oblique",
+                        textColor=MUTED,
+                        leading=10,
+                    ),
+                )
+            ],
+        ]
+        c = Table(rows, colWidths=[cw])
+        c.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, -1), LIGHT_ACCENT),
+                    ("BOX", (0, 0), (-1, -1), 0.5, BORDER),
+                    ("TOPPADDING", (0, 0), (-1, -1), 6),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                ]
+            )
+        )
+        return c
+
+    pairs = [members[i : i + 2] for i in range(0, len(members), 2)]
+    for pair in pairs:
+        row = [card(pair[0])]
+        row.append(card(pair[1]) if len(pair) == 2 else Paragraph("", S["body"]))
+        g = Table([row], colWidths=[LEFT_W, RIGHT_W + COL_GAP])
+        g.setStyle(
+            TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ]
+            )
+        )
+        elements.append(g)
+        elements.append(Spacer(1, SMALL))
+
+
+def _timeline(elements, phases):
+    elements.append(Spacer(1, MEDIUM))
+    elements.append(Paragraph("4. Timeline", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    max_w = max(p["end_week"] for p in phases)
+    cw = CONTENT_W * 0.60
+    lw = CONTENT_W * 0.35
+    rh = 24
+    gap = 6
+    th = len(phases) * (rh + gap) + 36
+    d = Drawing(CONTENT_W, th)
+    xo = lw + 12
+    y = th - 20
+    for w in range(0, max_w + 1, 2):
+        x = xo + (w / max_w) * cw
+        d.add(
+            String(x, y + 2, f"W{w}", fontSize=6, fontName="Helvetica", fillColor=MUTED)
+        )
+    y -= 14
+    clrs = [ACCENT, SECONDARY, PRIMARY, SUCCESS, WARNING]
+    for i, p in enumerate(phases):
+        c = clrs[i % len(clrs)]
+        d.add(
+            String(
+                0,
+                y + 6,
+                p["name"][:30],
+                fontSize=8,
+                fontName="Helvetica-Bold",
+                fillColor=BODY_TEXT,
+            )
+        )
+        bx = xo + (p["start_week"] / max_w) * cw
+        bw = ((p["end_week"] - p["start_week"]) / max_w) * cw
+        d.add(Rect(bx, y, bw, rh - 4, fillColor=c, strokeColor=None, rx=3, ry=3))
+        d.add(
+            String(
+                bx + 6,
+                y + 6,
+                f"Wk {p['start_week']}-{p['end_week']}",
+                fontSize=6,
+                fontName="Helvetica-Bold",
+                fillColor=colors.white,
+            )
+        )
+        y -= rh + gap
+    elements.append(d)
+    elements.append(Spacer(1, SECTION))
+
+
+def _risks(elements, risks):
+    elements.append(Paragraph("5. Risk Assessment", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    risk_clrs = {"High": DANGER, "Med": WARNING, "Low": SUCCESS}
+
+    def badge(lvl):
+        return Paragraph(
+            f"<b>{lvl}</b>",
+            ParagraphStyle(
+                "RB",
+                fontSize=8,
+                fontName="Helvetica-Bold",
+                textColor=risk_clrs.get(lvl, MUTED),
+                leading=11,
+                alignment=TA_CENTER,
+            ),
+        )
+
+    cw = [CONTENT_W * 0.26, CONTENT_W * 0.12, CONTENT_W * 0.12, CONTENT_W * 0.50]
+    th2 = ParagraphStyle(
+        "TH", fontSize=8, fontName="Helvetica-Bold", textColor=colors.white, leading=11
+    )
+    rows = [
+        [
+            Paragraph("<b>Risk</b>", th2),
+            Paragraph(
+                "<b>Likelihood</b>",
+                ParagraphStyle("TH2", parent=th2, alignment=TA_CENTER),
+            ),
+            Paragraph(
+                "<b>Impact</b>", ParagraphStyle("TH3", parent=th2, alignment=TA_CENTER)
+            ),
+            Paragraph("<b>Mitigation</b>", th2),
+        ]
+    ]
+    for r in risks:
+        rows.append(
+            [
+                Paragraph(r["risk"], S["body"]),
+                badge(r["likelihood"]),
+                badge(r["impact"]),
+                Paragraph(
+                    r["mitigation"],
+                    ParagraphStyle(
+                        "Mt",
+                        fontSize=8,
+                        fontName="Helvetica",
+                        textColor=BODY_TEXT,
+                        leading=11,
+                    ),
+                ),
+            ]
+        )
+    t = Table(rows, colWidths=cw)
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("ALIGN", (1, 0), (2, -1), "CENTER"),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("GRID", (0, 0), (-1, -1), 0.5, BORDER),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ROW_ALT]),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    elements.append(t)
+    elements.append(Spacer(1, SECTION))
+
+
+def _budget(elements, items, tax_rate, org, client):
+    elements.append(Paragraph("6. Budget", S["heading"]))
+    _bar(elements)
+    elements.append(Spacer(1, MEDIUM))
+    cw = [CONTENT_W * 0.65, CONTENT_W * 0.35]
+    th2 = ParagraphStyle(
+        "BH", fontSize=8, fontName="Helvetica-Bold", textColor=colors.white, leading=11
+    )
+    rows = [
+        [
+            Paragraph("<b>Category</b>", th2),
+            Paragraph(
+                "<b>Amount</b>", ParagraphStyle("BH2", parent=th2, alignment=TA_RIGHT)
+            ),
+        ]
+    ]
+    sub = 0
+    for it in items:
+        sub += it["amount"]
+        rows.append(
+            [
+                Paragraph(it["category"], S["body"]),
+                Paragraph(f"${it['amount']:,.2f}", S["body_right"]),
+            ]
+        )
+    br = ParagraphStyle(
+        "BoldR",
+        fontSize=9,
+        fontName="Helvetica-Bold",
+        textColor=PRIMARY,
+        leading=13,
+        alignment=TA_RIGHT,
+    )
+    rows.append(
+        [Paragraph("<b>Subtotal</b>", S["body_bold"]), Paragraph(f"${sub:,.2f}", br)]
+    )
+    tax = sub * tax_rate
+    total = sub + tax
+    if tax_rate:
+        rows.append(
+            [
+                Paragraph(f"<b>Tax ({tax_rate * 100:.0f}%)</b>", S["body_bold"]),
+                Paragraph(f"${tax:,.2f}", br),
+            ]
+        )
+    rows.append(
+        [
+            Paragraph(
+                "<b>TOTAL</b>",
+                ParagraphStyle(
+                    "TL",
+                    fontSize=11,
+                    fontName="Helvetica-Bold",
+                    textColor=PRIMARY,
+                    leading=15,
+                ),
+            ),
+            Paragraph(
+                f"<b>${total:,.2f}</b>",
+                ParagraphStyle(
+                    "TV",
+                    fontSize=11,
+                    fontName="Helvetica-Bold",
+                    textColor=ACCENT,
+                    leading=15,
+                    alignment=TA_RIGHT,
+                ),
+            ),
+        ]
+    )
+    ti = len(rows) - 1
+    t = Table(rows, colWidths=cw)
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), PRIMARY),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("GRID", (0, 0), (-1, ti - 2), 0.5, BORDER),
+                ("ROWBACKGROUNDS", (0, 1), (-1, ti - 2), [colors.white, ROW_ALT]),
+                ("LINEABOVE", (0, ti), (-1, ti), 2, PRIMARY),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    elements.append(t)
+
+    elements.append(Spacer(1, LARGE))
+    elements.append(Paragraph("Acceptance", S["subheading"]))
+    elements.append(
+        HRFlowable(width="100%", thickness=1, color=PRIMARY, spaceAfter=MEDIUM)
+    )
+    ss = ParagraphStyle(
+        "Sg", fontSize=9, fontName="Helvetica", textColor=BODY_TEXT, leading=13
+    )
+    ls = [
+        Paragraph(f"For <b>{org}</b>", ss),
+        Spacer(1, 32),
+        HRFlowable(width="90%", thickness=0.5, color=PRIMARY),
+        Paragraph("Authorized Signature / Date", S["caption"]),
+    ]
+    rs = [
+        Paragraph(f"For <b>{client}</b>", ss),
+        Spacer(1, 32),
+        HRFlowable(width="90%", thickness=0.5, color=PRIMARY),
+        Paragraph("Authorized Signature / Date", S["caption"]),
+    ]
+    st = Table([[ls, rs]], colWidths=[LEFT_W, RIGHT_W + COL_GAP])
+    st.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    elements.append(st)
+
+
+def generate_proposal(data: dict, output_path: str = "/home/user/proposal.pdf") -> str:
+    doc = SimpleDocTemplate(
+        output_path,
+        pagesize=A4,
+        leftMargin=MARGIN,
+        rightMargin=MARGIN,
+        topMargin=MARGIN,
+        bottomMargin=2 * cm,
+    )
+    elements = []
+    _cover(elements, data)
+    _exec_summary(elements, data["summary"], data["snapshot"])
+    _methodology(elements, data["phases"])
+    _team(elements, data["team"])
+    _timeline(elements, data["phases"])
+    _risks(elements, data["risks"])
+    elements.append(PageBreak())
+    _budget(
+        elements, data["budget"], data.get("tax_rate", 0), data["org"], data["client"]
+    )
+    doc.build(elements, onFirstPage=_footer, onLaterPages=_footer)
+    print(f"Generated: {output_path}")
+    return output_path
+
+
+# ── Sample data — edit this to generate your proposal ────────
+DATA = {
+    "title": "Cloud Infrastructure\nModernization Program",
+    "subtitle": "Technical Proposal & Implementation Plan",
+    "org": "Meridian Technology Partners",
+    "client": "Atlas Financial Group",
+    "date": "January 15, 2026",
+    "ref": "PROP-2026-0012",
+    "summary": [
+        "Meridian Technology Partners proposes a comprehensive cloud modernization program to migrate Atlas Financial Group's legacy infrastructure to a scalable, secure, cloud-native architecture.",
+        "This proposal outlines our phased methodology, dedicated team, detailed timeline, risk mitigations, and the investment required to deliver measurable results within 16 weeks.",
+    ],
+    "snapshot": [
+        ("Duration", "16 weeks"),
+        ("Team", "8 specialists"),
+        ("Methodology", "Agile Sprints"),
+        ("SLA", "99.9% uptime"),
+    ],
+    "phases": [
+        {
+            "name": "Assessment & Planning",
+            "description": "Audit current infrastructure, identify migration candidates, define target architecture.",
+            "activities": [
+                "Infrastructure audit",
+                "Dependency mapping",
+                "Architecture design",
+                "Migration roadmap",
+            ],
+            "duration": "3 weeks",
+            "start_week": 1,
+            "end_week": 3,
+        },
+        {
+            "name": "Foundation & Security",
+            "description": "Establish cloud foundations — networking, IAM, security baselines, CI/CD.",
+            "activities": [
+                "VPC & networking",
+                "IAM & SSO",
+                "Security baseline",
+                "CI/CD pipeline",
+            ],
+            "duration": "3 weeks",
+            "start_week": 3,
+            "end_week": 6,
+        },
+        {
+            "name": "Migration & Build",
+            "description": "Migrate workloads in prioritized waves, refactor critical services.",
+            "activities": [
+                "Wave 1: Non-critical",
+                "Wave 2: Core services",
+                "Wave 3: Data tier",
+                "Performance testing",
+            ],
+            "duration": "7 weeks",
+            "start_week": 6,
+            "end_week": 13,
+        },
+        {
+            "name": "Optimization & Handover",
+            "description": "Performance tuning, cost optimization, documentation, training.",
+            "activities": [
+                "Performance tuning",
+                "Cost review",
+                "Documentation",
+                "Training",
+                "Sign-off",
+            ],
+            "duration": "3 weeks",
+            "start_week": 13,
+            "end_week": 16,
+        },
+    ],
+    "team": [
+        {
+            "name": "Sarah Chen",
+            "role": "Program Director",
+            "bio": "15 years leading enterprise cloud migrations. AWS & Azure certified.",
+            "years_exp": 15,
+        },
+        {
+            "name": "Marcus Williams",
+            "role": "Lead Architect",
+            "bio": "Distributed systems specialist. 30+ cloud-native transformations.",
+            "years_exp": 12,
+        },
+        {
+            "name": "Priya Patel",
+            "role": "Security Lead",
+            "bio": "CISSP certified. Cloud security and zero-trust expert.",
+            "years_exp": 10,
+        },
+        {
+            "name": "James O'Brien",
+            "role": "DevOps Lead",
+            "bio": "Kubernetes & Terraform specialist. CI/CD for 50+ teams.",
+            "years_exp": 8,
+        },
+    ],
+    "risks": [
+        {
+            "risk": "Legacy dependencies block migration",
+            "likelihood": "Med",
+            "impact": "High",
+            "mitigation": "Early dependency mapping; parallel tracks.",
+        },
+        {
+            "risk": "Data migration exceeds SLA downtime",
+            "likelihood": "Low",
+            "impact": "High",
+            "mitigation": "Blue-green migration with rollback.",
+        },
+        {
+            "risk": "Team cloud-native knowledge gaps",
+            "likelihood": "Med",
+            "impact": "Med",
+            "mitigation": "Embedded training; runbooks.",
+        },
+        {
+            "risk": "Scope expansion cost overrun",
+            "likelihood": "Low",
+            "impact": "Med",
+            "mitigation": "Fixed-scope phases; change requests.",
+        },
+    ],
+    "budget": [
+        {"category": "Assessment & Planning", "amount": 45000},
+        {"category": "Foundation & Security", "amount": 52000},
+        {"category": "Migration & Build (7 weeks)", "amount": 168000},
+        {"category": "Optimization & Handover", "amount": 38000},
+        {"category": "Project Management", "amount": 24000},
+        {"category": "Training & Documentation", "amount": 15000},
+    ],
+    "tax_rate": 0.0,
+}
+
+if __name__ == "__main__":
+    generate_proposal(DATA)

--- a/skills/documents/scripts/pdf_to_images.py
+++ b/skills/documents/scripts/pdf_to_images.py
@@ -1,0 +1,75 @@
+"""Convert a PDF to PNG images (one per page) for preview/visibility.
+
+Renders each page as a PNG. Use after generating a PDF to get full visibility
+of the output before sharing. Requires pdf2image (and poppler in the sandbox).
+
+Usage:
+    python pdf_to_images.py
+
+Customization:
+    Edit the DATA dict at the bottom. Set pdf_path to the PDF file path
+    (e.g. /home/user/editorial.pdf) and output_dir for where to save images.
+
+Sandbox:
+    If you see "Unable to get page count" or poppler errors, install:
+    apt-get update && apt-get install -y poppler-utils
+"""
+
+import os
+import sys
+
+DATA = {
+    "pdf_path": "/home/user/editorial.pdf",
+    "output_dir": "/home/user/pdf_preview",
+    "dpi": 150,
+}
+
+
+def convert(pdf_path: str, output_dir: str, dpi: int = 150) -> list[str]:
+    """Convert PDF pages to PNG images. Returns list of output paths."""
+    try:
+        from pdf2image import convert_from_path
+    except ImportError:
+        print("pip install pdf2image", file=sys.stderr)
+        raise
+
+    if not os.path.isfile(pdf_path):
+        print(f"PDF not found: {pdf_path}", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+    base = os.path.splitext(os.path.basename(pdf_path))[0]
+
+    try:
+        images = convert_from_path(pdf_path, dpi=dpi)
+    except Exception as e:
+        if "poppler" in str(e).lower() or "Unable to get" in str(e):
+            print(
+                "poppler-utils required. In sandbox run: apt-get update && apt-get install -y poppler-utils",
+                file=sys.stderr,
+            )
+        raise
+
+    paths = []
+    for i, img in enumerate(images):
+        path = os.path.join(output_dir, f"{base}_page_{i + 1:03d}.png")
+        img.save(path, "PNG")
+        paths.append(path)
+
+    print(f"Saved {len(paths)} images to {output_dir}")
+    return paths
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Convert PDF pages to PNG images")
+    p.add_argument("pdf_path", nargs="?", default=DATA["pdf_path"], help="Path to PDF")
+    p.add_argument(
+        "-o", "--output", default=DATA["output_dir"], help="Output directory"
+    )
+    p.add_argument(
+        "--dpi", type=int, default=DATA.get("dpi", 150), help="DPI for rendering"
+    )
+    args = p.parse_args()
+    convert(args.pdf_path, args.output, args.dpi)

--- a/skills/email-lifecycle/SKILL.md
+++ b/skills/email-lifecycle/SKILL.md
@@ -1,6 +1,29 @@
 ---
 name: email-lifecycle
 description: Plan, build, and run lifecycle email programs through the Hyper MCP — welcome / onboarding, nurture, re-engagement, win-back, and abandoned-cart sequences across whichever provider fits (Klaviyo for ecommerce, Resend for SaaS / dev tools, Beehiiv for newsletters, Gmail for low-volume ops). Use when the user wants to build an email sequence, set up a welcome flow, recover lapsed users, send a broadcast, manage a list / audience / segment, or asks about lifecycle / drip / nurture campaigns.
+use_cases:
+  - Build a welcome or onboarding email sequence
+  - Plan nurture, re-engagement, and win-back flows
+  - Recover abandoned carts with email automation
+  - Send broadcasts and manage lists, audiences, and segments
+  - Choose between Klaviyo, Resend, Beehiiv, or Gmail for a program
+triggers:
+  - lifecycle email
+  - email sequence
+  - welcome flow
+  - drip campaign
+  - nurture campaign
+  - win-back
+  - abandoned cart
+  - newsletter
+requires_toolkits:
+  - klaviyo
+  - resend
+  - beehiiv
+  - gmail
+suggested_toolkits:
+  - sandbox
+  - file_manager
 ---
 
 # Email Lifecycle

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: gmail
+description: Manage Gmail end-to-end — send, reply, search, drafts, labels, attachments, and inbox organization. Use when the user wants to send or reply to email, clean up an inbox, build label systems, manage drafts, or pull attachments.
+use_cases:
+  - Organize my inbox with labels
+  - Send emails via Gmail
+  - Create and manage email drafts
+  - Move emails between folders
+  - Archive or trash emails
+  - Search and filter Gmail messages
+  - Email triage and cleanup
+triggers:
+  - gmail
+  - email
+  - inbox
+  - send email
+  - labels
+  - drafts
+requires_toolkits:
+  - gmail
+suggested_toolkits: []
+---
+
+# Gmail Email Management
+
+This skill provides comprehensive guidance for managing Gmail emails, labels, and organization.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Gmail integration** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Label Operations - Critical Distinctions
+
+### ADD LABEL (keeps email in current location + adds new label)
+- Use: `gmail_add_labels`
+- Use case: Adding labels WITHOUT moving the email from its current location
+- Example: Email stays in INBOX and also gets labeled "Important"
+
+### MOVE TO LABEL (removes from INBOX + adds to target label)
+- Use: `gmail_move_email_to_label`
+- Use case: Moving email OUT of inbox and INTO a specific label/folder
+- Example: Email is removed from INBOX and moved to "Archive" or "Work"
+- This performs TWO operations: removes INBOX label + adds target label
+
+### REMOVE LABEL (removes specific label)
+- Use: `gmail_remove_labels`
+- Use case: Removing labels from an email
+- Can remove any label including INBOX
+
+## Getting Label IDs
+
+**CRITICAL**: Most Gmail label operations require label IDs, NOT label names.
+- Always call `gmail_list_labels` first to get available labels and their IDs
+- Label IDs look like: "Label_123", "Label_456", or system labels: "INBOX", "SENT", "TRASH"
+- Never guess or make up label IDs
+
+## Common Workflows
+
+### Email Triage/Organization
+1. Call `gmail_list_labels` to see available labels
+2. Call `gmail_list_messages` to get emails
+3. Use `gmail_move_email_to_label` to move emails from INBOX to appropriate labels
+
+### Adding Categories (keep in inbox)
+1. Call `gmail_list_labels` to get label IDs
+2. Use `gmail_add_labels` to categorize emails while keeping them in INBOX
+
+### Creating New Labels
+- Use `gmail_create_label` if the desired label doesn't exist
+- Returns the new label's ID for immediate use
+
+## Searching and Listing Messages
+
+**gmail_list_messages** supports full Gmail search query syntax:
+- `query` parameter accepts the same syntax as Gmail's search box
+- Examples: `"is:unread"`, `"from:user@example.com"`, `"has:attachment subject:invoice"`
+- Combine operators: `"from:user@example.com is:unread has:attachment"`
+- By default, excludes drafts (adds `-in:draft` automatically)
+- Use `label` parameter to filter by specific label
+
+## Drafts Workflow
+
+### Creating and sending draft emails
+1. `gmail_create_draft` - Create initial draft
+2. `gmail_update_draft` - Edit existing draft (optional)
+3. `gmail_send_draft` - Send the draft as email
+
+### Managing drafts
+- `gmail_list_drafts` - List all draft emails
+- `gmail_get_draft` - Get a specific draft by ID
+- `gmail_delete_draft` - Delete a draft without sending
+
+### When to use drafts vs direct send
+- Use `gmail_send_message` for immediate one-step sending
+- Use draft workflow when you want to review/edit before sending or schedule for later
+
+## Email Actions - Important Distinctions
+
+### Archive vs Trash
+- `gmail_archive_message` - Removes from INBOX but keeps in "All Mail" (recoverable, not deleted)
+- `gmail_trash_message` - Moves to Trash folder (will be auto-deleted after 30 days)
+- Archive is the preferred way to "clean up" inbox while keeping emails
+
+### Attachments
+- `gmail_get_attachment` - Download attachments from received emails
+- When sending emails with attachments, use `file_ids` parameter (requires files to be in the database first)
+
+## Tool Selection Quick Reference
+
+| Action | Tool |
+|--------|------|
+| Add label X | `gmail_add_labels` |
+| Move to label X | `gmail_move_email_to_label` |
+| Remove from inbox | `gmail_move_email_to_label` (move to target) OR `gmail_remove_labels` (just remove INBOX) |
+| Archive email | `gmail_archive_message` (preferred for cleanup) |
+| Delete/trash email | `gmail_trash_message` |
+| Send email now | `gmail_send_message` |
+| Create email for later | `gmail_create_draft` + `gmail_send_draft` |

--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -1,6 +1,35 @@
 ---
 name: google-ads
-description: Plan and create new Google Ads campaigns end-to-end via the Hyper MCP. Use when the user wants to launch Search, Display, or Performance Max campaigns, or mentions Google Ads, AdWords, search ads, display ads, Performance Max, PMax, PPC, Google campaigns, Google blueprint, search term reports, negative keywords, or manager accounts (MCC). For ongoing optimization, search-term cleanup, conversion diagnosis, or restructuring existing accounts, defer to a future `google-ads-operator` sibling skill.
+description: Plan and create new Google Ads campaigns end-to-end via the Hyper MCP, and report on existing accounts with GAQL-backed evidence (conversions, funnels, search terms, budgets, dashboards). Use when the user wants to launch Search, Display, or Performance Max campaigns, build Google Ads reports, or mentions AdWords, PMax, PPC, negative keywords, or MCC accounts. For ongoing optimization, defer to a future google-ads-operator sibling skill.
+use_cases:
+  - Create Google Ads campaigns
+  - Set up search campaigns
+  - Set up display campaigns
+  - Set up Performance Max campaigns
+  - Configure Smart Bidding
+  - Research keywords for ads
+  - Create campaigns with blueprint system
+  - Launch net-new campaigns from research
+  - Preview Google Ads blueprints before creation
+triggers:
+  - google ads
+  - adwords
+  - search ads
+  - display ads
+  - performance max
+  - pmax
+  - ppc
+  - google campaign
+  - google blueprint
+  - search term report
+  - negative keywords
+  - manager account
+  - mcc
+requires_toolkits:
+  - google_ads
+suggested_toolkits:
+  - sandbox
+  - file_manager
 ---
 
 # Google Ads
@@ -13,6 +42,11 @@ Strategic guide for building new Google Ads campaigns. Research first, consult i
 - **Google Ads integration connected** at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
 
 If `google_ads_list_accounts` is not in the tool list, stop and tell the user to enable Hyper MCP and connect Google Ads.
+
+## Routing
+
+- **Reporting on existing accounts** (GAQL-backed reports, conversion breakdowns, funnels, search terms, budget views, optional dashboards) → read `references/reporting.md` first; per-report recipes live under `references/reporting/reports/`.
+- **Campaign creation** (Search, Display, PMax) → this guide, below.
 
 ## Out of scope
 

--- a/skills/google-ads/references/reporting.md
+++ b/skills/google-ads/references/reporting.md
@@ -1,0 +1,80 @@
+
+# Google Ads
+
+Report on existing Google Ads accounts using GAQL-backed data. Dashboards and
+data apps are optional presentation surfaces, not mandatory output. Every task starts with
+[references/reporting/workflows.md](references/reporting/workflows.md), then picks the report
+document with the closest data shape.
+
+For net-new campaign creation, use the main `google-ads` guide (SKILL.md) instead.
+
+## Core contract
+
+- Read [references/reporting/workflows.md](references/reporting/workflows.md) before any GAQL
+  or dashboard build.
+- Use `google_ads_execute_gaql` as the canonical Google Ads data tool.
+- Do not use the alternate GAQL alias in new examples or skills.
+- Do not use custom operator-tool heuristics as authoritative Google Ads
+  analysis.
+- Keep reporting separate from live account changes.
+- Written reports are valid outputs. Build a dashboard or data app only when
+  the user asks for one or when an interactive view materially improves the
+  answer.
+- Do not mention internal dashboard implementation details to the user unless
+  they explicitly ask how the interface is built.
+
+## Picking a report
+
+| The user wants...                              | Read                                                                       |
+|------------------------------------------------|----------------------------------------------------------------------------|
+| Full account health snapshot                   | [references/reporting/reports/account-overview.md](references/reporting/reports/account-overview.md) |
+| Why aren't conversions tracking right          | [references/reporting/reports/conversion-tracking.md](references/reporting/reports/conversion-tracking.md) |
+| Conversions broken down by action / per stage  | [references/reporting/reports/conversion-by-action.md](references/reporting/reports/conversion-by-action.md) |
+| Lead-gen / B2B multi-stage funnel              | [references/reporting/reports/conversion-funnel.md](references/reporting/reports/conversion-funnel.md) |
+| Where is spend going                           | [references/reporting/reports/budget-distribution.md](references/reporting/reports/budget-distribution.md) |
+| Wasteful search terms                          | [references/reporting/reports/search-terms-waste.md](references/reporting/reports/search-terms-waste.md) |
+| Should we restructure                          | [references/reporting/reports/campaign-structure.md](references/reporting/reports/campaign-structure.md) |
+| Campaign performance over time                 | [references/reporting/reports/campaign-performance.md](references/reporting/reports/campaign-performance.md) |
+| Ad-level performance                           | [references/reporting/reports/ad-performance.md](references/reporting/reports/ad-performance.md) |
+
+## Optional dashboard or data app
+
+When the user asks for a dashboard/data app, or an interactive view is clearly
+the best presentation, use the report's dashboard section as the agent-facing
+implementation recipe. Before building, load the Hyper Database dashboard/data
+app reference: `hyper-database/references/dashboard-building.md`.
+
+The implementation pattern is:
+
+1. `tool_data_sources` — the report's GAQL runs through
+   `google_ads_execute_gaql` and the rows are saved to a tenant cache
+   table (convention: `gads_<report>_<scope>`).
+2. `sql_data_sources` — re-aggregate the cache table into named
+   variables (KPIs, time series, top lists).
+3. Build the interface with cards, KPIs, charts, tables, and a clear visual
+   hierarchy.
+4. `refresh` — set `{"mode": "scheduled", "cron": "0 * * * *"}` to keep
+   the dashboard live; default is manual.
+
+Re-run the same call (or call `hyper_data_refresh_dashboard`) to refresh
+without re-invoking the agent.
+
+Before authoring, verify component names with
+`hyper_data_search_ui_components`. Read
+[references/reporting/report-template.md](references/reporting/report-template.md) for the
+reporting response structure.
+
+## When to use the campaign guide instead
+
+Use the main `google-ads` guide (SKILL.md) when the primary task is:
+
+- creating a brand new campaign
+- building a blueprint for launch
+- setting up a new Search, Display, or PMax campaign
+- turning research into campaign assets and configuration
+
+Use this skill when the primary task is:
+
+- building reports or dashboards from any of the above
+- explaining Google Ads metrics with GAQL evidence
+- creating a conversion-action or funnel dashboard

--- a/skills/google-ads/references/reporting/heuristics.md
+++ b/skills/google-ads/references/reporting/heuristics.md
@@ -1,0 +1,30 @@
+# Google Ads Reporting Notes
+
+## When to use
+
+Read this when explaining a Google Ads report. These notes describe how
+to keep claims tied to the queried data; they are not optimization rules.
+
+## Reporting rules
+
+- State the customer ID and date range used.
+- Name the GAQL resource queried, such as `campaign`, `ad_group`, or
+  `conversion_action`.
+- Treat rows as evidence, not as automatic recommendations.
+- Do not infer account changes from a report unless the user explicitly
+  asks for recommendations.
+- If a report depends on conversion actions, use
+  `segments.conversion_action` and `segments.conversion_action_name` for
+  campaign-level metrics.
+- If a report needs configured conversion-action metadata, query
+  `FROM conversion_action` separately.
+
+## Optional dashboard/data app rules
+
+- Use `google_ads_execute_gaql` inside `tool_data_sources`.
+- Query the saved cache table with `sql_data_sources`.
+- Bind only SQL output variables inside the dashboard/data app code.
+- Return the persisted dashboard artifact as the final output only when the
+  user asked for an interface or the task explicitly chose one.
+- Do not describe internal interface implementation details to the user unless
+  they ask.

--- a/skills/google-ads/references/reporting/report-template.md
+++ b/skills/google-ads/references/reporting/report-template.md
@@ -1,0 +1,31 @@
+# Google Ads Report Template
+
+## When to use
+
+Read this when writing the final response for a Google Ads report or
+dashboard. Keep the response evidence-backed and clear about whether a
+dashboard artifact was created.
+
+```text
+Google Ads Report for [Account Name]
+Date range: [Range]
+Data source: [GAQL resource and key segments]
+
+Output
+- Dashboard ID:
+- Dashboard name:
+- Refreshed by:
+
+What was queried
+- Tool:
+- GAQL:
+- Cache table:
+
+Key results
+- [metric/result 1]
+- [metric/result 2]
+- [metric/result 3]
+
+Notes
+- [freshness caveat, missing rows, or user-provided mapping]
+```

--- a/skills/google-ads/references/reporting/reports/account-overview.md
+++ b/skills/google-ads/references/reporting/reports/account-overview.md
@@ -1,0 +1,143 @@
+# Account Overview
+
+Full-account health snapshot. Combines spend, conversions, conversion
+rate, and cost per conversion in a single dashboard so the agent can
+orient before drilling into a specific issue.
+
+## When to use
+
+- "How is the account doing?"
+- First report to run for a new client engagement.
+- Periodic health check.
+- When routing to a more focused report (tracking / budget / search
+  terms / structure) requires an aggregate baseline.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+
+Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+reporting and refreshable dashboards.
+
+## GAQL
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  campaign.status,
+  metrics.cost_micros,
+  metrics.clicks,
+  metrics.impressions,
+  metrics.conversions,
+  metrics.conversions_value
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+## How to interpret
+
+- Treat any campaign with significant spend and zero conversions over a
+  meaningful window as a tracking-or-budget issue, not a "campaign
+  performance" issue.
+- ROAS and CPA are downstream signals — surface them only when
+  conversion tracking is verified (see
+  [conversion-tracking.md](conversion-tracking.md)).
+- Aggregate spend without segmenting by date hides pacing problems;
+  always include a daily series.
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Account Overview",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "campaign.status, metrics.cost_micros, metrics.clicks, "
+                    "metrics.impressions, metrics.conversions, "
+                    "metrics.conversions_value "
+                    "FROM campaign "
+                    "WHERE segments.date DURING LAST_30_DAYS "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_account_overview",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "total_spend": {
+            "shape": "scalar",
+            "sql": (
+                "SELECT COALESCE(SUM(metrics_cost_micros), 0)/1e6 "
+                "FROM gads_account_overview"
+            ),
+        },
+        "total_conversions": {
+            "shape": "scalar",
+            "sql": (
+                "SELECT COALESCE(SUM(metrics_conversions), 0) "
+                "FROM gads_account_overview"
+            ),
+        },
+        "daily": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_date AS date, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_account_overview GROUP BY 1 ORDER BY 1"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import AreaChart, ChartSeries
+
+with PrefabApp(title="Account Overview") as app:
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Account Overview")
+            Muted("Last 30 days")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Spend", value=f"${total_spend:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=f"{total_conversions:,.0f}")
+
+        with Card():
+            with CardContent():
+                Text("Daily spend and conversions", css_class="text-sm font-medium text-muted-foreground mb-2")
+                AreaChart(
+                    data=daily,
+                    x_axis="date",
+                    series=[
+                        ChartSeries(data_key="spend", label="Spend"),
+                        ChartSeries(data_key="conversions", label="Conversions"),
+                    ],
+                    show_legend=True,
+                    height=300,
+                )
+""",
+    refresh={"mode": "scheduled", "cron": "0 * * * *"},
+)
+```
+
+## Variants
+
+- Add `metrics.average_cpc`, `metrics.ctr`, `metrics.search_impression_share`
+  to the GAQL when the user wants efficiency context.
+- Group by `campaign.advertising_channel_type` to split Search / PMax /
+  Display in the same dashboard.

--- a/skills/google-ads/references/reporting/reports/ad-performance.md
+++ b/skills/google-ads/references/reporting/reports/ad-performance.md
@@ -1,0 +1,165 @@
+# Ad Performance
+
+Ad-level (RSA / asset) performance across campaigns. Drives creative
+optimization, ad rotation diagnosis, and asset-replacement decisions.
+
+## When to use
+
+- "Which ads are working / failing?"
+- Before rotating creatives or pausing underperforming RSAs.
+- After uploading new asset variants to compare against the baseline.
+- Diagnosing low-CTR ad groups that may be a creative problem rather
+  than a targeting one.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+- Optional: `campaign_ids` to scope.
+
+## GAQL
+
+```sql
+SELECT
+  ad_group_ad.ad.id,
+  ad_group_ad.ad.name,
+  ad_group_ad.ad.type,
+  ad_group_ad.status,
+  ad_group.name,
+  campaign.name,
+  metrics.impressions,
+  metrics.clicks,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.ctr,
+  metrics.average_cpc
+FROM ad_group_ad
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND ad_group_ad.status != 'REMOVED'
+  AND ad_group.status != 'REMOVED'
+  AND campaign.status != 'REMOVED'
+```
+
+## How to interpret
+
+- High-impression / low-CTR ads = creative or relevance problem;
+  candidates for headline / description rotation.
+- Low-impression ads (relative to peers in the same ad group) =
+  ad_strength / serving issue, not necessarily a performance issue.
+- An RSA dominating impressions inside an ad group should be the
+  benchmark when proposing variants.
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Ad Performance",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT ad_group_ad.ad.id, ad_group_ad.ad.name, "
+                    "ad_group_ad.ad.type, ad_group_ad.status, "
+                    "ad_group.name, campaign.name, "
+                    "metrics.impressions, metrics.clicks, metrics.cost_micros, "
+                    "metrics.conversions, metrics.ctr, metrics.average_cpc "
+                    "FROM ad_group_ad "
+                    "WHERE segments.date DURING LAST_30_DAYS "
+                    "AND ad_group_ad.status != 'REMOVED' "
+                    "AND ad_group.status != 'REMOVED' "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_ad_performance",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "top_ads": {
+            "shape": "rows",
+            "sql": (
+                "SELECT ad_group_ad_ad_name AS ad_name, "
+                "campaign_name AS campaign, "
+                "ad_group_name AS ad_group, "
+                "SUM(metrics_impressions) AS impressions, "
+                "SUM(metrics_clicks) AS clicks, "
+                "SUM(metrics_conversions) AS conversions, "
+                "SUM(metrics_cost_micros)/1e6 AS spend "
+                "FROM gads_ad_performance "
+                "GROUP BY 1, 2, 3 ORDER BY clicks DESC LIMIT 25"
+            ),
+        },
+        "by_type": {
+            "shape": "rows",
+            "sql": (
+                "SELECT ad_group_ad_ad_type AS ad_type, "
+                "SUM(metrics_clicks) AS clicks, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_ad_performance GROUP BY 1 ORDER BY clicks DESC"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import BarChart, ChartSeries
+
+with PrefabApp(title="Ad Performance") as app:
+    total_clicks = sum(row.get("clicks", 0) for row in top_ads)
+    total_conversions = sum(row.get("conversions", 0) for row in top_ads)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Ad Performance")
+            Muted("Top ads and creative format mix")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Clicks", value=f"{total_clicks:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=f"{total_conversions:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Performance by ad type", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=by_type,
+                        x_axis="ad_type",
+                        series=[
+                            ChartSeries(data_key="clicks", label="Clicks"),
+                            ChartSeries(data_key="conversions", label="Conversions"),
+                        ],
+                        show_legend=True,
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Top ads", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="ad_name", header="Ad"),
+                            DataTableColumn(key="campaign", header="Campaign"),
+                            DataTableColumn(key="ad_group", header="Ad Group"),
+                            DataTableColumn(key="impressions", header="Impressions"),
+                            DataTableColumn(key="clicks", header="Clicks"),
+                            DataTableColumn(key="conversions", header="Conversions"),
+                            DataTableColumn(key="spend", header="Spend"),
+                        ],
+                        rows=top_ads,
+                    )
+""",
+    refresh={"mode": "scheduled", "cron": "0 */6 * * *"},
+)
+```
+
+## Variants
+
+- Filter to `ad_group_ad.ad.type = 'RESPONSIVE_SEARCH_AD'` for
+  search-only RSA reviews.
+- Add `ad_group_ad.ad_strength` to see Google's own quality signal.
+- Group by `segments.device` for device-level creative performance.

--- a/skills/google-ads/references/reporting/reports/budget-distribution.md
+++ b/skills/google-ads/references/reporting/reports/budget-distribution.md
@@ -1,0 +1,145 @@
+# Budget Distribution
+
+Where spend is actually going across campaigns.
+
+## When to use
+
+- "Where is our budget going?"
+- "Which campaigns are wasting money?"
+- Pacing review before adjusting daily budgets.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+
+Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+reporting and refreshable dashboards.
+
+## GAQL
+
+```sql
+SELECT
+  campaign.id,
+  campaign.name,
+  campaign.status,
+  campaign_budget.amount_micros,
+  campaign_budget.delivery_method,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.conversions_value,
+  metrics.clicks
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+## How to interpret
+
+- High `cost_micros` + zero `conversions` over a meaningful window =
+  immediate candidate for budget reduction OR for a tracking audit.
+  Don't recommend cuts until tracking is ruled out.
+- Spend Herfindahl: if 80%+ of spend lives in 2–3 campaigns, the
+  account is concentrated; restructure work has high leverage.
+- Compare `cost_micros` to `campaign_budget.amount_micros * days` to
+  detect under-pacing (budget caps / bidding ceilings).
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Budget Distribution",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT campaign.id, campaign.name, campaign.status, "
+                    "campaign_budget.amount_micros, "
+                    "campaign_budget.delivery_method, "
+                    "metrics.cost_micros, metrics.conversions, "
+                    "metrics.conversions_value, metrics.clicks "
+                    "FROM campaign "
+                    "WHERE segments.date DURING LAST_30_DAYS "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_budget",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "by_campaign": {
+            "shape": "rows",
+            "sql": (
+                "SELECT campaign_name AS campaign, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_budget GROUP BY 1 ORDER BY spend DESC LIMIT 25"
+            ),
+        },
+        "zero_conv_high_spend": {
+            "shape": "rows",
+            "sql": (
+                "SELECT campaign_name AS campaign, "
+                "SUM(metrics_cost_micros)/1e6 AS spend "
+                "FROM gads_budget GROUP BY 1 "
+                "HAVING SUM(metrics_conversions) = 0 "
+                "AND SUM(metrics_cost_micros) > 50000000 "
+                "ORDER BY spend DESC"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import BarChart, ChartSeries
+
+with PrefabApp(title="Budget Distribution") as app:
+    total_spend = sum(row.get("spend", 0) for row in by_campaign)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Budget Distribution")
+            Muted("Spend concentration and zero-conversion risk")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Spend", value=f"${total_spend:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Zero-conversion campaigns", value=f"{len(zero_conv_high_spend):,}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Spend by campaign", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=by_campaign,
+                        x_axis="campaign",
+                        series=[ChartSeries(data_key="spend", label="Spend")],
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("High spend without conversions", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="campaign", header="Campaign"),
+                            DataTableColumn(key="spend", header="Spend"),
+                        ],
+                        rows=zero_conv_high_spend,
+                    )
+""",
+    refresh={"mode": "scheduled", "cron": "0 */6 * * *"},
+)
+```
+
+## Variants
+
+- Add `metrics.search_impression_share` to flag campaigns that are
+  budget-constrained vs. competitor-pressured.
+- Group by `campaign.advertising_channel_type` to compare Search vs
+  PMax vs Display efficiency separately.

--- a/skills/google-ads/references/reporting/reports/campaign-performance.md
+++ b/skills/google-ads/references/reporting/reports/campaign-performance.md
@@ -1,0 +1,161 @@
+# Campaign Performance
+
+Time-series view of spend, clicks, conversions, and ROAS per campaign.
+The general-purpose performance dashboard — pair with the diagnosis
+reports when an issue surfaces.
+
+## When to use
+
+- "How is each campaign performing over time?"
+- Weekly / monthly performance review with the client.
+- Identifying trend changes (sudden spend spike, conversion drop).
+- The default first dashboard for a new client engagement.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+- Optional: `campaign_ids` filter.
+
+Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+reporting and refreshable dashboards.
+
+## GAQL
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  campaign.advertising_channel_type,
+  metrics.impressions,
+  metrics.clicks,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.conversions_value,
+  metrics.ctr,
+  metrics.average_cpc
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+## How to interpret
+
+- Daily ROAS = `conversions_value / cost`. Plot as time series; a
+  step-down on a known date often correlates with an ad / landing-page
+  change.
+- A sustained drop in conversions with steady spend = tracking issue
+  or seasonality, not necessarily campaign decay.
+- Compare campaigns of the same `advertising_channel_type`; cross-type
+  comparisons (Search vs PMax) are misleading.
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Campaign Performance",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "campaign.advertising_channel_type, "
+                    "metrics.impressions, metrics.clicks, metrics.cost_micros, "
+                    "metrics.conversions, metrics.conversions_value, "
+                    "metrics.ctr, metrics.average_cpc "
+                    "FROM campaign "
+                    "WHERE segments.date DURING LAST_30_DAYS "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_campaign_performance",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "daily_totals": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_date AS date, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_conversions) AS conversions, "
+                "SUM(metrics_conversions_value) AS revenue "
+                "FROM gads_campaign_performance GROUP BY 1 ORDER BY 1"
+            ),
+        },
+        "by_campaign": {
+            "shape": "rows",
+            "sql": (
+                "SELECT campaign_name AS campaign, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_conversions) AS conversions, "
+                "CASE WHEN SUM(metrics_cost_micros) > 0 "
+                "THEN SUM(metrics_conversions_value)/(SUM(metrics_cost_micros)/1e6) "
+                "ELSE 0 END AS roas "
+                "FROM gads_campaign_performance GROUP BY 1 ORDER BY spend DESC LIMIT 25"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import AreaChart, ChartSeries
+
+with PrefabApp(title="Campaign Performance") as app:
+    total_spend = sum(row.get("spend", 0) for row in by_campaign)
+    total_conversions = sum(row.get("conversions", 0) for row in by_campaign)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Campaign Performance")
+            Muted("Spend, conversions, revenue, and campaign-level efficiency")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Spend", value=f"${total_spend:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=f"{total_conversions:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Daily performance", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    AreaChart(
+                        data=daily_totals,
+                        x_axis="date",
+                        series=[
+                            ChartSeries(data_key="spend", label="Spend"),
+                            ChartSeries(data_key="conversions", label="Conversions"),
+                            ChartSeries(data_key="revenue", label="Revenue"),
+                        ],
+                        show_legend=True,
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Campaign detail", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="campaign", header="Campaign"),
+                            DataTableColumn(key="spend", header="Spend"),
+                            DataTableColumn(key="conversions", header="Conversions"),
+                            DataTableColumn(key="roas", header="ROAS"),
+                        ],
+                        rows=by_campaign,
+                    )
+""",
+    refresh={"mode": "scheduled", "cron": "0 * * * *"},
+)
+```
+
+## Variants
+
+- Add `metrics.search_impression_share` and
+  `metrics.search_top_impression_share` to spot lost-by-budget /
+  lost-by-rank issues.
+- Group by `segments.device` for desktop vs mobile vs tablet splits.

--- a/skills/google-ads/references/reporting/reports/campaign-structure.md
+++ b/skills/google-ads/references/reporting/reports/campaign-structure.md
@@ -1,0 +1,154 @@
+# Campaign Structure
+
+Campaign and ad-group structure view for understanding where spend,
+clicks, and conversions sit across account organization.
+
+## When to use
+
+- "Show me campaign and ad group structure."
+- "Which ad groups are getting spend?"
+- "How are campaigns and ad groups performing together?"
+- Before launching a parallel campaign, inspect whether the existing
+  account already covers the same theme.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+
+Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+reporting and refreshable dashboards.
+
+## GAQL
+
+```sql
+SELECT
+  campaign.id,
+  campaign.name,
+  campaign.advertising_channel_type,
+  ad_group.id,
+  ad_group.name,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.clicks,
+  metrics.impressions
+FROM ad_group
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+  AND ad_group.status != 'REMOVED'
+```
+
+## How to interpret
+
+- One campaign carrying many ad groups with very different conversion
+  rates → segmentation candidates.
+- Brand-matching ad groups inside the same campaign as generic
+  non-brand ad groups → recommend a brand split (huge bidding leverage).
+- Ad groups with very low impression share inside high-spend campaigns
+  → likely competing internally with another ad group; consolidation
+  candidates.
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Campaign Structure",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT campaign.id, campaign.name, "
+                    "campaign.advertising_channel_type, "
+                    "ad_group.id, ad_group.name, "
+                    "metrics.cost_micros, metrics.conversions, "
+                    "metrics.clicks, metrics.impressions "
+                    "FROM ad_group "
+                    "WHERE segments.date DURING LAST_30_DAYS "
+                    "AND campaign.status != 'REMOVED' "
+                    "AND ad_group.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_structure",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "ad_groups_per_campaign": {
+            "shape": "rows",
+            "sql": (
+                "SELECT campaign_name AS campaign, "
+                "COUNT(DISTINCT ad_group_id) AS ad_groups, "
+                "SUM(metrics_cost_micros)/1e6 AS spend "
+                "FROM gads_structure GROUP BY 1 ORDER BY spend DESC LIMIT 25"
+            ),
+        },
+        "ad_group_efficiency": {
+            "shape": "rows",
+            "sql": (
+                "SELECT campaign_name AS campaign, ad_group_name AS ad_group, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_structure GROUP BY 1, 2 "
+                "ORDER BY spend DESC LIMIT 50"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import BarChart, ChartSeries
+
+with PrefabApp(title="Campaign Structure") as app:
+    total_ad_groups = sum(row.get("ad_groups", 0) for row in ad_groups_per_campaign)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Campaign Structure")
+            Muted("Ad group distribution and efficiency")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Campaigns", value=f"{len(ad_groups_per_campaign):,}")
+            with Card():
+                with CardContent():
+                    Metric(label="Ad Groups", value=f"{total_ad_groups:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Ad groups and spend", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=ad_groups_per_campaign,
+                        x_axis="campaign",
+                        series=[
+                            ChartSeries(data_key="ad_groups", label="Ad Groups"),
+                            ChartSeries(data_key="spend", label="Spend"),
+                        ],
+                        show_legend=True,
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Ad group efficiency", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="campaign", header="Campaign"),
+                            DataTableColumn(key="ad_group", header="Ad Group"),
+                            DataTableColumn(key="spend", header="Spend"),
+                            DataTableColumn(key="conversions", header="Conversions"),
+                        ],
+                        rows=ad_group_efficiency,
+                    )
+""",
+    refresh={"mode": "manual"},
+)
+```
+
+## Variants
+
+- Filter to `campaign.advertising_channel_type = 'SEARCH'` for
+  search-only restructure analysis.
+- Add `ad_group.type` to distinguish standard vs PMax asset groups.

--- a/skills/google-ads/references/reporting/reports/conversion-by-action.md
+++ b/skills/google-ads/references/reporting/reports/conversion-by-action.md
@@ -1,0 +1,225 @@
+# Conversions by Action
+
+Per–conversion-action breakdown across campaigns and dates. Use this
+when the user wants to see how each individual conversion event (like
+"sign up", "purchase", "qualified lead") performs over time and across
+campaigns — not just the aggregate `conversions` metric.
+
+## When to use
+
+- "Show me conversions broken down by action / by event."
+- "Which campaigns drive each stage of our funnel?" (paired with
+  [conversion-funnel.md](conversion-funnel.md))
+- Diagnosing a single noisy conversion action (e.g. duplicate primary).
+- Building a stacked area / bar chart of conversion mix over time.
+
+## Inputs
+
+- `customer_id` (required, format `XXX-XXX-XXXX`).
+- `date_range` (default: `LAST_30_DAYS`; or explicit `start_date` / `end_date`).
+- Optional: `campaign_ids` to scope to a subset.
+
+## GAQL
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  segments.conversion_action,
+  segments.conversion_action_name,
+  segments.conversion_action_category,
+  metrics.conversions,
+  metrics.all_conversions,
+  metrics.conversions_value
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+**Critical caveat — common failure mode:**
+
+Do **not** select `conversion_action.id` or `conversion_action.name`
+against `FROM campaign`. That triggers
+`PROHIBITED_RESOURCE_TYPE_IN_SELECT_CLAUSE`. Always use the
+`segments.conversion_action*` fields instead. The metric name is
+`metrics.conversions` (already segmented by `segments.conversion_action`),
+**not** `metrics.conversions_by_conversion_action` (which does not
+exist).
+
+Do **not** select `metrics.cost_micros` in this query. Google Ads rejects
+`metrics.cost_micros` with `segments.conversion_action*` using
+`PROHIBITED_SEGMENT_WITH_METRIC_IN_SELECT_OR_WHERE_CLAUSE`. If cost is
+needed, run a second campaign/date query and join downstream:
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  metrics.cost_micros,
+  metrics.clicks,
+  metrics.impressions
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+Join conversion rows to cost rows on `(segments.date, campaign.id)`. For
+ad-hoc analysis, an in-memory pandas/dataframe merge in the sandbox is enough;
+no cache table is required.
+
+If the user wants to enumerate conversion actions independently of
+campaigns, query the `conversion_action` resource directly — see
+[conversion-tracking.md](conversion-tracking.md).
+
+## How to interpret
+
+- Each row is `(date, campaign, conversion_action)`. A campaign that
+  fires three actions yields three rows per day.
+- `metrics.conversions` is the segmented count for that action; sum
+  across actions in a campaign to recover the campaign-level
+  `metrics.conversions`.
+- `segments.conversion_action_category` (e.g. `PURCHASE`, `SIGNUP`,
+  `LEAD`) lets you group ad-hoc events into business categories.
+- Joined cost is campaign/date context, not action-attributed spend. Do not
+  sum joined cost across conversion actions unless you intentionally allocate
+  campaign/date spend across actions first.
+
+## Building a dashboard from this report
+
+The dashboard/data app tool reads tool-sourced data via `tool_data_sources`,
+re-aggregates it via `sql_data_sources`, and binds the variables in the
+interface source. Cache table convention: `gads_<report>_<scope>`.
+
+```python
+result = hyper_data_build_dashboard(
+    name="Conversions by Action",
+    tool_data_sources={
+        "raw_conversions": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "segments.conversion_action, segments.conversion_action_name, "
+                    "segments.conversion_action_category, metrics.conversions, "
+                    "metrics.all_conversions, metrics.conversions_value "
+                    "FROM campaign "
+                    "WHERE segments.date BETWEEN '2026-03-01' AND '2026-05-12' "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_conv_by_action",
+            "mode": "replace",
+        },
+        "raw_cost": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "metrics.cost_micros, metrics.clicks, metrics.impressions "
+                    "FROM campaign "
+                    "WHERE segments.date BETWEEN '2026-03-01' AND '2026-05-12' "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_campaign_cost",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "totals_by_action": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_conversion_action_name AS action, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_conv_by_action "
+                "GROUP BY 1 ORDER BY conversions DESC"
+            ),
+        },
+        "cost_totals": {
+            "shape": "rows",
+            "sql": (
+                "SELECT SUM(metrics_cost_micros)/1e6 AS cost "
+                "FROM gads_campaign_cost"
+            ),
+        },
+        "trend": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_date AS date, "
+                "segments_conversion_action_name AS action, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_conv_by_action GROUP BY 1, 2 ORDER BY 1"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import AreaChart, BarChart, ChartSeries
+
+with PrefabApp(title="Conversions by Action") as app:
+    total_conversions = sum(row.get("conversions", 0) for row in totals_by_action)
+    total_cost = (cost_totals[0].get("cost", 0) if cost_totals else 0)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Conversions by Action")
+            Muted("Conversion mix, trend, and campaign spend context")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=f"{total_conversions:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Cost", value=f"${total_cost:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Conversion trend", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    AreaChart(
+                        data=trend,
+                        x_axis="date",
+                        series=[ChartSeries(data_key="conversions", label="Conversions")],
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Conversions by action", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=totals_by_action,
+                        x_axis="action",
+                        series=[ChartSeries(data_key="conversions", label="Conversions")],
+                        height=300,
+                    )
+
+        with Card():
+            with CardContent():
+                Text("Action detail", css_class="text-sm font-medium text-muted-foreground mb-2")
+                DataTable(
+                    columns=[
+                        DataTableColumn(key="action", header="Action"),
+                        DataTableColumn(key="conversions", header="Conversions"),
+                    ],
+                    rows=totals_by_action,
+                )
+""",
+    refresh={"mode": "scheduled", "cron": "0 * * * *"},
+)
+```
+
+## Variants
+
+- **Per ad group**: change `FROM campaign` to `FROM ad_group` and add
+  `ad_group.id`, `ad_group.name`. Useful when one ad group fires the
+  conversion but the campaign rolls up many.
+- **Per ad**: `FROM ad_group_ad` plus `ad_group_ad.ad.id`,
+  `ad_group_ad.ad.name`. Heavier but useful for ad-level diagnosis.
+- **Filtered to one action**: add
+  `AND segments.conversion_action = 'customers/.../conversionActions/12345'`
+  to focus on a single event.

--- a/skills/google-ads/references/reporting/reports/conversion-funnel.md
+++ b/skills/google-ads/references/reporting/reports/conversion-funnel.md
@@ -1,0 +1,285 @@
+# Conversion Funnel
+
+Multi-stage conversion funnel for lead-gen / B2B accounts. Pivots
+per-action conversion data into ordered funnel stages and computes
+step-conversion rates between stages.
+
+## When to use
+
+- Lead-gen / B2B accounts with multiple sequential stages (e.g.
+  application_submitted → lead_reached → scheduled → showed → won).
+- "What's the drop-off between [stage A] and [stage B]?"
+- "Which stage is the bottleneck?"
+- Pricing or onboarding optimization rooted in funnel data.
+
+For a flat per-action breakdown without ordering, use
+[conversion-by-action.md](conversion-by-action.md) instead.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+- An ordered list of conversion-action names (or IDs) that defines the
+  funnel. **The agent must discover these first** — no funnel ordering
+  is hard-coded.
+
+## GAQL
+
+### Step 1 — discover the user's conversion actions
+
+```sql
+SELECT
+  conversion_action.id,
+  conversion_action.name,
+  conversion_action.category,
+  conversion_action.status
+FROM conversion_action
+WHERE conversion_action.status != 'REMOVED'
+```
+
+Show the result to the user and ask them to map each action to a funnel
+stage in order. **Do not assume a six-stage funnel** (or any stage count) —
+funnels are workspace-specific.
+
+### Step 2 — pull per-action data
+
+Same shape as [conversion-by-action.md](conversion-by-action.md):
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  segments.conversion_action,
+  segments.conversion_action_name,
+  segments.conversion_action_category,
+  metrics.conversions,
+  metrics.all_conversions,
+  metrics.conversions_value
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+The same caveat applies: **only** segment via
+`segments.conversion_action*`, never `conversion_action.id` against
+`FROM campaign` (raises `PROHIBITED_RESOURCE_TYPE_IN_SELECT_CLAUSE`).
+The metric is `metrics.conversions`, not the nonexistent
+`metrics.conversions_by_conversion_action`.
+
+Do **not** include `metrics.cost_micros` in the per-action query. Google Ads
+rejects cost with `segments.conversion_action*` using
+`PROHIBITED_SEGMENT_WITH_METRIC_IN_SELECT_OR_WHERE_CLAUSE`. If cost is needed,
+run a separate campaign/date query:
+
+```sql
+SELECT
+  segments.date,
+  campaign.id,
+  campaign.name,
+  metrics.cost_micros,
+  metrics.clicks,
+  metrics.impressions
+FROM campaign
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status != 'REMOVED'
+```
+
+Join conversion rows to cost rows on `(segments.date, campaign.id)`. For
+one-off analysis, join in memory with pandas or an equivalent dataframe in the
+sandbox; cache tables are only needed for dashboard/data-app builds.
+
+## How to interpret
+
+- Pivot the raw rows so each user-mapped stage becomes a column,
+  values are stage totals.
+- Step conversion rate = `stage_n / stage_n-1`.
+- Joined cost is campaign/date context. Do not present it as action-attributed
+  cost per stage unless the report explicitly defines an allocation rule.
+- State the user-provided stage mapping in the final report. Do not
+  infer action order from names alone.
+
+## Building a dashboard from this report
+
+```python
+# After the agent has mapped action names to ordered stages, e.g.
+# stages = ["application_submitted", "lead_reached",
+#           "scheduled_for_training", "showed_for_training",
+#           "launched_from_training", "rep_that_sells"]
+result = hyper_data_build_dashboard(
+    name="Lead-Gen Funnel",
+    tool_data_sources={
+        "raw_conversions": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "segments.conversion_action, segments.conversion_action_name, "
+                    "segments.conversion_action_category, metrics.conversions, "
+                    "metrics.all_conversions, metrics.conversions_value "
+                    "FROM campaign "
+                    "WHERE segments.date BETWEEN '2026-03-01' AND '2026-05-12' "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_funnel_raw",
+            "mode": "replace",
+        },
+        "raw_cost": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT segments.date, campaign.id, campaign.name, "
+                    "metrics.cost_micros, metrics.clicks, metrics.impressions "
+                    "FROM campaign "
+                    "WHERE segments.date BETWEEN '2026-03-01' AND '2026-05-12' "
+                    "AND campaign.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_funnel_cost",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "stage_totals": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_conversion_action_name AS stage, "
+                "CASE segments_conversion_action_name "
+                "WHEN 'application_submitted' THEN 1 "
+                "WHEN 'lead_reached' THEN 2 "
+                "WHEN 'scheduled_for_training' THEN 3 "
+                "WHEN 'showed_for_training' THEN 4 "
+                "WHEN 'launched_from_training' THEN 5 "
+                "WHEN 'rep_that_sells' THEN 6 END AS stage_order, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_funnel_raw "
+                "WHERE segments_conversion_action_name IN ("
+                "  'application_submitted', 'lead_reached', "
+                "  'scheduled_for_training', 'showed_for_training', "
+                "  'launched_from_training', 'rep_that_sells'"
+                ") GROUP BY 1, 2 ORDER BY 2"
+            ),
+        },
+        "step_rates": {
+            "shape": "rows",
+            "sql": (
+                "WITH ordered AS ("
+                "  SELECT segments_conversion_action_name AS stage, "
+                "  CASE segments_conversion_action_name "
+                "  WHEN 'application_submitted' THEN 1 "
+                "  WHEN 'lead_reached' THEN 2 "
+                "  WHEN 'scheduled_for_training' THEN 3 "
+                "  WHEN 'showed_for_training' THEN 4 "
+                "  WHEN 'launched_from_training' THEN 5 "
+                "  WHEN 'rep_that_sells' THEN 6 END AS stage_order, "
+                "  SUM(metrics_conversions) AS conversions "
+                "  FROM gads_funnel_raw "
+                "  WHERE segments_conversion_action_name IN ("
+                "    'application_submitted', 'lead_reached', "
+                "    'scheduled_for_training', 'showed_for_training', "
+                "    'launched_from_training', 'rep_that_sells'"
+                "  ) GROUP BY 1, 2"
+                ") SELECT stage, conversions, "
+                "conversions / NULLIF(LAG(conversions) OVER (ORDER BY stage_order), 0) "
+                "AS step_rate "
+                "FROM ordered ORDER BY stage_order"
+            ),
+        },
+        "cost_totals": {
+            "shape": "rows",
+            "sql": (
+                "SELECT SUM(metrics_cost_micros)/1e6 AS cost "
+                "FROM gads_funnel_cost"
+            ),
+        },
+        "stage_trend": {
+            "shape": "rows",
+            "sql": (
+                "SELECT segments_date AS date, "
+                "segments_conversion_action_name AS stage, "
+                "SUM(metrics_conversions) AS conversions "
+                "FROM gads_funnel_raw GROUP BY 1, 2 ORDER BY 1"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import AreaChart, BarChart, ChartSeries
+
+with PrefabApp(title="Lead-Gen Funnel") as app:
+    total_conversions = sum(row.get("conversions", 0) for row in stage_totals)
+    total_cost = (cost_totals[0].get("cost", 0) if cost_totals else 0)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Lead-Gen Funnel")
+            Muted("Stage volume, trend, and step-rate health")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Conversions", value=f"{total_conversions:,.0f}")
+            with Card():
+                with CardContent():
+                    Metric(label="Cost", value=f"${total_cost:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Stage trend", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    AreaChart(
+                        data=stage_trend,
+                        x_axis="date",
+                        series=[ChartSeries(data_key="conversions", label="Conversions")],
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Stage totals", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=stage_totals,
+                        x_axis="stage",
+                        series=[ChartSeries(data_key="conversions", label="Conversions")],
+                        height=300,
+                    )
+
+        with Grid(columns=[1, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Stage detail", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="stage", header="Stage"),
+                            DataTableColumn(key="conversions", header="Conversions"),
+                        ],
+                        rows=stage_totals,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Step rates", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="stage", header="Stage"),
+                            DataTableColumn(key="conversions", header="Conversions"),
+                            DataTableColumn(key="step_rate", header="Step Rate"),
+                        ],
+                        rows=step_rates,
+                    )
+""",
+    refresh={"mode": "scheduled", "cron": "0 * * * *"},
+)
+```
+
+## Variants
+
+- **Step rates**: add an `sql_data_sources` entry that uses window
+  functions (`LAG`) to compute `conversions / lag_conversions` between
+  ordered stages and bind it to a separate KPI row.
+- **Per campaign**: filter `WHERE campaign.id = ...` to compare funnel
+  shapes between campaigns.
+- **Allocated cost per stage**: join campaign/date cost to conversion rows,
+  then apply an explicit allocation rule before presenting stage cost.

--- a/skills/google-ads/references/reporting/reports/conversion-tracking.md
+++ b/skills/google-ads/references/reporting/reports/conversion-tracking.md
@@ -1,0 +1,151 @@
+# Conversion Tracking
+
+Conversion-action inventory report. Use it to list configured
+conversion actions and their metadata before building action-specific
+dashboards.
+
+## When to use
+
+- "Which conversion actions exist?"
+- "Which conversion actions are enabled?"
+- "What are the conversion action categories and settings?"
+- Before building a funnel dashboard that needs user-mapped stages.
+
+## Inputs
+
+- `customer_id` (required).
+
+Use the GAQL below through `google_ads_execute_gaql` when you need
+conversion-action metadata. This is separate from campaign-level
+conversion metrics, which use `segments.conversion_action*`.
+
+## GAQL
+
+```sql
+SELECT
+  conversion_action.id,
+  conversion_action.name,
+  conversion_action.category,
+  conversion_action.type,
+  conversion_action.status,
+  conversion_action.primary_for_goal,
+  conversion_action.counting_type,
+  conversion_action.click_through_lookback_window_days
+FROM conversion_action
+WHERE conversion_action.status != 'REMOVED'
+```
+
+## How to interpret
+
+- **No enabled conversion actions** → optimization is blind; halt all
+  Smart Bidding advice until at least one is configured.
+- **Multiple `PRIMARY_FOR_GOAL` actions in the same category** (e.g. two
+  primary purchase actions) → Smart Bidding double-counts; recommend
+  demoting one to secondary.
+- **`PURCHASE` category but `counting_type = MANY_PER_CLICK`** is rare
+  and usually a misconfiguration; flag for review.
+- **Lookback window mismatches** between online + offline actions can
+  produce inconsistent attribution.
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Conversion Tracking Audit",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT conversion_action.id, conversion_action.name, "
+                    "conversion_action.category, conversion_action.type, "
+                    "conversion_action.status, conversion_action.primary_for_goal, "
+                    "conversion_action.counting_type, "
+                    "conversion_action.click_through_lookback_window_days "
+                    "FROM conversion_action "
+                    "WHERE conversion_action.status != 'REMOVED'"
+                ),
+            },
+            "cache_table": "gads_conv_actions",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "by_category": {
+            "shape": "rows",
+            "sql": (
+                "SELECT conversion_action_category AS category, "
+                "COUNT(*) AS total_actions, "
+                "SUM(CASE WHEN conversion_action_primary_for_goal THEN 1 ELSE 0 END) AS primary_actions "
+                "FROM gads_conv_actions GROUP BY 1 ORDER BY 1"
+            ),
+        },
+        "actions": {
+            "shape": "rows",
+            "sql": (
+                "SELECT conversion_action_name AS name, "
+                "conversion_action_category AS category, "
+                "conversion_action_status AS status, "
+                "conversion_action_primary_for_goal AS primary "
+                "FROM gads_conv_actions ORDER BY name"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+from prefab_ui.components.charts import BarChart, ChartSeries
+
+with PrefabApp(title="Conversion Tracking Audit") as app:
+    primary_actions = sum(row.get("primary_actions", 0) for row in by_category)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Conversion Tracking Audit")
+            Muted("Configured actions, primary actions, and status")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Actions", value=f"{len(actions):,}")
+            with Card():
+                with CardContent():
+                    Metric(label="Primary Actions", value=f"{primary_actions:,.0f}")
+
+        with Grid(columns=[2, 1], gap=6):
+            with Card():
+                with CardContent():
+                    Text("Actions by category", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    BarChart(
+                        data=by_category,
+                        x_axis="category",
+                        series=[
+                            ChartSeries(data_key="total_actions", label="Total"),
+                            ChartSeries(data_key="primary_actions", label="Primary"),
+                        ],
+                        show_legend=True,
+                        height=300,
+                    )
+            with Card():
+                with CardContent():
+                    Text("Action inventory", css_class="text-sm font-medium text-muted-foreground mb-2")
+                    DataTable(
+                        columns=[
+                            DataTableColumn(key="name", header="Action"),
+                            DataTableColumn(key="category", header="Category"),
+                            DataTableColumn(key="status", header="Status"),
+                            DataTableColumn(key="primary", header="Primary"),
+                        ],
+                        rows=actions,
+                    )
+""",
+    refresh={"mode": "manual"},
+)
+```
+
+## Variants
+
+- Join with the `conversion-by-action.md` cache table to overlay actual
+  conversion volume on each action's setup status.
+- Filter to `category = 'PURCHASE'` for ecommerce-only audits.

--- a/skills/google-ads/references/reporting/reports/search-terms-waste.md
+++ b/skills/google-ads/references/reporting/reports/search-terms-waste.md
@@ -1,0 +1,131 @@
+# Search Terms Waste
+
+Search terms report showing query-level cost, clicks, conversions, and
+conversion value.
+
+## When to use
+
+- "What search terms are getting spend?"
+- "Which search terms converted?"
+- "Show search terms by campaign/ad group."
+- Before discussing negatives, inspect the actual search-term evidence.
+
+## Inputs
+
+- `customer_id` (required).
+- `date_range` (default: `LAST_30_DAYS`).
+- Optional: `campaign_ids` to scope.
+- Threshold: cost-without-conversion floor (default: $10 / 10_000_000
+  micros over the window).
+
+Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+reporting and refreshable dashboards.
+
+## GAQL
+
+```sql
+SELECT
+  search_term_view.search_term,
+  search_term_view.status,
+  campaign.name,
+  ad_group.name,
+  metrics.cost_micros,
+  metrics.clicks,
+  metrics.conversions,
+  metrics.conversions_value
+FROM search_term_view
+WHERE segments.date BETWEEN '{start}' AND '{end}'
+```
+
+## How to interpret
+
+- Highest spend with zero conversions over a meaningful window = top
+  candidates for negatives.
+- Off-intent terms (job seekers when you sell software, "free" when you
+  sell paid, competitor names you don't want to bid on) deserve
+  campaign- or account-level negatives, not ad-group-level.
+- A single ad group surfacing many wasteful themes signals a structural
+  problem; pair with [campaign-structure.md](campaign-structure.md).
+
+## Building a dashboard from this report
+
+```python
+result = hyper_data_build_dashboard(
+    name="Search Terms Waste",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {
+                "customer_id": "123-456-7890",
+                "query": (
+                    "SELECT search_term_view.search_term, search_term_view.status, "
+                    "campaign.name, ad_group.name, "
+                    "metrics.cost_micros, metrics.clicks, "
+                    "metrics.conversions, metrics.conversions_value "
+                    "FROM search_term_view "
+                    "WHERE segments.date DURING LAST_30_DAYS"
+                ),
+            },
+            "cache_table": "gads_search_terms",
+            "mode": "replace",
+        },
+    },
+    sql_data_sources={
+        "top_waste": {
+            "shape": "rows",
+            "sql": (
+                "SELECT search_term_view_search_term AS term, "
+                "campaign_name AS campaign, "
+                "SUM(metrics_cost_micros)/1e6 AS spend, "
+                "SUM(metrics_clicks) AS clicks "
+                "FROM gads_search_terms "
+                "GROUP BY 1, 2 "
+                "HAVING SUM(metrics_conversions) = 0 "
+                "AND SUM(metrics_cost_micros) > 10000000 "
+                "ORDER BY spend DESC LIMIT 50"
+            ),
+        },
+    },
+    prefab_python="""
+from prefab_ui import PrefabApp
+from prefab_ui.components import Card, CardContent, Column, DataTable, DataTableColumn, Grid, Heading, Metric, Muted, Text
+
+with PrefabApp(title="Search Terms Waste") as app:
+    wasted_spend = sum(row.get("spend", 0) for row in top_waste)
+
+    with Column(gap=6, css_class="p-6"):
+        with Column(gap=1):
+            Heading("Search Terms Waste")
+            Muted("Highest-spend terms with weak or missing conversion value")
+
+        with Grid(columns=4, gap=4):
+            with Card():
+                with CardContent():
+                    Metric(label="Flagged Terms", value=f"{len(top_waste):,}")
+            with Card():
+                with CardContent():
+                    Metric(label="Flagged Spend", value=f"${wasted_spend:,.0f}")
+
+        with Card():
+            with CardContent():
+                Text("Waste candidates", css_class="text-sm font-medium text-muted-foreground mb-2")
+                DataTable(
+                    columns=[
+                        DataTableColumn(key="term", header="Search Term"),
+                        DataTableColumn(key="campaign", header="Campaign"),
+                        DataTableColumn(key="spend", header="Spend"),
+                        DataTableColumn(key="clicks", header="Clicks"),
+                    ],
+                    rows=top_waste,
+                )
+""",
+    refresh={"mode": "scheduled", "cron": "0 */6 * * *"},
+)
+```
+
+## Variants
+
+- Group by theme (regex patterns over `search_term`) to surface
+  thematic waste rather than per-query waste.
+- Add `metrics.average_cpc` to spot expensive-per-click terms even
+  when total spend is small.

--- a/skills/google-ads/references/reporting/workflows.md
+++ b/skills/google-ads/references/reporting/workflows.md
@@ -1,0 +1,88 @@
+# Google Ads Reporting Workflow
+
+## When to use
+
+Read this before authoring GAQL, optional dashboard sources, or a reporting
+response for an existing Google Ads account.
+
+## Core contract
+
+- Use `google_ads_execute_gaql` as the canonical Google Ads data tool.
+- Written GAQL-backed reports are valid outputs. Dashboards and data apps are
+  optional presentation surfaces.
+- Build a dashboard/data app only when the user asks for one or when an
+  interactive view materially improves the presentation.
+- When building an interface, fetch external rows through `tool_data_sources`,
+  save them into a tenant cache table, query that cache with
+  `sql_data_sources`, and render the final interface from those variables.
+- Do not use the alternate GAQL alias in new examples.
+- Do not use custom operator-tool heuristics as authoritative analysis.
+- Do not inject Google Ads credentials into the dashboard/data app runtime.
+- Keep reporting separate from live account mutations.
+- Do not mention internal interface implementation details to the user unless
+  they explicitly ask how it is built.
+
+## Phase 1: Access and scope
+
+1. Call `google_ads_list_accounts()` before touching account data.
+2. Confirm the customer ID if more than one account is available.
+3. Confirm the reporting window if the user has not given one.
+4. If the user did not ask for a dashboard/data app and the best output is
+   unclear, ask whether they want a written report or an interactive view.
+
+## Phase 2: Choose the report
+
+Pick the narrowest report doc under `reports/`:
+
+- conversion action breakdown: `reports/conversion-by-action.md`
+- lead-gen / B2B funnel: `reports/conversion-funnel.md`
+- conversion action inventory: `reports/conversion-tracking.md`
+- budget distribution: `reports/budget-distribution.md`
+- search terms: `reports/search-terms-waste.md`
+- campaign performance: `reports/campaign-performance.md`
+- ad performance: `reports/ad-performance.md`
+
+When the user asks for a funnel dashboard, use the conversion funnel
+recipe. Do not add a new Google Ads tool for that case.
+
+## Phase 3: Query with GAQL
+
+Use GAQL fields that are selectable with the report resource. For
+campaign-level conversion action reporting, use campaign metrics
+segmented by `segments.conversion_action` and
+`segments.conversion_action_name`.
+
+Do not select `conversion_action.id` or `conversion_action.name` from
+`FROM campaign`; Google rejects that shape. Query the
+`conversion_action` resource separately only when you need the inventory
+of configured conversion actions.
+
+## Phase 4: Optional dashboard/data app
+
+Skip this phase for plain written reports. If building an interface, first load
+`hyper-database/references/dashboard-building.md`, then use a call shaped like:
+
+```python
+hyper_data_build_dashboard(
+    name="Google Ads Report",
+    tool_data_sources={
+        "raw": {
+            "tool_name": "google_ads_execute_gaql",
+            "tool_args": {"customer_id": "...", "query": "..."},
+            "cache_table": "gads_report_raw",
+            "mode": "replace",
+        }
+    },
+    sql_data_sources={...},
+    prefab_python="...",
+)
+```
+
+The tool source name is not a Python variable. It populates the cache
+table. SQL sources create the variables used by the interface code.
+
+## Phase 5: Response format
+
+Use the template in `report-template.md`. State what data was queried, which
+date range was used, and whether the final output is a written report,
+dashboard, data app, or published interface.

--- a/skills/google-sheets/SKILL.md
+++ b/skills/google-sheets/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: google-sheets
+description: Safe workflow for reading, mapping, and writing Google Sheets without shifting columns or overwriting the wrong ranges. Use when the user wants to read, update, or append spreadsheet data, fix sheet structure, or sync data into Google Sheets.
+use_cases:
+  - Update a Google Sheet safely
+  - Append rows to a spreadsheet
+  - Map data into existing sheet columns
+  - Fill CRM sheets from tool or database results
+  - Verify spreadsheet headers before writing
+  - Repair or avoid column misalignment in Sheets
+triggers:
+  - google sheets
+  - spreadsheet
+  - sheet mapping
+  - write rows
+  - append rows
+  - update cells
+  - map columns
+  - fill sheet
+requires_toolkits:
+  - google_sheets
+suggested_toolkits:
+  - sandbox
+---
+
+# Google Sheets Writing
+
+Use this skill whenever you need to write structured data into an existing spreadsheet.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Google Sheets integration** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Core Rule
+
+Never write to Google Sheets from guessed column letters alone.
+
+Always:
+1. inspect the workbook and target worksheet
+2. find the real header row
+3. map fields by header name
+4. verify the destination range
+5. write
+6. read back sample rows to confirm alignment
+
+## Critical Failure Modes To Avoid
+
+- Do not assume row 1 is the real header row.
+- Do not assume column `A` is the first business/data column.
+- Do not treat helper cells like `Total`, notes, formulas, merged labels, or spacer columns as real headers.
+- Do not overwrite a broad range before checking existing data and layout.
+- Do not claim success until you read back the written cells.
+
+## Required Workflow
+
+### Step 1: Inspect workbook structure
+
+Start with:
+- `google_sheets_get_spreadsheet`
+- `google_sheets_list_worksheets` if needed
+
+Confirm:
+- worksheet title
+- row/column counts
+- whether there are multiple candidate tabs
+
+### Step 2: Read enough context to find the real headers
+
+Read more than one row when structure is unknown.
+
+Typical pattern:
+- `google_sheets_get_values(..., range="Sheet1!A1:Z5")`
+
+Look for:
+- true column labels
+- helper columns before the real table
+- title rows, totals, formulas, blank separators
+
+If the first row contains labels like `Total`, `Notes`, or other non-record metadata, do not anchor your write range to that row alone.
+
+### Step 3: Build a header map
+
+Map your source fields to actual sheet headers by name, not memory.
+
+Example:
+- source field `business_name` -> sheet header `Business Name`
+- source field `contact_email` -> sheet header `Owner (s) Email`
+
+If a required header is missing or ambiguous, stop and ask the user instead of guessing.
+
+### Step 4: Choose the safest write strategy
+
+Use:
+- `google_sheets_update_values` for one verified contiguous range
+- `google_sheets_batch_update_values` for multiple verified ranges
+
+Prefer narrow writes over large blanket writes.
+
+If appending records into a table that already has fixed columns, compute the exact destination columns from the header map first.
+
+## Write Rules
+
+- Only write columns you have positively mapped.
+- Leave unrelated columns untouched.
+- When a sheet contains helper columns before the table, start writing at the true mapped column, not column `A`.
+- If a field is intentionally blank, write a blank value only to that verified column.
+- Use `RAW` unless the user explicitly wants formulas or Sheets parsing behavior.
+
+## Verification Is Mandatory
+
+Immediately after writing:
+1. read back the exact written range
+2. inspect at least 2-3 sample rows
+3. confirm each field landed under the intended header
+
+If the read-back is misaligned, acknowledge it and correct it before reporting success.
+
+## Recommended Tool Pattern
+
+1. `google_sheets_get_spreadsheet`
+2. `google_sheets_get_values` on a header-discovery range such as `A1:Z5`
+3. optional `google_sheets_batch_get_values` for existing data + destination area
+4. `google_sheets_update_values` or `google_sheets_batch_update_values`
+5. `google_sheets_get_values` on the written range for verification
+
+## Example Mindset
+
+Bad:
+- “I saw `Business Name` near the start, so I will write `A2:F51`.”
+
+Good:
+- “The first visible row includes `Total: 7` in column `A`, while `Business Name` is actually in column `B`, so I will map the write range from `B` onward and verify it after writing.”

--- a/skills/gtm/SKILL.md
+++ b/skills/gtm/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: gtm
+description: GTM operating system for a brand — decide where to focus (content, community, or ads), write and maintain the marketing plan, run the chosen workflows, and set up recurring monitoring. Delegates channel execution to the dedicated skills. Use when the user asks what to do next, wants a marketing plan, GTM or growth strategy, a full brand audit, or the weekly content/community/ads cadence run.
+use_cases:
+  - Write the first marketing plan after onboarding
+  - Recommend where the brand should focus next
+  - Choose between content, community, and ads
+  - Run a Full Brand Audit (brand profile, tracking audit, competitors, SEO/AI visibility, social intel)
+  - Audit SEO keywords and AI search visibility
+  - Research a SERP and write an SEO blog post
+  - Generate a social content package distilled from a blog post
+  - Publish approved content to Webflow
+  - Find high-engagement Reddit threads and draft community replies
+  - Launch paid campaigns through the meta-ads / google-ads skills
+  - Set up recurring monitoring tasks (daily campaign report, weekly intel)
+  - Explain what to measure and which tools are missing
+triggers:
+  - gtm
+  - go to market
+  - marketing plan
+  - marketing strategy
+  - growth strategy
+  - what should we do
+  - where should i focus
+  - next steps
+  - pick a channel
+  - channel strategy
+  - brand audit
+  - run brand audit
+  - audit seo keywords
+  - check ai visibility
+  - write blog post
+  - generate social posts
+  - publish to webflow
+  - find reddit threads
+  - draft reddit replies
+  - daily campaign report
+  - cmo task
+requires_toolkits:
+  - cmo
+  - sandbox
+  - firecrawl_toolkit
+  - hyperseo
+suggested_toolkits:
+  - files
+  - hyper_database
+  - image_gen
+  - meta_ads_library
+  - meta_business
+  - google_ads
+  - webflow_toolkit
+  - reddit_scraper
+  - google_search_console_toolkit
+  - google_analytics_toolkit
+  - website_analyzer_toolkit
+---
+
+# GTM
+
+Help a brand decide what to do next, write the plan, and run it.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **CMO toolkit** plus the baseline execution set (sandbox, Firecrawl, HyperSEO) enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations). Channel workflows need their own integrations (Meta Business, Google Ads, Webflow, Reddit scraper) — inspect what is connected before running a step.
+
+This skill has two layers:
+
+- **Decision layer** — read the brand state, choose one focus, write `/files/cmo/{domain}/plan.md`, keep `status.md` current, propose scheduled tasks. This layer decides; nothing else does.
+- **Execution layer** — run the workflow the plan chose. Research and audit steps live in this skill's references; channel execution (paid campaigns, ad creative, competitor ad scans) is delegated to the dedicated channel skills.
+
+Keep the writing plain. The user should be able to read the answer quickly and understand the point without learning internal labels.
+
+## When to use which layer
+
+Decision layer:
+
+- onboarding is done and the brand needs its first plan
+- the user asks what to do next, or where to focus
+- the user wants to change the plan
+- the user asks for a marketing strategy or GTM plan
+
+Execution layer:
+
+- the plan exists and a specific step should run ("write the blog post", "scan competitor ads", "draft Reddit replies")
+- the user explicitly asks for an execution-side outcome and the channel is already settled
+- a Full Brand Audit needs the research foundation before the decision layer can synthesize a plan
+
+# Decision layer
+
+The job is simple:
+
+1. Read the brand files.
+2. Ask only the questions that are still missing.
+3. Choose one main focus.
+4. Write `/files/cmo/{domain}/plan.md`.
+5. Update `/files/cmo/{domain}/status.md`.
+6. Ask in chat before adding scheduled tasks.
+
+## How to think
+
+Use normal language. Do not write internal labels or process notes into chat or `plan.md`.
+
+- "The offer is not clear enough yet."
+- "Focus on content first."
+- "Search Console is missing, so we do not have a real organic baseline."
+- "I can add a weekly SEO task, but it needs HyperSEO first."
+
+## What the agent can choose
+
+Choose one main focus unless the user clearly asks for more.
+
+The normal choices are:
+
+- Content: blog posts, search, social posts, and visibility in AI answers.
+- Community: Reddit, forums, or similar places where the audience already talks.
+- Ads: Meta or Google Ads, only when the right ad tools and measurement are connected.
+
+Warm outreach, cold outreach, affiliates, and referrals are not started from this skill. Mention them only if the user says they already run them and the detail matters. (For dedicated outbound work, the `cold-email-outreach` skill exists — but it is not part of the default focus choice.)
+
+## Read the current state
+
+Read these files first:
+
+- `/files/cmo/{domain}/business_context.md`
+- `/files/cmo/{domain}/status.md`
+- `/files/cmo/{domain}/plan.md`, if it exists
+
+Use `cmo_get_brand_data` when you need the current structured brand data.
+
+Do not recollect brand data unless it is missing, stale, or the user asks for a refresh. If you call `cmo_collect_brand_data`, pass the brand URL.
+
+Use `cmo_collect_ad_performance` only when connected ad accounts are available.
+
+## Ask only useful questions
+
+Use `ask_user` when the answer changes the plan.
+
+Ask as few questions as possible. One batch is preferred. Do not ask what tools are connected; inspect that yourself.
+
+Useful questions:
+
+- What should this brand win in the next 90 days?
+- Which audience should we focus on first?
+- Are content, ads, or community off-limits?
+- Are warm outreach, cold outreach, affiliates, or referrals already running?
+- If the user wants ads and ad tools are missing: what budget range are they considering?
+
+Skip questions that the brand files already answer.
+
+If a question is still unanswered, ask it in chat. Do not put unanswered questions into `plan.md`.
+
+## Choose the focus
+
+Use the references when deciding:
+
+- `references/strategy/offer-first.md`: use when the offer is unclear.
+- `references/strategy/channels.md`: use when choosing content, community, or ads.
+- `references/strategy/channel-fit-diagnostic.md`: use when the best focus is not obvious.
+- `references/strategy/concentration.md`: use when the plan is spreading effort too widely.
+- `references/strategy/always-on-content.md`: use for the weekly baseline.
+- `references/strategy/recurring-schedules.md`: use only after the plan is written, when proposing scheduled tasks.
+
+Choose content when:
+
+- people already search for the problem or category
+- competitors rank and the brand does not
+- the brand needs useful public pages before ads can work well
+- measurement tools are missing and content is the safest useful start
+
+Choose community when:
+
+- the audience is clearly active in one place
+- people discuss the exact problem there
+- the brand can join without sounding forced
+
+Choose ads when:
+
+- Meta or Google Ads is connected
+- tracking is good enough to measure results
+- the offer is clear enough to spend against
+- there is evidence that ads can work for the brand or category
+
+If the offer is unclear, say that plainly. Recommend fixing the offer before spending on more traffic.
+
+## Evidence rules
+
+Do not invent measurements.
+
+If a tool or file did not measure something, say it is missing.
+
+Examples:
+
+- Do not say the brand has "0 AI citations" unless a file or tool actually checked AI answers.
+- Do not say search traffic is growing unless Search Console or another real source shows it.
+- Do not invent a baseline for traffic, leads, revenue, ROAS, rankings, or AI answer visibility.
+- If a source is missing, name the missing source and explain what it would measure.
+
+Every recommendation should cite the files or dashboard panels that support it.
+
+## Write `plan.md`
+
+Write or revise exactly this file:
+
+`/files/cmo/{domain}/plan.md`
+
+Use this shape:
+
+```md
+# Marketing plan
+
+## Diagnosis
+
+What is happening, why it matters, and which files or dashboard panels support it.
+
+## Focus
+
+The one place to focus first, why it is the right next move, and which workflow should run.
+
+## Measurement
+
+The weekly goal, the main number to watch, the source of truth, the current baseline if known, and missing tools.
+
+## Weekly cadence
+
+The basic weekly work that should keep happening.
+
+## Not doing now
+
+Only include this when leaving something out matters.
+```
+
+Do not put these in `plan.md`:
+
+- unanswered questions
+- task ideas waiting for approval
+- scheduled tasks
+- approval text
+- schedule record IDs
+- copied task lists
+- internal tool-call notes
+
+`plan.md` is the permanent marketing plan. It is not a task manager.
+
+## Update `status.md`
+
+After writing the plan, update:
+
+`/files/cmo/{domain}/status.md`
+
+Update only the parts that matter:
+
+- mark the initial plan as written
+- note the current goal
+- note the latest decision
+- note the next action
+- note missing measurement tools
+- record approved scheduled tasks after they are actually created
+
+Keep task state in `status.md`, the task sidebar, and chat. Do not copy it into `plan.md`.
+
+## Ask before scheduling tasks
+
+After the plan is written, suggest useful scheduled tasks in chat.
+
+Keep it short:
+
+```text
+I suggest adding a weekly SEO scan and a Monday blog draft task. The blog draft needs HyperSEO and Firecrawl. Approve these, or tell me what to change.
+```
+
+Before scheduling a task:
+
+1. Check which tools the task needs.
+2. Check which tools are connected.
+3. Ask the user to approve the task.
+4. If needed tools are missing, create the task inactive or ask the user to connect the tools first.
+
+When calling `agents_schedule`, use only supported arguments:
+
+- `agent_id`
+- `instructions`
+- `cron` or `run_at`
+- `timezone`
+- `name`
+- `active`
+
+Do not pass fields such as `requires`, `required_providers`, or `required_toolkits`.
+
+In the task instructions, start with a plain sentence like:
+
+```text
+Tools needed: HyperSEO and Firecrawl. If either tool is not connected, stop and tell the user what is missing.
+```
+
+After approved schedules are created, confirm in chat and update `status.md`. Do not update `plan.md` with schedule details.
+
+## Final response to the user
+
+After writing the plan and updating status, reply with:
+
+- the main problem
+- the focus
+- the measurement source or missing source
+- the weekly cadence
+- any task approval question
+
+Keep it short. Do not repeat the whole plan in chat.
+
+# Execution layer
+
+Run the workflow the plan chose. Research and produce artifacts; surface them as you go. This layer never picks channels or goals — the decision layer owns those.
+
+## Routing table (workflow slug → where the steps live)
+
+| Workflow slug | Read / delegate, in order |
+|---|---|
+| `research/foundation` | `references/playbooks/research/00-client-intake.md` → `01-scrape-brand-profile.md` → `02-audit-website-tracking.md` → `03-research-competitors.md` |
+| `organic-content/seo-blog` | `references/playbooks/organic-content/04-audit-seo-keywords.md` → `08-research-serp.md` → `11-write-blog-post.md` → `16-publish-to-webflow.md` |
+| `organic-content/ai-visibility` | `references/playbooks/organic-content/05-check-ai-visibility.md` → `04-audit-seo-keywords.md` |
+| `organic-content/social-cadence` | `references/playbooks/organic-content/12-generate-social-posts.md`; for posting, hand off to the [`linkedin`](../linkedin), [`instagram`](../instagram), and [`tiktok`](../tiktok) skills |
+| `community/reddit` | `references/playbooks/community/07-find-reddit-threads.md` → `13-draft-reddit-replies.md`; for deeper mining, the [`reddit`](../reddit) skill |
+| `paid-ads/meta` | Delegate: [`meta-ads-library`](../meta-ads-library) (competitor scan) → [`ad-creative-generation`](../ad-creative-generation) (copy + images) → [`meta-ads`](../meta-ads) (build the paused campaign) |
+| `paid-ads/google` | `references/playbooks/organic-content/04-audit-seo-keywords.md` → [`ad-creative-generation`](../ad-creative-generation) → [`google-ads`](../google-ads) (build the paused campaign) |
+| `monitoring/recurring-tasks` | `references/playbooks/monitoring/tasks.md` |
+
+Deeper channel research also delegates: [`seo-research`](../seo-research) for keyword/SERP depth beyond the audit docs, [`competitor-intel`](../competitor-intel) for full competitor monitoring, [`customer-research`](../customer-research) for voice-of-customer mining, [`analytics-insights`](../analytics-insights) for GA4/GSC/GTM work, [`email-lifecycle`](../email-lifecycle) for lifecycle email.
+
+## How to execute a slug
+
+1. Look up the slug in the routing table. Read the listed reference docs in order — each has a "When to use" block at the top so you can confirm fit before running. Where a step delegates to a channel skill, load that skill and follow it; the CMO file conventions in this skill still apply to the artifacts.
+2. Run the steps in sequence. Where one step's output becomes another's input (SERP brief → blog post, copy variants + images → Meta campaign), respect the order.
+3. Surface artifacts to the user as you go. Do not wait until the end of the workflow to attach files or report findings.
+4. If a required integration is missing (Meta Business not connected for `paid-ads/meta`, Webflow not connected for the publish step, etc.), stop the workflow at the gating step and surface the gap. Do not skip steps that depend on the missing integration.
+
+## Composed workflow: Full Brand Audit
+
+Run before the decision layer synthesises a plan:
+
+1. `research/foundation` → starts from `cmo_get_brand_data` for the current CMO brand; if the brand is missing or stale, run `cmo_collect_brand_data({"url": "https://..."})` before producing the foundation files (`product-brief.md`, `brand-identity.md`, `competitors.md`, plus tracking notes)
+2. `references/playbooks/organic-content/04-audit-seo-keywords.md` + `05-check-ai-visibility.md` → produces `seo-geo-audit.md`
+3. `references/playbooks/community/07-find-reddit-threads.md` (read-only — no replies yet) → contributes to `social-intel.md`
+4. Competitor ad scan via the [`meta-ads-library`](../meta-ads-library) skill (read-only — no campaign yet) → contributes to `social-intel.md` and the ads section of `competitors.md`
+
+After step 4, return to the decision layer to write `/files/cmo/{domain}/plan.md`. The execution layer does not emit a plan.
+
+## Self-Update Checklist (after research)
+
+Mandatory after running `research/foundation` plus the audit-side organic and paid steps. Do not just present findings in chat — create the files, attach them to the agent, and confirm each one.
+
+| File | Contents | Source steps |
+|------|----------|--------------|
+| `product-brief.md` | Product name, tagline, summary, features, ICP, brand voice, value props, CTA patterns, proof points | `research/01-scrape-brand-profile.md` |
+| `brand-identity.md` | Colors, typography, logo, brand personality, visual asset quality, consistency, positioning vs competitors | `research/01-scrape-brand-profile.md` + `research/03-research-competitors.md` |
+| `competitors.md` | Direct/adjacent/aspirational competitors with domains, traffic, keywords, messaging themes, gaps, ad strategies, market segments, differentiation | `research/03-research-competitors.md` + the `meta-ads-library` skill |
+| `seo-geo-audit.md` | Current rankings, keyword opportunities by cluster, competitive gap keywords, difficulty distribution, AI search volume, SEO health, recommendations | `organic-content/04-audit-seo-keywords.md` + `05-check-ai-visibility.md` |
+| `social-intel.md` | Reddit sentiment, pain points, high-engagement threads, community language, AI visibility scores, competitor ad activity, creative patterns, opportunities | `community/07-find-reddit-threads.md` + `organic-content/05-check-ai-visibility.md` + the `meta-ads-library` skill |
+| `marketing-dashboard` *(conditional)* | Live performance dashboard with panels for each connected integration (GSC queries/rankings, GA4 traffic/conversions, Meta/Google Ads spend+ROAS) | Built only if at least one of GSC / GA4 / Meta / Google Ads is connected. |
+
+Each file should contain real data, real URLs, real numbers — never placeholder text or invented metrics.
+
+Use the CMO brand store before running one-off collectors. First call `cmo_get_brand_data` with no arguments to get the current agent's brand, business context, competitors, socials, search visibility, and context files. Do not re-derive what is already in the business context. Run `cmo_collect_brand_data` only when that data is missing/stale or the user asks for a refresh. The SEO, community, and ad-library steps are execution-specific enrichment, not replacements for the CMO brand store.
+
+After the files are created, attach them in one call:
+
+```
+agents_update_context(
+  agent_id=YOUR_AGENT_ID,
+  resource_type="file",
+  op="add",
+  ids=[product_brief_id, brand_identity_id, competitors_id, seo_geo_audit_id, social_intel_id]
+)
+```
+
+Brand assets should come from `cmo_get_brand_data` when available. If creative-quality logo/screenshot references are missing, use the Firecrawl fallback in `references/playbooks/research/01-scrape-brand-profile.md` and attach the resulting assets in the same `agents_update_context` call.
+
+## Tools and integrations
+
+The execution layer expects a baseline toolkit set: `sandbox` (file ops), `firecrawl_toolkit` (scraping), `hyperseo` (keyword + SERP data). The other suggested toolkits matter per workflow — `meta_business` / `meta_ads_library` for `paid-ads/meta`, `google_ads` for `paid-ads/google`, `webflow_toolkit` for the publish step, `reddit_scraper` for community work, etc.
+
+Inspect available tools at the start of a workflow. If a step's required toolkit is not connected, stop at the gating step and surface the gap rather than hallucinating. Don't ask the user "what's connected" — check yourself.
+
+## Important
+
+- Honest scope: the execution layer researches and executes. It does not derive ICP, pick goals, or pick channels. Those belong to the decision layer.
+- Paid campaigns are always built **paused**. The user reviews and launches manually. The `meta-ads` and `google-ads` skills enforce this too.
+- Reddit replies are always drafted, never auto-posted. The user posts manually.
+- Every artifact gets attached to the agent — chat-only output is not enough.

--- a/skills/gtm/references/playbooks/community/07-find-reddit-threads.md
+++ b/skills/gtm/references/playbooks/community/07-find-reddit-threads.md
@@ -1,0 +1,59 @@
+# Find Reddit Threads
+
+Discover high-signal Reddit threads where the ICP discusses problems the brand solves. These are engagement opportunities — not spam targets.
+
+## When to use
+
+Read this when the gtm decision layer routes to `community/reddit`, or during a Full Brand Audit to populate `social-intel.md`. Inputs: ICP and product summary from `01-scrape-brand-profile.md`, plus any keyword cluster from `04-audit-seo-keywords.md`. Output is a ranked list of threads that becomes the input to `13-draft-reddit-replies.md`.
+
+## What You Get
+
+- **Filtered thread list** — title, URL, subreddit, upvotes, match reason
+- **Sorted by engagement** — highest upvotes first
+- **Capped at 20** — quality over quantity, but enough to see patterns
+
+## Choosing Keywords and Subreddits
+
+Keywords from the confirmed brief:
+- ICP pain points ("how to automate ad reporting")
+- Category terms ("ai marketing agent")
+- Problem language ("managing multiple ad platforms")
+
+Subreddits based on the ICP:
+- SaaS/tech: r/SaaS, r/startups, r/entrepreneur
+- Marketing: r/marketing, r/PPC, r/digital_marketing
+- Industry-specific: whatever subreddit the ICP frequents
+
+## Tool Calls
+
+```
+scrape_reddit_leads(
+  searches=[
+    {"keyword": "{ICP pain point}", "subreddit": "{target_sub}"},
+    {"keyword": "{category term}", "subreddit": "{target_sub}"},
+    {"keyword": "{category term}"}
+  ],
+  hours_back=720,
+  search_posts=True,
+  search_comments=False,
+  sort="relevance",
+  max_items=15
+)
+```
+
+Use 720 hours (30 days) as default — 168 (1 week) is too narrow for most categories. Include at least one search without a subreddit filter for global discovery. Use `"relevance"` sort to find the most topical threads, not just the newest.
+
+**Response shape:** Results come back in an `items` array. Each item has `matched_keyword`, `matched_subreddit`, `type` ("post" or "comment"), `title`, `text`, `url`, `community`, `upvotes`, `comments_count`, `created_at`. Filter on `type == "post"`.
+
+## Filtering
+
+- Posts only (`type == "post"`) — comments show `title` as "Comment on: N/A" and are harder to engage with
+- Upvotes >= 3 — signal that the community cares (5 is too high for niche subs)
+- Deduplicate by URL
+- Sort by upvotes descending
+
+## Failure Modes
+
+- **Reddit returns nothing:** The category might not have Reddit presence, or the keywords are too specific. Broaden the keywords or try adjacent subreddits.
+- **All results are old:** Increase `hours_back` from 168 (1 week) to 720 (1 month). If still nothing, the category doesn't have active Reddit discussion. Note this honestly.
+- **Results are off-topic:** The keywords are too generic. Use more specific ICP language from the confirmed brief.

--- a/skills/gtm/references/playbooks/community/13-draft-reddit-replies.md
+++ b/skills/gtm/references/playbooks/community/13-draft-reddit-replies.md
@@ -1,0 +1,41 @@
+# Reddit Reply Drafting
+
+Draft 5-8 replies to high-signal threads from `07-find-reddit-threads.md`. Each reply targets a different thread — cover the top threads by engagement.
+
+## When to use
+
+Read this only after `07-find-reddit-threads.md` has produced a ranked thread list. Always part of the `community/reddit` workflow. Inputs: thread list, brand voice from `01-scrape-brand-profile.md`. Output is human-quality replies the user reviews and posts manually (the agent does not auto-post — Reddit etiquette).
+
+## The Test
+
+A good Reddit reply works even if the product name were removed. If removing the product mention makes the reply useless, it's an ad, not a reply.
+
+## Rules
+
+- Under 300 words
+- Answer the actual question being asked
+- No sales language
+- No fake personal experience ("I've been using X for months and...")
+- No CTA unless it fits organically
+- Mention the product only as context, never as a pitch
+- Match subreddit norms and tone
+
+## Format
+
+For each reply:
+```
+Thread: [title]
+URL: [url]
+Why this matters: [connection to ICP pain]
+Reply:
+[draft text]
+```
+
+## Tone Calibration
+
+- r/marketing → practitioner-level, tactical, specific
+- r/entrepreneur → builder-mindset, real numbers, no hype
+- r/SaaS → operator-focused, understated, product-aware
+- General subreddits → conversational, helpful, zero promotional energy
+
+Present drafts for user approval. Do not post automatically.

--- a/skills/gtm/references/playbooks/monitoring/tasks.md
+++ b/skills/gtm/references/playbooks/monitoring/tasks.md
@@ -1,0 +1,110 @@
+# Tasks — built-in recurring tasks for the CMO agent
+
+Tasks turn the agent from a one-shot research tool into a live marketing operator. They run on a schedule, pull from integrations the user has connected, and deliver results to wherever the user wants them.
+
+> Proposed from `strategy/recurring-schedules.md` based on the primary channel in `plan.md`. That reference stores the strategy-level task tables and data-boundary rules; this file remains the monitoring task catalog of record (full schemas, setup prompts, output formats).
+
+## When to use
+
+Read this whenever the gtm decision layer routes to `monitoring/recurring-tasks`, or after the confirmed-brief step when the user is ready to set up scheduled work (Daily Campaign Report, weekly competitive intel, etc.). Tasks are disabled by default — offer them, don't auto-enable. Each task lists the integrations it needs; if a required integration isn't connected, surface that as an `open_question` in the strategy plan rather than enabling the task blind.
+
+All tasks are **disabled by default**. Offer them after the confirmed-brief step. If a task requires an integration the user doesn't have, don't offer it — say what connecting it would unlock.
+
+---
+
+## 1. Weekly Performance Report
+
+**Requires:** at least one of GSC / GA4 / Meta Ads / Google Ads connected.
+
+**Default schedule:** Monday 9 AM (user's time zone)
+
+**Data sources:** Google Search Console, Google Analytics, Meta Ads, Google Ads, HyperSEO (whatever's connected).
+
+**Report structure:**
+
+1. Executive summary — biggest win, biggest concern, recommended action
+2. Channel performance — spend, conversions, CPA, ROAS per channel (WoW delta)
+3. SEO movement — queries gained/lost, ranking changes (GSC)
+4. Top-performing content — pages with highest traffic or conversions
+5. Recommendations — what to do this week
+
+**Output:** updates the persistent `marketing-dashboard` and delivers a weekly Markdown snapshot.
+
+**Setup prompt:** "Which channels should I include — all connected, or just some? Any metrics you care about more than others (default: CPA + ROAS)? Deliver to Slack, email, or just the dashboard?"
+
+---
+
+## 2. Social Media + Competitor Monitoring
+
+**Requires:** nothing (uses external scrapers).
+
+**Default schedule:** Wednesday 9 AM (user's time zone)
+
+**Data sources:** Reddit scraper, Twitter scraper, Meta Ads Library.
+
+**Report structure:**
+
+1. Hot Reddit threads — title, subreddit, upvotes, engagement opportunity
+2. Twitter/X trends — keyword discussions, thought-leadership openings
+3. Active competitor ads — new hooks, offers, creative patterns
+4. Recommended actions — threads to reply to, content angles, hooks to test
+
+**Output:** Markdown file + updates `social-intel.md`.
+
+**Setup prompt:** "Which Reddit communities should I monitor? Any specific Twitter keywords or competitors to track? Any ICP-specific phrases to scan for?"
+
+---
+
+## 3. Daily Campaign Report
+
+**Requires:** Meta Business or Google Ads connected, plus at least one active campaign.
+
+**Default schedule:** 8 AM daily (option to skip weekends).
+
+**Data sources:** Meta Ads, Google Ads, GA4 (for conversion attribution).
+
+**Report structure:**
+
+1. Spend yesterday vs prior day (WoW)
+2. Performance by campaign — impressions, CTR, CPC, conversions, ROAS
+3. Top ads by CTR and by ROAS
+4. **Fatigue flags** — any ad where CTR dropped ≥ 30% over a 7-day rolling window, CPM rose ≥ 25% with impressions still growing, or frequency > 3.0 on a prospecting audience
+5. Audience performance and overlap signals
+6. Recommended actions — pause / scale / refresh creative
+
+**Output:** Short Markdown digest delivered to Slack or email. Fatigue flags can also fire as real-time alerts (opt-in).
+
+**Setup prompt:** "Want this every morning, weekdays only, or only while a campaign is live? Which campaigns — all of them, or specific ones? Should fatigue flags also trigger real-time alerts, or just appear in the daily report?"
+
+---
+
+## 4. SEO + AI Search
+
+**Requires:** nothing is hard-required; GSC upgrades this significantly.
+
+**Default schedule:** Friday 9 AM (weekly).
+
+**What it does:**
+
+1. **Opportunity scan** — combine GSC queries ranking 5–15 (quick wins) with HyperSEO gap keywords and AI search volume. Surface the highest-impact opportunities ordered by difficulty × relevance.
+2. **AI search check** — run the brand and competitors through the AI visibility flow (per `playbooks/organic-content/05-check-ai-visibility.md`) and flag positioning gaps.
+3. **Content generation** — for the top 2–3 opportunities, draft blog posts (via `playbooks/organic-content/11-write-blog-post.md`) ready for review. Optional: publish to Webflow via `playbooks/organic-content/16-publish-to-webflow.md` when the user approves.
+
+**Output:** weekly opportunity report + draft blog posts attached to the thread.
+
+**Setup prompt:** "Focus on quick-win SEO positions, AI visibility gaps, or both? How aggressive on content — draft 1 post a week, 2–3, or just flag opportunities without drafting? Any topics to avoid?"
+
+---
+
+## How to create a task
+
+When the user opts in:
+
+1. Run through the setup prompt one question at a time.
+2. Confirm the final config back before creating.
+3. Use the scheduler to register the task with the confirmed cron + parameters.
+4. Tell the user where to find / modify / disable it later.
+
+## How to retire a task
+
+Any task must be disableable in one message. "Turn off the daily campaign report" should be enough — don't make the user hunt through settings.

--- a/skills/gtm/references/playbooks/organic-content/04-audit-seo-keywords.md
+++ b/skills/gtm/references/playbooks/organic-content/04-audit-seo-keywords.md
@@ -1,0 +1,143 @@
+# Audit SEO Keywords
+
+Build a keyword set of **at least 50 keywords** from multiple sources. SEO tools are the baseline — not the ceiling. The best keywords come from how real people talk about the problem right now.
+
+## When to use
+
+Read this when the gtm decision layer routes to `organic-content/seo-blog`, `organic-content/ai-visibility`, or `paid-ads/google`. Output (the keyword set) feeds `08-research-serp.md`, `11-write-blog-post.md`, and `the `google-ads` skill`. Skip if the user hands you a confirmed keyword list — accept it as the current truth and move on.
+
+## Round 1: SEO Tool Baseline (parallel)
+
+Start with 10-15 seeds from the confirmed brief:
+- Category terms
+- ICP job-to-be-done phrases
+- Top competitor names + "alternative"
+- Problem language from the confirmed brief
+
+```
+hyperseo_keyword_ideas(keywords=seeds, limit=30)
+hyperseo_ai_search_volume(keywords=seeds)
+hyperseo_domain_keywords(domain=DOMAIN, limit=20)
+hyperseo_backlinks_history(target=DOMAIN)
+hyperseo_domain_overview(domain=DOMAIN)
+```
+
+**Warning:** `hyperseo_keyword_ideas` often returns irrelevant results for niche or emerging categories (e.g., seeds about "ai marketing agent" returning "digital marketing agency nj"). Treat its output as a starting pool to filter, not a reliable list. The real value in Round 1 comes from `hyperseo_ai_search_volume` (shows which seeds have AI chatbot traffic) and `hyperseo_domain_keywords` (what the client already ranks for). For new/small domains, `hyperseo_domain_keywords` may return very few results — that's expected.
+
+## Round 2: Competitor Keyword Mining (parallel)
+
+Use the top 3-5 direct competitor domains from competitor research (03). **Only mine competitors with significant organic presence** — check the competitor research output for keyword counts. Domains with fewer than ~100 organic keywords will return nothing useful.
+
+```
+hyperseo_domain_keywords(domain="{established_competitor_1}", limit=20)
+hyperseo_domain_keywords(domain="{established_competitor_2}", limit=20)
+hyperseo_domain_keywords(domain="{established_competitor_3}", limit=20)
+```
+
+If all direct competitors are new/small domains (common in emerging categories), skip this round — the data won't be there. Web search (Round 3) and community mining (Round 4) become your primary sources instead.
+
+Extract keywords competitors rank for that the client doesn't. These are proven — someone is already getting traffic from them.
+
+## Round 3: Current Language from Web Search (6-8 queries)
+
+SEO tools have stale data. Find what people are searching for RIGHT NOW:
+
+```
+web_search(queries=[
+  "best {category} 2026",
+  "how to {ICP job-to-be-done}",
+  "{category} comparison",
+  "{category} for {ICP role}",
+  "new {category} tools",
+  "{category} workflow",
+  "{ICP problem} solution",
+  "{category} site:producthunt.com"
+], num_results=5)
+```
+
+Read the titles and descriptions of ranking pages. Extract:
+- Exact phrases used in titles (these are validated — they rank)
+- Category terms you didn't think of
+- New product names being mentioned alongside the category
+- Long-tail variants of your seeds
+
+## Round 4: Community Language Mining
+
+If Reddit research (07) has been run, go through the thread titles and top comments. Extract:
+- The exact words the ICP uses when describing their problem
+- Tool names and framework names being discussed
+- Emerging jargon ("MCP", "agent skills", "tool calling" — whatever the space calls things now)
+- Questions people ask (these become content keyword targets)
+
+If Reddit research hasn't been run yet:
+```
+web_search(queries=[
+  "{category} site:reddit.com",
+  "{ICP problem} site:reddit.com",
+  "what tools for {ICP job} site:reddit.com"
+], num_results=5)
+```
+
+Community language matters because people don't search the way SEO tools think they do. Someone doesn't search "marketing operations automation platform" — they search "how do I stop doing this manually" or "best Claude setup for marketing."
+
+## Round 5: Emerging and Adjacent Terms
+
+Search for what's new in the space. These keywords won't show volume in SEO tools yet but they're what the ICP is starting to search:
+
+```
+web_search(queries=[
+  "{category} site:news.ycombinator.com",
+  "{category} launched 2025 OR 2026",
+  "ai agents {industry} 2026",
+  "{adjacent_category} vs {category}"
+], num_results=5)
+```
+
+Extract product names, framework names, protocol names, and terminology that didn't appear in Rounds 1-4. These are your `trend` keywords.
+
+## Round 6: Search Intent Classification
+
+Take the top 15 keywords by volume:
+```
+hyperseo_search_intent(keywords=top_15)
+```
+
+## Compile and Tag
+
+Merge all keywords from Rounds 1-5. Deduplicate. You should have **at least 50 unique keywords**. If fewer, you haven't mined enough sources — go back to whichever rounds returned thin results and expand with more queries.
+
+Tag each keyword:
+
+| Tag | Criteria | Action |
+|-----|----------|--------|
+| `quick_win` | difficulty < 30, volume > 200 | Target immediately with content |
+| `big_bet` | difficulty >= 30, volume > 1000 | Long-term SEO investment |
+| `trend` | from Rounds 4-5, low/no SEO volume but discussed in communities | Get in early |
+| `competitor` | contains competitor name | Create comparison/alternative pages |
+| `brand` | contains brand/product terms | Monitor, don't target |
+| `supporting` | everything else | Use in content clusters |
+
+Group into clusters by intent:
+- **Problem-aware** — searcher knows the pain, not the solution
+- **Solution-aware** — searcher knows the category
+- **Comparison** — evaluating options
+- **Emerging** — new terms, frameworks, protocols with no established volume yet
+- **Brand** — product name searches
+
+## Quality Gates
+
+- **Minimum 50 keywords** after deduplication
+- **At least 4 clusters** represented
+- **At least 10 keywords from community/web sources** (Rounds 3-5) — not just SEO tool output
+- **At least 5 competitor-derived keywords** from Round 2
+- **At least 5 trend/emerging keywords** from Rounds 4-5
+
+If any gate fails, go back to the thin round and run more queries.
+
+## Cross-Pollination
+
+- **← From competitor research (03):** Competitor domains for mining, competitor names for comparison terms
+- **← From Reddit threads (07):** Exact language the ICP uses — these become seeds and trend keywords
+- **→ To blog post (11):** Quick-win keywords become blog topic candidates
+- **→ To ad copy (09):** High-CPC keywords show what competitors bid on
+- **→ To AI visibility (05):** Keywords with AI search volume go into visibility checks

--- a/skills/gtm/references/playbooks/organic-content/05-check-ai-visibility.md
+++ b/skills/gtm/references/playbooks/organic-content/05-check-ai-visibility.md
@@ -1,0 +1,74 @@
+# Check AI Visibility
+
+Determine whether the brand appears in AI-generated answers (ChatGPT, Perplexity, Claude, Gemini) for category-relevant queries. GEO = Generative Engine Optimization.
+
+## When to use
+
+Read this when the gtm decision layer routes to `organic-content/ai-visibility`, or when running a Full Brand Audit (always run alongside `04-audit-seo-keywords.md` so the keyword set has both classical-SEO and AI-search signal). Output feeds the AI-visibility section of `seo-geo-audit.md`, which the decision layer reads to recommend `organic_content` with the AI-visibility workflow.
+
+## What You Get
+
+- **Per-query mention status** — is the brand mentioned in AI answers for each query?
+- **Top sources cited** — which URLs do AI models cite instead?
+- **Visibility level** — high (4+ mentions), medium (2-3), low (0-1)
+- **Biggest gap** — the highest-volume query where the brand is NOT mentioned
+- **Who wins instead** — which competitors show up in AI answers
+
+## Step 1: Build Query Set (minimum 8 queries)
+
+Don't just use the seed keywords. Build queries from **at least 4 of these angles:**
+
+1. **Category "best of"** — "best {category}", "top {category} tools 2026"
+2. **Problem-solution** — "how to {solve the ICP's problem}", "what tool can {do the job}"
+3. **Comparison** — "{client} vs {competitor}", "is {client} worth it"
+4. **Recommendation** — "what {category} should I use", "recommend a {category}"
+5. **ICP-specific** — "best {category} for {ICP}", "{category} for agencies"
+6. **Use-case** — "tool for automating {specific task}", "how to {specific workflow}"
+
+## Step 2: Check AI Search Volume
+
+```
+hyperseo_ai_search_volume(keywords=all_queries)
+```
+
+Sort by AI search volume. Take the top 8 (or all of them if fewer than 8 have volume).
+
+## Step 3: Track Mentions (parallel)
+
+Run all in parallel:
+```
+hyperseo_track_mentions(query="{query_1}", brands=[brand_name, competitor_1, competitor_2, competitor_3])
+hyperseo_track_mentions(query="{query_2}", brands=[brand_name, competitor_1, competitor_2, competitor_3])
+...
+```
+
+Include the top 3 direct competitors from competitor research (03) in the `brands` array. This shows not just "are we mentioned" but "who gets mentioned instead."
+
+## Step 4: AI Overview
+
+```
+hyperseo_ai_overview(keyword="{top_category_keyword}")
+```
+
+Read what the AI overview says about the category. This is the narrative the AI models are telling searchers.
+
+## Quality Gates
+
+- **Minimum 8 queries checked.** Fewer means you're only testing one angle.
+- **Include competitor names in brand tracking.** "Are we mentioned?" is half the story. "Who IS mentioned?" is the other half.
+- **At least one "best of" query and one problem-solution query.** These are the two highest-value AI answer types.
+
+## Cross-Pollination
+
+- **← From keyword research (04):** Use the keywords with highest AI search volume as inputs
+- **← From competitor research (03):** Include competitor names in brand tracking
+- **→ To content strategy:** Queries where the brand is NOT mentioned but competitors ARE = content gaps to fill
+- **→ To positioning:** What the AI overview says about the category shapes how the brand should position
+
+## Failure Modes
+
+- **All queries return "not mentioned":** Normal for new brands. Map who IS mentioned — those are the AI visibility leaders to study and outperform with content.
+- **AI search volume is zero for everything:** Category doesn't have AI search traffic yet. Report honestly. This is an opportunity to be first.
+- **Track mentions returns partial model failures:** The tool queries multiple LLMs (GPT, Claude, Perplexity). Individual models may return errors (e.g., Perplexity 404). Report results from the models that succeeded and note which ones failed. Two out of three models responding is still useful data.
+- **`hyperseo_ai_overview` returns a service error:** This endpoint can be intermittent. If it fails, note it and move on — the `track_mentions` data is more valuable anyway.
+- **Track mentions returns errors for all models:** Tool may have rate limits or connectivity issues. Reduce to top 5 queries and retry with a short delay between calls.

--- a/skills/gtm/references/playbooks/organic-content/08-research-serp.md
+++ b/skills/gtm/references/playbooks/organic-content/08-research-serp.md
@@ -1,0 +1,37 @@
+# SERP Research
+
+Research what currently ranks for a keyword and where the content gaps are. Run this before writing any SEO content.
+
+## When to use
+
+Read this whenever the agent is about to write an SEO blog post (`11-write-blog-post.md`). Always runs after a target keyword has been picked from `04-audit-seo-keywords.md`. Output is a structured SERP brief (top URLs, content gaps, ranking patterns) that becomes the input to the blog writing step.
+
+## Workflow
+
+1. `hyperseo_serp_results(keyword=..., depth=10)` — get top 10 organic results
+2. `hyperseo_ai_overview(keyword=...)` — see how AI summarizes this topic
+3. `firecrawl_batch_scrape(urls=top_8, formats=["markdown"], only_main_content=True)` — read what ranks
+
+Scraping only 3 results gives you a keyhole view. You need 8-10 to see the actual patterns — what angles are saturated, what's missing, who dominates, and where the real gap is.
+
+## Gap Analysis
+
+From the scraped content, identify:
+
+- **What they all cover** — the commodity content every post includes. You need to cover this too, but it's not your angle.
+- **What they all repeat** — the lazy sections that get copy-pasted across listicles. Don't add to the pile.
+- **What's missing** — the specific question, use case, or depth that nobody addresses. This is your angle.
+- **What the AI overview gets wrong or oversimplifies** — opportunity for nuance that gets cited.
+- **Content format patterns** — are they all listicles? All how-tos? All comparisons? A different format is itself a gap.
+- **Freshness** — when were the top results published? Stale content (2024 or older) is easy to outrank with current information.
+
+## Output
+
+A writing brief with:
+- Target keyword + related terms
+- Top 8-10 URLs with publish dates and their angles (one line each)
+- AI overview summary and its gaps
+- Saturated angles (what NOT to write)
+- Missing angles and unanswered questions (at least 3)
+- Recommended article angle (the gap to exploit)
+- Suggested word count based on competitor lengths

--- a/skills/gtm/references/playbooks/organic-content/11-write-blog-post.md
+++ b/skills/gtm/references/playbooks/organic-content/11-write-blog-post.md
@@ -1,0 +1,38 @@
+# Blog Post Writing
+
+Write a 1,500-2,000 word SEO blog post targeting a specific keyword. Run after SERP research from `08-research-serp.md`.
+
+## When to use
+
+Read this when the gtm decision layer routes to `organic-content/seo-blog`, or as part of the always-on baseline (1 blog/week). Always runs after `08-research-serp.md` and (where it exists) `01-scrape-brand-profile.md` for voice. Output is a blog draft ready for review or for `16-publish-to-webflow.md`.
+
+## Structure
+
+- **H1** with keyword
+- **Hook paragraph** that earns the scroll — not a definition, not throat-clearing
+- **3-4 core sections** covering the gap brief
+- **Differentiated section** on what existing content misses (this is the angle)
+- **CTA** at the bottom, matched to the sales motion
+
+## Requirements
+
+- Keyword in H1, intro, one H2, and closing
+- Voice matches brand profile from `02_branding.md`
+- Angle matches confirmed ICP and goal
+- Include internal link suggestions
+- Meta description (155 chars) with keyword and a reason to click
+
+## Matching Sales Motion
+
+**Enterprise:** Longer, more technical, case-study-oriented. "How [Company] reduced X by Y%."
+
+**Self-serve:** Practical, tutorial-style, show the product in action. "How to do X in 5 minutes."
+
+**Community-led:** Opinionated, founder-voice, takes a position. "Why most X advice is wrong."
+
+## Anti-Patterns
+
+- "What is X?" intro when the SERP is saturated with definitions
+- Generic listicle when the gap brief shows a specific angle
+- Enterprise tone for a self-serve product (or vice versa)
+- Filler paragraphs that repeat the keyword without adding substance

--- a/skills/gtm/references/playbooks/organic-content/12-generate-social-posts.md
+++ b/skills/gtm/references/playbooks/organic-content/12-generate-social-posts.md
@@ -1,0 +1,40 @@
+# Social Post Generation
+
+Create a social content package: 5 X posts, 2 LinkedIn posts, 2 Instagram captions. Each post should have a distinct angle — not the same message reformatted.
+
+## When to use
+
+Read this when the gtm decision layer routes to `organic-content/social-cadence`, or as part of the always-on baseline (2-3 short social posts/week distilled from the weekly blog). Inputs: `01-scrape-brand-profile.md` (voice), the source angle (a blog post, campaign, or research thread). Output is the social content package the user can publish or feed into a scheduler.
+
+## Platform Rules
+
+### X / Twitter
+- Short, sharp, one idea per post
+- Strong opening line (it's the hook in a feed)
+- Low fluff, high signal
+- No hashtags unless genuinely useful
+
+### LinkedIn
+- 3-5 short paragraphs
+- Credibility framing and context first
+- Clear CTA or thought-starter at the end
+- Can be longer and more structured
+
+### Instagram
+- Hook in the first line (caption gets truncated)
+- Simpler wording than LinkedIn
+- Up to 5 relevant hashtags
+- Visual context should complement the caption
+
+## Writing Priorities
+
+1. Confirmed goal
+2. Confirmed ICP
+3. Brand voice from `02_branding.md`
+4. Current campaign angle or keyword
+
+## Key Rule
+
+Each platform gets a **different angle**. Do not reformulate the same thought three times. The X posts should each be distinct from each other and from the LinkedIn post.
+
+If optimizing for leads, social should still fit the platform. A LinkedIn post that reads like an ad gets scrolled past.

--- a/skills/gtm/references/playbooks/organic-content/16-publish-to-webflow.md
+++ b/skills/gtm/references/playbooks/organic-content/16-publish-to-webflow.md
@@ -1,0 +1,31 @@
+# Webflow Publishing
+
+Publish approved content to a Webflow CMS collection as a draft.
+
+## When to use
+
+Read this only after a blog post (or other content artifact) is fully drafted and approved, and the brand uses Webflow as its CMS (check `02-audit-website-tracking.md`). Always the final step of `organic-content/seo-blog`. Skip if the brand is on Ghost, WordPress, etc., and surface that as an `open_question` in the strategy plan.
+
+## Workflow
+
+1. `webflow_list_sites()` — find the target site
+2. `webflow_list_collections(site_id=...)` — find the blog collection
+3. `webflow_get_collection_fields(site_id=..., collection_id=...)` — inspect actual field schema
+4. Create draft: `webflow_create_collection_item_proxy(..., is_draft=True)`
+5. Share preview with user
+6. Only publish live if user confirms
+
+## Field Mapping
+
+Map to actual collection field names from step 3. Do not assume field names. Common fields:
+- Title → name field
+- Slug → slug field
+- Body → rich text field
+- Summary → plain text field
+- Main image → image field
+
+## Non-Negotiable
+
+- Always create as draft first
+- If the site is not on Webflow, stop and say so
+- Do not guess field names — read the schema

--- a/skills/gtm/references/playbooks/research/00-client-intake.md
+++ b/skills/gtm/references/playbooks/research/00-client-intake.md
@@ -1,0 +1,53 @@
+# Client Intake (Pipeline Kickoff)
+
+The research-pipeline kickoff: turn a website URL into the inputs that the rest of the `research/` group needs. The *decision* layer (which integration bucket the workspace is in, which channels to recommend) is no longer here — that lives in the gtm decision layer.
+
+## When to use
+
+Read this whenever the agent is starting a fresh research pipeline (Full Brand Audit, or any time the cached research files are stale). Always the first step of `research/foundation`.
+
+## What this step does
+
+This is a thin entry point. Its only job is to:
+
+1. Capture what the user already provided (URL, ICP hints, known competitors, channel preferences, off-platform channels they're already running, constraints).
+2. Verify a usable URL.
+3. Hand off to `01-scrape-brand-profile.md`, then `02-audit-website-tracking.md`, then `03-research-competitors.md` in that order.
+
+## What this step does NOT do
+
+- It does not classify the workspace into "Fully connected / Partially connected / Disconnected" — the gtm decision layer does that, after the research files exist, when picking a channel.
+- It does not propose channels — the gtm decision layer does that.
+- It does not auto-enable monitoring tasks — those are offered after the confirmed brief, see `playbooks/monitoring/tasks.md`.
+
+## Inputs to capture from the user (or from previous turn context)
+
+| Field | Source |
+|---|---|
+| `website_url` | User-provided. Required. |
+| `known_competitors` | User-provided if any; otherwise leave empty and let `03-research-competitors.md` find them. |
+| `existing_off_platform_channels` | User-provided list of channels the user is already running off-platform (warm/cold outreach, affiliate program, partner referrals). The strategy skill uses this to emit `advisory` plan steps. |
+| `constraints` | Free-form (e.g., "no Reddit", "no paid social", regulatory category). |
+| `goals` | Free-form. The strategy skill prefers to derive these from the research files, but accepts user-stated goals as truth. |
+
+## Output
+
+A `client_intake_brief` object passed forward into the rest of the `research/` group:
+
+```json
+{
+  "website_url": "https://example.com",
+  "known_competitors": ["competitor-a.com", "competitor-b.com"],
+  "existing_off_platform_channels": ["affiliates_referrals"],
+  "constraints": ["regulated industry: healthcare"],
+  "goals": ["leads"]
+}
+```
+
+That's it. The brand profile, tracking audit, and competitor research live in the next three docs in this folder.
+
+## Important
+
+- If the user gave a URL with no other context, that's enough — proceed to `01-scrape-brand-profile.md` immediately and do not nag for more inputs.
+- If the URL is unreachable or returns a 4xx/5xx, stop and surface that to the user before wasting tool calls.
+- The integration-bucket logic that used to live in this doc has moved to the gtm decision layer (SKILL.md). Don't re-introduce it here.

--- a/skills/gtm/references/playbooks/research/01-scrape-brand-profile.md
+++ b/skills/gtm/references/playbooks/research/01-scrape-brand-profile.md
@@ -1,0 +1,56 @@
+# Scrape Brand Profile
+
+Extract product identity, brand assets, and voice from the canonical CMO brand store or, when needed, from a website URL. This is the foundation — everything downstream depends on this being right.
+
+## When to use
+
+Read this when running the `research/foundation` group (first step of a Full Brand Audit, or any time the brand has changed positioning and the cached profile is stale). Always check `cmo_get_brand_data` first. If the brand data is missing/stale, run `cmo_collect_brand_data({"url": URL})` to refresh the canonical profile before using fallback one-off scrapers. This step feeds `02-audit-website-tracking.md` and `03-research-competitors.md`.
+
+## What You Get
+
+- **Product name, tagline, summary** — extracted from page copy
+- **CTA patterns** — normalized labels (book_demo, start_free, contact_sales)
+- **Voice** — tone, sentence style, vocabulary level, proof style, personality traits
+- **Brand assets** — logo file_id, screenshot file_id, OG image file_id (if available)
+- **Colors and typography** — from Firecrawl branding extraction
+
+## Tool Calls
+
+Preferred canonical flow:
+
+```
+cmo_get_brand_data()
+```
+
+If no current brand is attached, or if the user provided a new URL/explicit refresh request:
+
+```
+cmo_collect_brand_data(url=URL)
+```
+
+Use direct Firecrawl only as a fallback for one-off creative asset extraction when canonical CMO data does not include usable logo/screenshot references:
+
+```
+firecrawl_extract_branding(url=URL)
+firecrawl_scrape_url(url=URL, formats=["markdown"], only_main_content=True)
+```
+
+From canonical CMO data or fallback scraped copy, extract product name, tagline, summary, CTA patterns, and voice. If fallback copy is too thin, scrape 2-3 sub-pages (pricing, features, about) if visible in the homepage to get richer copy for voice analysis.
+
+## Voice Extraction
+
+Do not guess voice from the company name or logo. Analyze actual copy:
+
+- **Tone** — direct, casual, technical, aspirational, etc.
+- **Sentence style** — short imperatives, long explanatory, mixed
+- **Vocabulary** — technical jargon, plain language, operator-first
+- **Proof style** — product demos, ROI claims, social proof, case studies
+- **Energy** — low/measured vs high/urgent
+
+Read the homepage hero, subheads, pricing page CTA text, and proof sections. Voice is how they actually write, not what their brand guidelines say.
+
+## Failure Modes
+
+- **Firecrawl returns empty markdown:** Page might block scraping or use heavy client-side rendering. Try `firecrawl_scrape_url` with `wait_for=5000` to wait for JS. If still empty, note it and move on with branding data only.
+- **No OG image:** Common. Skip it, note "not available" in the brand file.
+- **ai_function returns generic voice:** The input copy is probably too short. Scrape 2-3 sub-pages (pricing, features, about) and re-run with more text.

--- a/skills/gtm/references/playbooks/research/02-audit-website-tracking.md
+++ b/skills/gtm/references/playbooks/research/02-audit-website-tracking.md
@@ -1,0 +1,34 @@
+# Audit Website Tracking
+
+Check what tracking pixels, CMS, and performance infrastructure a site has. Determines paid campaign readiness and SEO baseline.
+
+## When to use
+
+Read this in the `research/foundation` group, immediately after `01-scrape-brand-profile.md`. Its output (Meta Pixel present? GA4 connected? CMS = Webflow?) gates several downstream choices: whether `paid-ads/meta` is plausible, whether `playbooks/organic-content/16-publish-to-webflow.md` will work, and whether the gtm decision layer should flag missing tracking as an `open_question`.
+
+## What You Get
+
+- **Tracking pixels** — Meta Pixel ID, GTM ID, LinkedIn Insight Tag, Twitter Pixel, TikTok Pixel, Hotjar
+- **Tech stack** — framework, CMS, hosting
+- **Page speed** — performance score, LCP, FCP, CLS
+- **Launch readiness** — paid ready (has pixel), SEO ready (speed score >= 60), tracking score
+
+## Tool Calls
+
+Run in parallel:
+
+```
+analyze_website(url="https://{DOMAIN}")
+hyperseo_pagespeed(url="https://{DOMAIN}", strategy="mobile")
+```
+
+`analyze_website` returns tracking pixels (Meta Pixel, GTM, LinkedIn, Twitter/X, TikTok, Hotjar), CMS, detected technologies (frameworks like Next.js, Tailwind), quality signals (SSL, mobile viewport, clear CTA, contact info, social links), and a tracking score.
+
+Most sites redirect apex to www (or vice versa), so both calls return the same data. Only call both variants if the first one returns no pixels and you suspect a redirect issue.
+
+## Failure Modes
+
+- **Both variants return no pixels:** Could be GTM loading pixels dynamically after page render. Note it, ask the user to confirm their pixel setup manually.
+- **Page speed returns null:** Domain might be behind a WAF or CDN that blocks Lighthouse. Note "unable to measure" rather than guessing.
+- **CMS not detected:** Common for custom builds (Next.js, Nuxt, etc.). Report the framework instead.
+

--- a/skills/gtm/references/playbooks/research/03-research-competitors.md
+++ b/skills/gtm/references/playbooks/research/03-research-competitors.md
@@ -1,0 +1,148 @@
+# Competitor Research
+
+Find real competitors through the canonical CMO brand store first, then multiple rounds of search from different sources only when the stored data is insufficient. One round of web_search is never enough — each round reveals names and terms that inform the next round.
+
+## When to use
+
+Read this in the `research/foundation` group, after `01-scrape-brand-profile.md`. Start with `cmo_get_brand_data().market_research.direct_competitors` and `cmo_get_brand_data().search_visibility.competitors`. Run the additional web/SEO research below only when current brand data has too few competitors, looks stale, or lacks enough detail for the specific playbook. The output (`competitors.md` artifact) is consumed by the gtm decision layer's offer-first gate, the channel-fit diagnostic, and several execution flows: `the `meta-ads-library` skill` (look up the actual competitor pages), `playbooks/organic-content/04-audit-seo-keywords.md` (gap keywords), and `playbooks/organic-content/08-research-serp.md` (top-ranking competitor URLs).
+
+## Canonical Seed
+
+```
+brand = cmo_get_brand_data()
+```
+
+Use:
+
+- `brand.market_research.direct_competitors` for rich competitor records
+- `brand.search_visibility.competitors` for SERP-discovered competitor domains
+- `brand.market_research.category_terms` and `brand.market_research.search_queries` as query seeds
+
+If those fields are empty or stale, refresh with `cmo_collect_brand_data(url=brand.url)` before running extra search rounds.
+
+## Round 1: ICP-Shaped Search (8-10 queries, parallel)
+
+Generate queries the buyer would actually type. Use at least 5 of these angles:
+
+1. **Pain language** — "how to automate ad reporting without hiring"
+2. **Job-to-be-done** — "ai marketing agent for small teams"
+3. **Category + modifier** — "ai marketing automation platform", "autonomous marketing tool"
+4. **Comparison intent** — "best {category} 2026", "{category} comparison"
+5. **Problem + solution shape** — "stop manually creating ad creatives", "one tool for all marketing channels"
+6. **ICP-specific** — "marketing tool for solo founder", "agency campaign management platform"
+
+```
+web_search(queries=[all 8-10], num_results=5)
+hyperseo_competitors_domain(domain=DOMAIN, limit=15)
+hyperseo_competitors(keywords=[top 3-4 category terms], limit=15)
+```
+
+**Warning about SEO competitor tools:** For new or small domains (fewer than ~50 organic keywords), `hyperseo_competitors_domain` returns platforms like YouTube, LinkedIn, Instagram — not actual competitors. `hyperseo_competitors` (keyword-based) is slightly better but still noisy. For new brands, web search does the heavy lifting. Don't rely on SEO tools alone.
+
+Collect every product name and domain from the results. Filter out platforms (YouTube, LinkedIn, Reddit, Google, Facebook, Instagram), review sites, listicles, blogs, educational sites, and the client's own domain.
+
+## Round 2: Discovery Platforms (4-6 queries, parallel)
+
+The first round finds who SEO knows about. This round finds what's emerging.
+
+```
+web_search(queries=[
+  "{category} site:producthunt.com",
+  "{category} site:news.ycombinator.com",
+  "{category} launched 2025 OR 2026",
+  "new {category} tools",
+  "{category} alternatives site:reddit.com",
+  "{ICP role} tools stack 2026"
+], num_results=5)
+```
+
+Extract any new product names that didn't appear in Round 1.
+
+## Round 3: Expand from Findings (3-5 queries)
+
+Take the top 3-5 product names discovered in Rounds 1 and 2. Search for THEIR competitors and alternatives:
+
+```
+web_search(queries=[
+  "{discovered_product_1} alternatives",
+  "{discovered_product_2} vs",
+  "{discovered_product_3} competitors",
+  "tools like {discovered_product_4}",
+  "{discovered_product_5} alternative"
+], num_results=5)
+```
+
+This catches products that don't rank for the category term but compete head-to-head with the products that do. Each round expands the map.
+
+## Round 4: Community Verification
+
+If Reddit research (07) has been run, scan the thread titles and comments for product names that didn't surface in web search. People mention tools in discussions that never appear in SEO results — new tools, niche tools, frameworks, open-source projects.
+
+If Reddit research hasn't been run yet, do a quick:
+
+```
+web_search(queries=[
+  "{category} site:reddit.com",
+  "what {category} do you use site:reddit.com"
+], num_results=5)
+```
+
+## Classification
+
+After all rounds, you should have 15-40 candidate products. Classify each:
+
+
+| Classification       | Definition                                                               |
+| -------------------- | ------------------------------------------------------------------------ |
+| **Direct**           | Same problem, same ICP. The buyer evaluates these side by side.          |
+| **Adjacent**         | Nearby job or slightly different buyer. Shows up in same conversations.  |
+| **Aspirational**     | Market reference that shapes expectations but isn't a direct substitute. |
+| **Not a competitor** | Platforms, listicles, blogs, marketplaces → discard.                     |
+
+
+**Minimum bar:** At least 5 direct competitors identified. If fewer than 5 after 4 rounds of search, the category is genuinely emerging — say so and ask the user who they encounter in the market.
+
+## Tiered Enrichment
+
+**Direct competitors (top 5):** Full scrape.
+
+```
+firecrawl_batch_scrape(urls=[competitor homepages + pricing pages], formats=["markdown"], only_main_content=True)
+```
+
+For each, extract:
+
+- Positioning statement (hero copy)
+- Pricing model and price points
+- Key features they lead with
+- Who they target (read CTA patterns, case studies)
+- Strengths vs the client
+- Weaknesses
+- Gap the client can exploit
+
+**Adjacent (3-5):** One paragraph each from search snippets. What they do, how they differ, why the ICP encounters them.
+
+**Aspirational (0-2):** One sentence. Who they are and what expectation they set.
+
+## Trust Hierarchy
+
+1. **User says "we lose deals to X"** → highest trust. Always include as direct.
+2. **Multiple search rounds surface X** → high trust.
+3. **Only one round found X** → moderate trust. Verify with a follow-up search.
+4. **SEO overlap tools say X** → moderate trust. Often returns platforms.
+5. **The website says "alternative to X"** → useful but could be aspirational.
+
+## Cross-Pollination
+
+- **→ Keyword research (04):** Competitor names become seeds ("{competitor} alternative", "{competitor} vs"). Competitor domains become inputs for keyword mining.
+- **→ Ad library (06):** Direct competitor names become search queries.
+- **→ AI visibility (05):** Competitor names go into brand tracking.
+- **→ ICP expansion:** If competitors target audiences the client hasn't considered, flag it in the report.
+
+## When Discovery Fails
+
+Don't pad with loosely related tools. Instead:
+
+1. Report what you found and how many rounds you ran
+2. Ask: "Who do you actually encounter in deals or see mentioned by your target customers?"
+3. The user's answer overrides all search results

--- a/skills/gtm/references/strategy/always-on-content.md
+++ b/skills/gtm/references/strategy/always-on-content.md
@@ -1,0 +1,39 @@
+# Weekly Cadence
+
+Most brands should keep a small weekly rhythm going while the main plan runs.
+
+## When to use
+
+Read this before writing the `## Weekly cadence` section in `plan.md`.
+
+## Default rhythm
+
+Use this unless the user has said no:
+
+- Write one useful long-form post each week.
+- Turn that post into two or three short social posts.
+- Join one useful community conversation each week, if a good community exists.
+
+This is not meant to be a huge content machine. It is the basic work that keeps the brand visible.
+
+## When to change it
+
+Increase the cadence only when content is the main focus and the brand can keep quality high.
+
+Reduce or skip it when:
+
+- the user says no
+- the team cannot support it
+- the offer is being rewritten and the user wants all attention there
+
+## How to write it in the plan
+
+Write normal sentences:
+
+```md
+## Weekly cadence
+
+Publish one useful article each week and turn it into two or three short posts. Use the article topics from the SEO or community research. If a strong Reddit or forum thread appears, draft one helpful reply for review.
+```
+
+Do not write object-like lines such as `channel=...`, `action=...`, or `success_metric=...` in `plan.md`.

--- a/skills/gtm/references/strategy/channel-fit-diagnostic.md
+++ b/skills/gtm/references/strategy/channel-fit-diagnostic.md
@@ -1,0 +1,73 @@
+# Choosing Where To Focus
+
+Use this when the best next step is not obvious.
+
+## When to use
+
+Read this before writing or revising `plan.md`.
+
+Work through the checks in order. Stop when you have a clear answer.
+
+## 1. Check whether the offer is clear
+
+Read the brand files and competitor notes.
+
+Recommend fixing the offer first when:
+
+- the homepage does not clearly say who the product is for
+- the outcome is vague
+- competitors say almost the same thing
+- traffic exists but very few visitors convert
+
+If this is the issue, say it plainly:
+
+```text
+The offer needs work before we spend on more traffic.
+```
+
+## 2. Check whether content is the right focus
+
+Content is usually the right focus when:
+
+- people search for the problem or category
+- competitors rank for useful searches and the brand does not
+- the brand needs stronger pages that explain the product
+- paid measurement is missing
+
+Use the SEO blog workflow when search data supports it.
+
+Use the AI-answer visibility workflow only when a file or tool actually measured AI answers. If nothing measured it, say the measurement is missing.
+
+## 3. Check whether community is the right focus
+
+Community is usually the right focus when:
+
+- the audience talks about the problem in one visible place
+- the threads are specific and useful
+- the brand can join with helpful answers
+- competitors are not already owning the conversation
+
+Use the Reddit workflow only when Reddit is actually the useful place.
+
+## 4. Check whether ads are the right focus
+
+Ads are usually the right focus when:
+
+- the offer is clear
+- Meta or Google Ads is connected
+- tracking is good enough to know what happened
+- the brand or competitors show signs that ads can work
+
+Do not recommend ads as the first focus when ad tools and measurement are missing.
+
+## 5. If nothing is clear
+
+Default to content.
+
+It is useful, low-risk, and creates pages and posts the brand can use later. Make the measurement gap clear instead of pretending the data exists.
+
+## What to cite
+
+Every recommendation should cite the files or dashboard panels that led to it.
+
+If there is no supporting file or panel, reread the inputs before writing the plan.

--- a/skills/gtm/references/strategy/channels.md
+++ b/skills/gtm/references/strategy/channels.md
@@ -1,0 +1,62 @@
+# Places To Focus
+
+The plan should usually choose one place to focus first.
+
+## When to use
+
+Read this when choosing the focus for `plan.md`, or when explaining why a user-suggested option should wait.
+
+## Content
+
+Use content when the brand needs useful pages and posts that explain the product.
+
+Good fits:
+
+- people search for the problem
+- competitors rank for searches the brand should own
+- the brand needs more trust before ads or outreach will work
+- measurement tools are missing and the safest useful move is to publish helpful material
+
+Useful workflows:
+
+- `organic-content/seo-blog`
+- `organic-content/ai-visibility`
+- `organic-content/social-cadence`
+
+Use the AI-answer visibility workflow only when AI answers were actually checked or the task is to set up that check.
+
+## Community
+
+Use community when the audience already talks about the problem in a visible place.
+
+Good fits:
+
+- useful Reddit or forum threads exist
+- the brand can answer without sounding salesy
+- the community is specific enough to matter
+
+Useful workflow:
+
+- `community/reddit`
+
+## Ads
+
+Use ads when the brand is ready to spend and can measure the result.
+
+Good fits:
+
+- the offer is clear
+- Meta Ads or Google Ads is connected
+- tracking is good enough
+- there is evidence that the audience buys through ads
+
+Useful workflows:
+
+- `paid-ads/meta`
+- `paid-ads/google`
+
+## Work that should wait
+
+Do not start warm outreach, cold outreach, affiliates, or referrals from this skill.
+
+Mention them only when the user says they already run them and the detail changes the recommendation. If they matter, put a short note under `## Not doing now`.

--- a/skills/gtm/references/strategy/concentration.md
+++ b/skills/gtm/references/strategy/concentration.md
@@ -1,0 +1,47 @@
+# Focus Before Adding More
+
+Small teams usually get better results by doing one useful thing well before adding more channels.
+
+## When to use
+
+Read this when:
+
+- the plan is spreading effort across too many things
+- the user asks to run several channels at once
+- the brand has several audiences or offers and the message is getting vague
+- you are deciding whether to add another channel
+
+## What to recommend
+
+Pick:
+
+- one audience to speak to first
+- one place to focus first
+- one offer to lead with
+- one product or plan to sell first
+
+This is advice, not a hard rule. If the user wants a broader plan, explain the trade-off once and then write the plan they asked for.
+
+## How to say it
+
+Use plain language:
+
+```text
+I recommend focusing on content first. The brand is not visible for the searches competitors already rank for, and splitting effort across ads, content, and community would slow the first useful result.
+```
+
+If the user wants two channels:
+
+```text
+We can do content and ads together. The trade-off is that each one gets less attention, so we should review results in a month and keep the one that is working.
+```
+
+## When to add another channel
+
+Add another channel when the first one is showing a real signal:
+
+- content is bringing useful search traffic
+- ads are producing measured results
+- community work is bringing replies, visits, signups, or sales conversations
+
+If there is no signal yet, keep the second channel under `## Not doing now` if it matters.

--- a/skills/gtm/references/strategy/offer-first.md
+++ b/skills/gtm/references/strategy/offer-first.md
@@ -1,0 +1,41 @@
+# Make The Offer Clear First
+
+If people cannot quickly understand what the brand sells and why it matters, more traffic will not fix the real problem.
+
+## When to use
+
+Read this when the brand may have an offer or message problem.
+
+Common signs:
+
+- the page does not clearly name the customer
+- the outcome is vague
+- the call to action is unclear
+- competitors say almost the same thing
+- the brand gets traffic but very few people convert
+
+## What to recommend
+
+Say the problem plainly:
+
+```text
+The offer needs work before we spend on more traffic.
+```
+
+Then explain why using the files or dashboard panels you read.
+
+Recommend one next step:
+
+- rewrite the headline and main offer
+- make the customer and outcome clear
+- make the call to action consistent
+- compare the new message against the closest competitors
+
+Keep the weekly cadence only if it will not distract from fixing the offer.
+
+## What to avoid
+
+- Do not recommend more traffic when the brand cannot convert the traffic it already has.
+- Do not dress this up with internal labels.
+- Do not invent conversion data. If conversion tracking is missing, say it is missing.
+- If the user still wants ads or another channel, explain the risk once and then write the plan around their choice.

--- a/skills/gtm/references/strategy/recurring-schedules.md
+++ b/skills/gtm/references/strategy/recurring-schedules.md
@@ -1,0 +1,255 @@
+# Scheduled Tasks
+
+Use scheduled tasks when the CMO should keep checking or drafting something over time.
+
+## When to use
+
+Read this after `plan.md` is written, or when the user asks what the CMO can keep doing.
+
+Do not copy task proposals or schedule details into `plan.md`.
+
+Task state belongs in:
+
+- chat, while asking for approval
+- the task sidebar, after tasks are created
+- `/files/cmo/{domain}/status.md`, as a short record
+
+## Scheduling rules
+
+Before adding a task:
+
+1. Decide whether the task is actually useful.
+2. Check which tools the task needs.
+3. Check whether those tools are connected.
+4. Ask the user to approve the task.
+5. If tools are missing, create the task inactive or ask the user to connect the tools first.
+
+Use only supported `agents_schedule` arguments:
+
+- `agent_id`
+- `instructions`
+- `cron` or `run_at`
+- `timezone`
+- `name`
+- `active`
+
+Do not pass unsupported fields.
+
+Start the task instructions with:
+
+```text
+Tools needed: ...
+```
+
+If a needed tool is missing, the instructions must tell the scheduled run to stop and report what is missing.
+
+## How to ask the user
+
+Keep the message short:
+
+```text
+I suggest adding a weekly SEO scan and a Monday blog draft task. The blog draft needs HyperSEO and Firecrawl. Approve these, or tell me what to change.
+```
+
+Do not paste a long task list into chat unless the user asks for details.
+
+## Housekeeping
+
+Use this for every CMO brand after onboarding.
+
+Name: Daily CMO housekeeping
+
+When: daily at 08:30
+
+Tools needed: agents, read_file, edit_file
+
+What it does:
+
+- reads `status.md`, `business_context.md`, and `plan.md`
+- checks active schedules
+- flags stale, duplicate, risky, or expensive tasks
+- updates the operating notes in `status.md`
+
+It must not start paid work or spend money.
+
+## Content tasks
+
+Use these when content is the focus or when the brand needs a basic weekly cadence.
+
+Name: SEO keyword setup
+
+When: once, next business morning
+
+Tools needed: HyperSEO
+
+What it does: creates the first keyword cluster table.
+
+Output: `seo/keywords.md`
+
+Workflow: `organic-content/04-audit-seo-keywords`
+
+Name: SEO weekly scan
+
+When: Fridays at 09:00
+
+Tools needed: HyperSEO. Better with Search Console and Analytics.
+
+What it does: finds the best search and content opportunities for next week.
+
+Output: `seo/opportunities.md`
+
+Workflow: `organic-content/04-audit-seo-keywords`
+
+Name: Weekly blog draft
+
+When: Mondays at 10:00
+
+Tools needed: HyperSEO and Firecrawl
+
+What it does: drafts one post from the best approved topic. It does not publish.
+
+Output: draft attached for review
+
+Workflow: `organic-content/seo-blog`
+
+Name: AI answer check
+
+When: monthly
+
+Tools needed: HyperSEO or another tool that actually checks AI answers
+
+What it does: checks whether AI answer engines mention the brand and competitors.
+
+Output: short update in the research notes
+
+Workflow: `organic-content/ai-visibility`
+
+Do not claim AI answer results unless this task or another cited source actually measured them.
+
+## Social and community tasks
+
+Name: Weekly social post pack
+
+When: Mondays at 09:00
+
+Tools needed: none
+
+What it does: drafts short posts from the weekly content or latest plan.
+
+Output: five to seven draft posts for manual review
+
+Workflow: `organic-content/social-cadence`
+
+Name: Competitor and social scan
+
+When: Wednesdays at 09:00
+
+Tools needed: none. Better with Reddit or ad-library tools.
+
+What it does: checks what competitors and relevant communities are talking about.
+
+Output: update to `social-intel.md`
+
+Name: Reddit thread scan
+
+When: Tuesdays and Thursdays at 09:00
+
+Tools needed: Reddit scraper
+
+What it does: finds useful Reddit threads worth answering.
+
+Output: ranked thread list
+
+Workflow: `community/reddit`
+
+Name: Reddit reply drafts
+
+When: Tuesdays and Thursdays at 14:00
+
+Tools needed: Reddit scraper
+
+What it does: drafts helpful replies for selected threads. It does not post.
+
+Output: reply drafts for review
+
+Workflow: `community/reddit`
+
+## Ads tasks
+
+Use these only when ad tools and measurement are connected, or create them inactive until the tools are connected.
+
+Name: Daily campaign check
+
+When: weekdays at 08:00
+
+Tools needed: Meta Ads or Google Ads
+
+What it does: checks spend, results, and signs that ads need new creative.
+
+Output: short campaign note
+
+Name: Weekly performance note
+
+When: Mondays at 09:00
+
+Tools needed: one connected measurement source, such as Search Console, Analytics, Meta Ads, or Google Ads
+
+What it does: summarizes what changed, what worked, what is concerning, and what to do next.
+
+Output: weekly snapshot
+
+Name: Competitor ad scan
+
+When: Wednesdays at 09:00
+
+Tools needed: Meta ad-library access
+
+What it does: reviews competitor ads for hooks, offers, and creative ideas.
+
+Output: update to `social-intel.md`
+
+Name: Creative refresh draft
+
+When: Fridays at 10:00
+
+Tools needed: image generation. Better with ad-library access.
+
+What it does: drafts ad copy and image ideas for review.
+
+Output: copy and image concepts
+
+Name: Paused Meta campaign build
+
+When: once, next business morning
+
+Tools needed: Meta Ads and image generation
+
+What it does: builds a paused campaign for review. It does not launch.
+
+Output: paused campaign
+
+Workflow: `paid-ads/meta`
+
+Name: Paused Google campaign build
+
+When: once, next business morning
+
+Tools needed: Google Ads and HyperSEO
+
+What it does: builds a paused search campaign for review. It does not launch.
+
+Output: paused campaign
+
+Workflow: `paid-ads/google`
+
+## Outreach and referral work
+
+Do not start outreach or referral programs from this skill.
+
+If the user says they already run warm outreach, cold outreach, affiliates, or referrals, you may suggest a light review or reminder task. Ask first and keep the task inactive if the needed tools are missing.
+
+## Example schedule instruction
+
+```text
+Tools needed: HyperSEO and Firecrawl. If either tool is missing, stop and tell the user what is missing. Run the weekly blog draft workflow for example.com. Pick the approved topic from seo/opportunities.md, draft one post, and attach it for review. Do not publish.
+```

--- a/skills/hyper-cli/SKILL.md
+++ b/skills/hyper-cli/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: hyper-cli
 description: Use the Hyper CLI to run Hyper marketing skills from a terminal. Use when the user wants to use `hyperai`, inspect live tool schemas, translate MCP tool names from a skill into CLI commands, switch connected accounts, or run marketing tools outside an MCP-native agent host.
+use_cases:
+  - Run Hyper marketing skills from a terminal
+  - Inspect live tool schemas from the CLI
+  - Trace and debug Hyper tool calls locally
+triggers:
+  - hyperai
+  - hyper cli
+  - cli
+suggested_toolkits:
+  - sandbox
 ---
 
 # Hyper CLI

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -1,6 +1,23 @@
 ---
 name: image-generation
 description: Choose the right image generation tool through the Hyper MCP — OpenAI (gpt-image-2), Nano Banana (Gemini), Seedream (ByteDance via fal.ai) — for ad creatives, branded compositions, text-heavy assets, photorealistic product shots, image-to-image edits, and high-resolution output. Use when the user asks to generate an image, create an ad creative, do an image-to-image edit, render text inside an image, or produce a print-quality poster.
+use_cases:
+  - Generate images with AI
+  - Create ad creatives with text
+  - Image-to-image generation
+  - Style transfer
+  - High-resolution image production
+triggers:
+  - image
+  - generate image
+  - create image
+  - ad creative
+  - image with text
+requires_toolkits:
+  - image_gen
+suggested_toolkits:
+  - file_manager
+  - firecrawl
 ---
 
 # Image Generation

--- a/skills/instagram/SKILL.md
+++ b/skills/instagram/SKILL.md
@@ -1,6 +1,30 @@
 ---
 name: instagram
 description: Manage Instagram professional accounts via the Hyper MCP — publish photos, Reels, Stories, and carousels; moderate comments and mentions; send Direct Messages; pull account and media insights. Uses the Instagram API with Instagram Login (Business Login). Use when the user mentions Instagram posts, Reels, Stories, carousels, IG DMs, Instagram comments, mentions, profile, or analytics. For paid Instagram advertising, use `meta-ads`.
+use_cases:
+  - Post photos, Reels, Stories, and carousels to Instagram
+  - Manage Instagram Direct Messages
+  - Moderate comments on Instagram posts
+  - Get Instagram account and media insights
+  - View Instagram profile and media library
+  - Reply to Instagram mentions and tags
+triggers:
+  - instagram post
+  - post to instagram
+  - instagram dm
+  - instagram message
+  - instagram comment
+  - instagram insights
+  - instagram analytics
+  - instagram profile
+  - instagram story
+  - instagram reel
+  - instagram carousel
+requires_toolkits:
+  - instagram_toolkit
+suggested_toolkits:
+  - file_manager
+  - sandbox
 ---
 
 # Instagram

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -1,6 +1,26 @@
 ---
 name: linkedin
 description: Publish and manage LinkedIn content via the Hyper MCP — text posts, article / link previews, document and PDF posts, organization (company page) posts, and AI-generated text-to-carousel posts. Use when the user wants to post on LinkedIn, share an article on LinkedIn, post to a LinkedIn company page, upload a PDF / document to LinkedIn, or build a LinkedIn carousel from text.
+use_cases:
+  - Post a text update to LinkedIn
+  - Share a website link on LinkedIn with explicit article metadata
+  - Post to a LinkedIn company page
+  - Upload a PDF or document to LinkedIn
+  - Create a LinkedIn carousel from text content
+  - Manage LinkedIn posting flows for agents
+triggers:
+  - linkedin post
+  - post to linkedin
+  - linkedin carousel
+  - linkedin article
+  - linkedin document
+  - linkedin company page
+requires_toolkits:
+  - linkedin_toolkit
+suggested_toolkits:
+  - file_manager
+  - image_gen
+  - sandbox
 ---
 
 # LinkedIn

--- a/skills/meta-ads-library/SKILL.md
+++ b/skills/meta-ads-library/SKILL.md
@@ -1,6 +1,31 @@
 ---
 name: meta-ads-library
 description: Research competitor Facebook and Instagram ads from the Meta Ads Library via the Hyper MCP — search by keyword, pull full ad creative and metadata, enrich with page contact info for lead generation, and surface structured ad-intelligence summaries in chat. Use when the user wants to scrape the Meta Ads Library, spy on competitor ads, monitor new ads in a category, build a lead list from advertisers, or surface creative trends across an industry.
+use_cases:
+  - Research competitor Facebook and Instagram ads
+  - Scrape the Meta Ads Library for ad creative inspiration
+  - Import ad library data into database tables for analysis
+  - Build ad research databases from Meta Ads Library results
+  - Analyze competitor ad strategies with SQL queries
+  - Track ad trends across industries or keywords
+  - Enrich ad data with page contact information
+  - Pipe scraped ad results into structured tables
+  - Compare ad creatives across competitors
+  - Monitor new ads in a category over time
+triggers:
+  - meta ads library
+  - facebook ads library
+  - competitor ads
+  - ad research
+  - ad scraping
+  - scrape ads
+  - import ads
+  - ad spy
+  - ad library
+requires_toolkits:
+  - meta_ads_library
+suggested_toolkits:
+  - hyper_database
 ---
 
 # Meta Ads Library

--- a/skills/meta-ads/SKILL.md
+++ b/skills/meta-ads/SKILL.md
@@ -1,6 +1,34 @@
 ---
 name: meta-ads
 description: Plan and create Meta (Facebook + Instagram) advertising campaigns end-to-end via the Hyper MCP, defaulting to Advantage+ automation. Use when the user wants to launch Meta ads, Facebook ads, Instagram ads, Advantage+ campaigns, carousel ads, dynamic creative ads, set up Meta conversion tracking, or build Meta performance dashboards. Also triggers on phrases like meta campaign, facebook campaign, advantage+, or meta blueprint.
+use_cases:
+  - Create Meta Ads campaigns
+  - Create Facebook ads
+  - Create Instagram ads
+  - Configure Advantage+ campaigns
+  - Upload Meta ad creative media
+  - Preview Meta ad creatives
+  - Analyze Meta ad performance
+  - Build Meta Ads dashboards
+  - Query cached Meta insights data
+  - Set up carousel and dynamic creative ads
+triggers:
+  - meta ads
+  - facebook ads
+  - instagram ads
+  - meta campaign
+  - facebook campaign
+  - instagram campaign
+  - advantage+
+  - meta dashboard
+  - facebook dashboard
+requires_toolkits:
+  - meta_ads
+suggested_toolkits:
+  - firecrawl
+  - file_manager
+  - hyper_database
+  - sandbox
 ---
 
 # Meta Ads
@@ -390,3 +418,12 @@ The workflow is complete when:
 3. The user has given explicit approval to activate.
 
 Only then call `meta_business_update_campaign(campaign_id="<id>", status="ACTIVE")` to go live. Never activate without this confirmation.
+
+## Beyond campaign creation
+
+| Task | Reference |
+| --- | --- |
+| Full account audit (structure, performance, ad sets, creatives, recommendations) | `references/account-audit.md` |
+| Cached insights, 90-day ad-level insights, dashboard workflow | `references/insights-and-dashboards.md` |
+| Competitor ad research in the Meta Ad Library | [`meta-ads-library`](../meta-ads-library) |
+| Generating ad creatives and copy variants | [`ad-creative-generation`](../ad-creative-generation) |

--- a/skills/meta-ads/references/account-audit.md
+++ b/skills/meta-ads/references/account-audit.md
@@ -1,0 +1,78 @@
+
+# Meta Account Audit
+
+This skill guides you through a comprehensive Meta Ads account audit.
+
+## Step 1: Account Overview
+
+Start by fetching account-level data:
+
+1. Use `meta_get_ad_accounts` to list all ad accounts
+2. For each account, note the spend limits, timezone, and currency
+3. Check account status and any restrictions
+
+## Step 2: Campaign Structure Review
+
+For each account:
+
+1. Use `meta_get_campaigns` to list all campaigns
+2. Group campaigns by objective:
+   - Awareness campaigns
+   - Traffic campaigns
+   - Conversion campaigns
+   - Lead generation campaigns
+3. Note naming conventions and organization
+
+## Step 3: Performance Analysis
+
+Pull performance data for the last 30 days:
+
+1. Use `meta_get_insights` with date range for account-level metrics
+2. Key metrics to capture:
+   - Total spend
+   - Impressions and reach
+   - Click-through rate (CTR)
+   - Cost per result (CPR)
+   - Return on ad spend (ROAS)
+
+## Step 4: Ad Set Analysis
+
+For top-spending campaigns:
+
+1. Use `meta_get_adsets` to get ad set details
+2. Review targeting settings:
+   - Audience sizes
+   - Age/gender targeting
+   - Interest and behavior targeting
+   - Lookalike audiences
+3. Check budget distribution
+
+## Step 5: Creative Review
+
+For top ad sets:
+
+1. Use `meta_get_ads` to list all ads
+2. Review creative types in use:
+   - Static images
+   - Videos
+   - Carousels
+   - Dynamic creative
+3. Check ad fatigue (frequency > 3)
+
+## Step 6: Recommendations
+
+Based on findings, provide:
+
+1. **Quick Wins**: Changes that can be made immediately
+2. **Structural Changes**: Longer-term improvements
+3. **Testing Opportunities**: New approaches to try
+
+## Output Format
+
+Create a summary report with:
+- Executive summary
+- Key metrics table
+- Top/bottom performing campaigns
+- Prioritized recommendations
+
+Consider using the sandbox to create a visualization dashboard if requested.

--- a/skills/meta-ads/references/insights-and-dashboards.md
+++ b/skills/meta-ads/references/insights-and-dashboards.md
@@ -1,0 +1,59 @@
+# Meta Insights Caching and Dashboards
+
+## Cached Insights Usage
+
+- Use the integration-scoped table shown in toolkit context.
+- Start with simple SQL slices (daily trend, campaign breakdown, ad set breakdown).
+- Prefer cached analytics for reporting and dashboarding; use API endpoints when cache is missing or user needs uncached fields.
+
+## 90-Day Ad-Level Insights
+
+When the user needs historical ad-level performance, first query the ad account insights edge with `level: "ad"` instead of asking for a manual export or iterating every ad ID.
+
+```json
+{
+  "object_id": "act_123456789",
+  "object_type": "account",
+  "level": "ad",
+  "date_preset": "last_90d",
+  "include_actions": true
+}
+```
+
+- Use `time_increment: "1"` only when daily rows are needed for delivery dates or dormancy checks.
+- Use `object_type: "ad"` only for a shortlisted individual ad drilldown.
+- Do not claim Meta only supports 7 days unless the actual API response says so.
+
+## Dashboard Workflow (Preset First)
+
+When the user asks for a Meta dashboard or performance report:
+
+1. **Use cached data context first**
+   - Read the Meta context block for table name and last sync info.
+   - Query cached data via `hyper_data_sql`.
+   - Do not start with direct Meta API fetches when cache exists.
+
+2. **Check dashboard templates before custom building**
+   - Call `hyper_data_list_dashboard_templates`.
+   - If a suitable preset exists (for example `meta_business_performance`), use it:
+
+   `hyper_data_build_dashboard` with:
+   ```json
+   {
+     "name": "Meta Performance Dashboard",
+     "template_id": "meta_business_performance"
+   }
+   ```
+
+3. **Only build custom dashboards if needed**
+   - Use the Hyper Database dashboard/data app reference when the user asks for
+     non-preset metrics or a special layout.
+   - Pass SQL through `sql_data_sources` with explicit `scalar` or `rows`
+     shapes; do not embed raw SQL placeholders in UI props.
+   - Keep custom dashboards focused on the user question.
+
+4. **Cache refresh policy**
+   - Data syncs automatically every 30 minutes.
+   - If data is stale or the user requests fresh data, call `meta_business_sync` with no parameters.
+   - This is a background refresh. Do not wait for completion.
+   - If no cached data exists yet, you may use the Meta API tools directly as a fallback.

--- a/skills/openai-ads/SKILL.md
+++ b/skills/openai-ads/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: openai-ads
+description: Manage OpenAI Ads campaigns end-to-end — auth, account discovery, image upload, chat_card creative, status flow, and insights — using the openai_ads toolkit. Use when the user wants to launch or manage ads inside ChatGPT, upload chat_card creatives, or pull OpenAI Ads insights.
+use_cases:
+  - Create OpenAI Ads campaigns, ad groups, and ads
+  - Upload ad images and reference them in creatives
+  - Manage status (active / paused / archived) at every level
+  - Pull performance insights at account, campaign, ad group, and ad level
+  - Refresh and inspect a cached snapshot of the account
+triggers:
+  - openai ads
+  - openai advertiser
+  - chatgpt ads
+  - openai ad campaign
+  - openai ad group
+  - openai ad
+  - chat card ad
+  - openai ads insights
+requires_toolkits:
+  - openai_ads
+suggested_toolkits:
+  - hyper_database
+  - sandbox
+  - file_manager
+---
+
+# OpenAI Ads Campaigns
+
+Strategic guide for managing the OpenAI Advertiser API. All operations go
+through `https://api.ads.openai.com/v1`. One bearer API key is scoped to
+exactly one ad account, so all "list ad accounts" patterns from other ad
+platforms collapse into "fetch the connected account."
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **OpenAI Ads toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Critical Rules
+
+> **CRITICAL**: All money values on inputs are **integer micros**.
+> $1.00 = 1_000_000 micros. $50/day = 50_000_000. The `daily_spend_limit_micros`
+> minimum is `1_000_000` ($1). The ad group `max_bid_micros` is capped at
+> `100_000_000` ($100). Insights responses use plain floats in account
+> currency (NOT micros).
+
+> **CRITICAL**: Always create campaigns, ad groups, and ads with
+> `status="paused"`. Surface what was created to the user, then activate
+> using the dedicated activate endpoint.
+
+> **CRITICAL**: Ads have an extra `review_status` field set by OpenAI's
+> review process. New ads enter `in_review`. They WILL NOT serve until
+> `review_status="approved"` even if `status="active"`. Watch for
+> `review_status="rejected"` and surface the reason to the user.
+
+> **CRITICAL**: To create an ad you need a `file_id`. Always upload the
+> image first via `openai_ads_upload_image`, then pass the returned
+> `file_id` to `openai_ads_create_ad`. PNG, 1024x1024, ≤ 1 MB.
+
+> **CRITICAL**: When updating an ad's creative, you must pass ALL FOUR
+> fields together: `title`, `body`, `target_url`, `file_id`. Partial
+> creative updates are not supported by the API.
+
+> **CRITICAL**: One API key = one ad account. There is no "list ad accounts"
+> endpoint. `openai_ads_get_ad_account` returns the single account this key
+> is scoped to.
+
+> **IMPORTANT**: The only creative type today is `chat_card`. The only
+> billing event is `impression`. Don't try other values; they will be
+> rejected.
+
+> **IMPORTANT**: Limits are per-creative: `title` max 50 chars, `body` max
+> 100 chars, `name` 3-1000 chars. Validate before calling.
+
+## Phase 1: Account Discovery
+
+Run these in parallel after connect:
+
+```
+openai_ads_get_ad_account()
+openai_ads_list_campaigns(limit=100)
+```
+
+The connect-time context builder may have already populated a cached
+snapshot. Prefer:
+
+```
+openai_ads_get_cache()
+```
+
+If `success=False` because the cache is empty, refresh once:
+
+```
+openai_ads_refresh_cache()
+```
+
+Note the account `id`, `currency_code`, `timezone`. Every subsequent
+budget you propose should be in that currency expressed in micros.
+
+## Phase 2: Plan & Confirm
+
+Before creating anything, confirm with the user:
+
+- Objective in plain language ("install Hyper", "downloads", "subscribe").
+- Daily and/or lifetime budget in account currency.
+- Target geos (`countries` is the simplest knob: ISO-2 codes like `["US", "GB"]`).
+- Any geo exclusions.
+- Headline (`title`, ≤ 50 chars), body (≤ 100 chars), click-through URL.
+- One image asset (PNG, 1024x1024, ≤ 1 MB) — either a public URL or a base64 blob.
+- Max bid in micros (`max_bid_micros` — start small, e.g. `2_000_000` = $2 CPM).
+- Optional: `context_hints` — short natural-language phrases that describe
+  when the ad should show. e.g. `["users asking about marketing automation"]`.
+
+If anything is missing, ask. Do not invent budgets, geos, or copy.
+
+## Phase 3: Build the Hierarchy
+
+```
+Ad Account (one per API key)
+└── Campaign (budget, geo targeting, dates)
+    └── Ad Group (max bid, billing event, context hints)
+        └── Ad (chat_card creative, file_id, copy, target_url)
+```
+
+### 1. Create the Campaign (PAUSED)
+
+```
+openai_ads_create_campaign(
+    name="Hyper - US Test",
+    status="paused",
+    daily_spend_limit_micros=50_000_000,           # $50/day
+    targeting_country_codes=["US"],
+    description="Initial pilot",
+)
+```
+
+**Budget rules:**
+- At least one of `daily_spend_limit_micros` or `lifetime_spend_limit_micros` must be set.
+- Daily minimum is `1_000_000` ($1).
+- If you set `start_time` / `end_time`, both are unix epoch seconds.
+
+### 2. Create the Ad Group (PAUSED)
+
+```
+openai_ads_create_ad_group(
+    campaign_id="CAMPAIGN_ID",
+    name="US - Marketing Operators",
+    status="paused",
+    max_bid_micros=2_000_000,                      # $2 max bid
+    context_hints=[
+        "user is asking about ad automation",
+        "user wants to scale paid acquisition",
+    ],
+)
+```
+
+`billing_event_type` defaults to `"impression"` — the only currently
+supported value.
+
+### 3. Upload the Image
+
+```
+openai_ads_upload_image(image_url="https://cdn.example.com/asset.png")
+# OR
+openai_ads_upload_image(
+    image_base64=BASE64_BLOB,
+    filename="card.png",
+    content_type="image/png",
+)
+```
+
+Capture the returned `file_id`.
+
+### 4. Create the Ad (PAUSED)
+
+```
+openai_ads_create_ad(
+    ad_group_id="AD_GROUP_ID",
+    name="US - Marketing - Variant A",
+    title="Run ads on autopilot",                   # ≤ 50 chars
+    body="Hyper builds, ships, and optimizes ads for you.",  # ≤ 100 chars
+    target_url="https://hyperfx.ai?utm_source=openai_ads",
+    file_id=FILE_ID_FROM_UPLOAD,
+    status="paused",
+)
+```
+
+The response includes `review_status`. Surface it.
+
+## Phase 4: Review and Activate
+
+After the user reviews the paused tree:
+
+```
+openai_ads_activate_campaign(campaign_id=CID)
+openai_ads_activate_ad_group(ad_group_id=AGID)
+openai_ads_activate_ad(ad_id=AID)
+```
+
+Activation only takes effect at the ad level once `review_status="approved"`.
+Poll `openai_ads_get_ad(ad_id=...)` if you need to confirm review state.
+
+## Phase 5: Insights
+
+Insights endpoints are server-aggregated. Pass:
+
+- `time_granularity`: `"hour"`, `"day"`, `"week"`, `"month"`, `"all_time"`.
+- `aggregation_level`: `"ad_account" | "campaign" | "ad_group" | "ad"`.
+- `time_ranges`: list of inclusive ISO date ranges, e.g.
+  `["2026-05-01..2026-05-07"]`.
+- `fields`: list of metric + dimension keys, e.g.
+  `["spend", "clicks", "impressions", "ctr", "cpc", "cpm", "campaign_id", "campaign_name"]`.
+- `filters`: list of `key=value` strings, e.g. `["campaign_id=cmp_xxx"]`.
+- `sort`: e.g. `["spend desc"]`.
+
+Money values in insights responses are floats in the account currency
+(NOT micros).
+
+```
+openai_ads_get_ad_account_insights(
+    time_granularity="day",
+    aggregation_level="campaign",
+    time_ranges=["2026-05-01..2026-05-07"],
+    fields=["spend","clicks","impressions","ctr","cpc","campaign_id","campaign_name"],
+    sort=["spend desc"],
+)
+```
+
+For a single campaign use `openai_ads_get_campaign_insights(campaign_id=...)`,
+similar for ad groups and ads.
+
+## Status Flow
+
+`paused` ⇄ `active` → `archived` (irreversible) at every level
+(campaign, ad group, ad). Use the dedicated tools — do not pass
+status changes through `update_*`.
+
+| Tool | Effect |
+|---|---|
+| `openai_ads_activate_*` | Sets status to `active` |
+| `openai_ads_pause_*` | Sets status to `paused` |
+| `openai_ads_archive_*` | Sets status to `archived` (final) |
+
+Ads also have:
+- `review_status="in_review"` (default) — not delivering yet.
+- `review_status="approved"` — eligible to deliver.
+- `review_status="rejected"` — needs a new creative.
+
+## Cache Snapshot
+
+The connect-time context builder writes a snapshot of the account into
+`integration.toolkit_settings["openai_ads_cache"]`. Use:
+
+- `openai_ads_get_cache()` for cheap read-only access (campaigns, ad groups, ads, account, last-7d insights).
+- `openai_ads_refresh_cache()` to refresh it (account + campaigns + ad groups + ads + insights).
+
+Refresh sparingly — once per session is plenty unless something feels stale.
+
+## Pagination
+
+All list endpoints use cursor pagination:
+
+- `limit` (default 20, max 100).
+- `after` / `before`: pass the previous response's `last_id` / `first_id`.
+- `order`: `"asc"` | `"desc"`.
+
+Responses include `has_more` — keep paging only when true and only when
+you actually need everything.
+
+## Health Check
+
+After connecting, run `openai_ads_health_check()`. It returns:
+
+```
+{ "connected": true, "ad_account": {...} }
+```
+
+If `connected=false`, the API key is missing/invalid/expired. Tell the
+user to regenerate from the Ads Manager (Settings → API).
+
+## Safety Rules
+
+**Never:**
+- Pass dollar amounts directly. All money inputs are micros.
+- Activate a campaign / ad group / ad without explicit user approval.
+- Skip the image upload step — `openai_ads_create_ad` needs a real `file_id`.
+- Update creative fields partially. Pass all four (`title`, `body`, `target_url`, `file_id`) together.
+- Try a creative `type` other than `"chat_card"` or a `billing_event_type` other than `"impression"` — both are rejected.
+- Assume an ad is delivering just because `status="active"`. Always check `review_status`.
+- Treat `archive` as reversible. It's not.
+- Promise paid traffic on a brand-new ad. New ads sit in `review_status="in_review"` until OpenAI approves them.

--- a/skills/pinterest-ads/SKILL.md
+++ b/skills/pinterest-ads/SKILL.md
@@ -1,6 +1,28 @@
 ---
 name: pinterest-ads
 description: Plan and create Pinterest Ads campaigns through the Hyper MCP — Awareness, Consideration, Video View, Web Conversion, Catalog Sales, and Web Sessions objectives — with strict microcurrency budgeting, CBO rules, audience and customer-list management, conversion tag handling, keyword targeting, and campaign analytics. Use when the user mentions Pinterest ads, Pinterest campaign, Pinterest ad group, Pinterest audience, Pinterest conversion tracking, Pinterest tag, or Pinterest customer list.
+use_cases:
+  - Create Pinterest ad campaigns
+  - Manage Pinterest ad groups and ads
+  - Set up audience targeting
+  - Track conversions with Pinterest tags
+  - Manage customer lists for targeting
+  - Analyze campaign performance
+  - Send conversion events
+triggers:
+  - pinterest ads
+  - pinterest campaign
+  - pinterest ad group
+  - pinterest audience
+  - pinterest conversion
+  - pinterest tag
+  - pinterest customer list
+requires_toolkits:
+  - pinterest_ads
+suggested_toolkits:
+  - hyper_database
+  - sandbox
+  - file_manager
 ---
 
 # Pinterest Ads

--- a/skills/polymarket-trading/SKILL.md
+++ b/skills/polymarket-trading/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: polymarket-trading
+description: Trade on Polymarket prediction markets with a safe workflow and risk management. Use when the user wants to browse markets, check prices, place or close positions on Polymarket, or review their prediction-market portfolio.
+use_cases:
+  - Trade on Polymarket
+  - Find prediction markets
+  - Check Polymarket portfolio
+  - Analyze market odds
+  - Buy/sell prediction shares
+triggers:
+  - polymarket
+  - prediction market
+  - betting
+  - market odds
+requires_toolkits:
+  - polymarket_toolkit
+suggested_toolkits:
+  - system_web_toolkit
+---
+
+# Polymarket Trading
+
+Guide for trading on Polymarket prediction markets. Polymarket is a decentralized prediction market on Polygon.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Polymarket toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Important: Time Sensitivity
+
+**Prediction markets are time-sensitive!**
+- Check if market end_date has passed or is imminent
+- Consider how much time remains for events to occur
+- Markets about past events have already been resolved
+- Always verify current date context
+
+## Getting Fresh News
+
+For news-driven trading, ALWAYS use real-time sources:
+1. **Web Search** - Use `web_search` with time filters like "last hour" or "today"
+2. **X/Twitter** - Check trending topics and breaking news
+3. Cross-reference multiple sources for accuracy
+4. Be skeptical of cached/old results
+
+## Tool Categories
+
+### Market Discovery (Read-Only)
+
+| Tool | Use Case |
+|------|----------|
+| `polymarket_get_trending_markets` | Find what's hot RIGHT NOW (volume in last N minutes) |
+| `polymarket_search_events` | Find events by topic (events contain related markets) |
+| `polymarket_get_event` | Get specific event by ID or URL slug |
+| `polymarket_search_markets` | Find individual markets by keyword |
+| `polymarket_get_markets` | Browse top markets by liquidity/volume |
+| `polymarket_get_market` | Get details for specific market by ID |
+| `polymarket_get_market_by_slug` | Get market directly by URL slug |
+
+**Events vs Markets:**
+- **Events** are top-level objects (e.g., "Super Bowl 2026")
+- **Markets** are individual outcomes within events (e.g., "Will Chiefs win?")
+- Use `search_events` first for discovery, then explore markets within events
+
+### Trading Analysis
+
+| Tool | Use Case |
+|------|----------|
+| `polymarket_get_order_book` | See bid/ask depth for a token |
+| `polymarket_get_price` | Get current price (BUY or SELL side) |
+
+### Portfolio Management (Authenticated)
+
+| Tool | Use Case |
+|------|----------|
+| `polymarket_get_balance` | Check USDC balance |
+| `polymarket_get_positions` | View current holdings with P&L |
+| `polymarket_get_orders` | List open orders |
+| `polymarket_get_trades` | View trade history |
+
+### Trading (Authenticated)
+
+| Tool | Use Case |
+|------|----------|
+| `polymarket_market_buy` | Buy shares at market price |
+| `polymarket_market_sell` | Sell shares at market price |
+| `polymarket_create_order` | Place limit order at specific price |
+| `polymarket_cancel_order` | Cancel a specific order |
+| `polymarket_cancel_all_orders` | Cancel all open orders |
+
+## Optimal Trading Workflow
+
+### Finding Good Markets
+1. Use search tools - defaults filter out resolved, expired, and low liquidity markets
+2. Best markets have:
+   - Liquidity > $50,000
+   - Price between 20-80%
+   - End date in the future
+   - Recent volume
+
+### Before Trading - ALWAYS Check:
+```python
+# 1. Verify funds
+polymarket_get_balance()
+
+# 2. Check spread and liquidity
+polymarket_get_order_book(token_id=token_id)
+
+# 3. Get actual execution price
+polymarket_get_price(token_id=token_id, side="BUY")
+```
+
+### Executing a Buy
+```python
+# 1. Get market details to find token_id
+market = polymarket_get_market(market_id)
+# token_ids are in market.clob_token_ids - first is YES, second is NO
+
+# 2. Check order book
+book = polymarket_get_order_book(token_id=yes_token_id)
+
+# 3. Execute market buy
+result = polymarket_market_buy(token_id=yes_token_id, amount=10)  # $10 USDC
+```
+
+## Token ID Rules
+
+### Binary Markets (Yes/No)
+- `clob_token_ids[0]` = YES token
+- `clob_token_ids[1]` = NO token
+- Buying YES = betting event WILL happen
+- Buying NO = betting event WON'T happen
+
+### Token ID Format
+- Token IDs are VERY long integers (76+ digits)
+- ALWAYS pass as strings to avoid truncation
+
+## Understanding Prices & Odds
+
+| Price | Probability | Interpretation |
+|-------|-------------|----------------|
+| 0.10 | 10% | Unlikely to happen |
+| 0.50 | 50% | Coin flip |
+| 0.80 | 80% | Likely to happen |
+| 0.95 | 95% | Very likely (near certainty) |
+
+**Payout Calculation:**
+- Buy YES at $0.40, event happens → Win $1.00 per share (profit: $0.60)
+- Buy YES at $0.40, event doesn't happen → Lose $0.40 per share
+
+## Common Patterns
+
+### "What's happening on Polymarket RIGHT NOW?"
+```python
+polymarket_get_trending_markets(minutes=5, limit=10)
+# Returns markets with most volume in last 5 minutes
+```
+
+### "Find events about X"
+```python
+polymarket_search_events(query="Ukraine ceasefire", limit=5)
+# Returns events sorted by volume
+```
+
+### "Buy $10 of X at current price"
+```python
+polymarket_market_buy(token_id="...", amount=10)
+# Executes immediately at best available price
+```
+
+### "What's my current portfolio?"
+```python
+polymarket_get_positions()
+# Shows all holdings with P&L
+```
+
+## Error Handling
+
+| Error | Solution |
+|-------|----------|
+| Cloudflare 403 | VPN/geo issue - check network |
+| Insufficient balance | Deposit USDC on Polygon |
+| Market closed | Cannot trade closed markets |
+| Order rejected | Check spread, may need better price |

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: reddit
+description: Research Reddit discussions with high signal using scrape_reddit_leads and scrape_reddit — pain points, intent discovery, and trend tracking. Use when the user wants to mine subreddits for leads, find threads worth replying to, or track what a community says about a topic.
+use_cases:
+  - Find customer pain points from Reddit conversations
+  - Monitor keyword mentions in specific subreddits
+  - Discover high-intent discussions for outreach
+  - Compare themes across Reddit communities
+  - Build a Reddit-based insight summary with sources
+triggers:
+  - reddit research
+  - reddit leads
+  - scrape reddit
+  - subreddit research
+  - reddit pain points
+  - reddit mentions
+requires_toolkits:
+  - reddit_scraper
+suggested_toolkits: []
+---
+
+# Reddit Research
+
+Use these tools in this order for research quality:
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Reddit scraper toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+1. `scrape_reddit_leads` (precision first)
+2. `scrape_reddit` (expand recall second)
+
+## Default Workflow
+
+### Step 1: Precision pass with `scrape_reddit_leads`
+
+Start with focused keyword + subreddit pairs:
+
+- `searches`: list of `{ "keyword": "...", "subreddit": "..." }`
+- `hours_back`: set a clear recency window
+- `search_posts=true`
+- `search_comments=true` only when comment evidence is needed
+- `sort="new"` for monitoring or `sort="top"` for stable discussions
+- `negative_keywords` to suppress spam/noise
+
+Use 1-3 specific keywords first. Avoid broad single words.
+
+### Step 2: Expand with `scrape_reddit`
+
+If precision results are too narrow:
+
+- run `scrape_reddit` with subreddit `start_urls`
+- add adjacent keyword variants in `searches`
+- tune `sort` and `time` for recency vs quality
+- keep `skip_comments=true` when only post-level signal is needed
+
+## Query Quality Rules
+
+- Prefer scoped subreddits before global search.
+- Include negative filters (e.g. `onlyfans`, `porn`, `nsfw`, `promo`, `buy now`) when results are noisy.
+- Increase specificity before increasing `max_items`.
+- If results are sparse, widen subreddits and add semantically related keywords.
+
+## Output Requirements
+
+Return:
+
+- top findings with short rationale
+- source URLs
+- subreddit distribution
+- repeated themes/pain points
+- recommended follow-up keywords
+
+Do not return unfiltered dumps. Prioritize relevance and evidence.
+

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: sandbox
+description: Execute code, build webapps, and analyze data in the sandbox. Use when the user wants to run Python scripts, process files, scrape at scale, build and preview web apps, or produce CSV/Excel/JSON/PDF outputs.
+use_cases:
+  - Execute Python scripts
+  - Build web applications from starter repositories
+  - Create data visualizations and charts
+  - Run code in a sandbox
+  - Process and analyze data locally
+  - Create CSV/Excel/JSON/PDF reports
+  - Generate professional documents
+  - Bulk web scraping and data collection
+  - Multi-step tool pipelines (search → process → save to database)
+  - Code-driven tool orchestration with call_tool
+triggers:
+  - sandbox
+  - starter repo
+  - git clone
+  - code execution
+  - python
+  - webapp
+  - dashboard
+  - react app
+  - vp
+  - vite
+  - data analysis
+  - charts
+  - pdf report
+  - bulk scrape
+  - call_tool
+  - tool chaining
+  - data pipeline
+  - website building
+requires_toolkits:
+  - sandbox
+---
+
+# Sandbox Development
+
+Execute code, build webapps, and analyze data in E2B with a clone-first workflow.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Sandbox toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Core Principles
+
+1. Sandbox is lean: no pre-baked framework apps.
+2. For app work, initialize inside the sandbox active directory. The sandbox active directory is authoritative. Use `sandbox_pwd()` to inspect it and `sandbox_set_active_directory(path=...)` to change it.
+3. Verify runtime/tooling availability before assuming defaults.
+4. Python/data-analysis output now has a dedicated results surface in the UI; app work uses the current thread's sandbox IDE + preview surface.
+5. Save user-deliverable files to `/files/` for sharing when you explicitly want to attach or share a file.
+6. `/files/...` is VFS, not a sandbox-local directory. Sandbox code can only open `/home/user/...` unless you copy data in first.
+
+## User Interaction Rules
+
+1. **Users are non-technical.** Never ask about stack, framework, deployment, hosting, SSR, routing, or build tools. These are your decisions, not theirs.
+2. **Always use the React Router + shadcn starter** (`hyper-sandbox-1`) for websites, landing pages, dashboards, and web apps. Do not offer HTML, Next.js, Astro, or other alternatives. The only exception is if the user explicitly names a different stack.
+3. **Infer scope from context.** Short brief = single-page site. Detailed multi-section content = multi-page. Don't ask "full site or landing page?" -- decide based on what you're given.
+4. **When given a reference URL**, perform brand research before building. See `references/frontend-design.md` for the workflow. Use normal agent tool calls for research -- not in-sandbox code.
+5. The only acceptable questions to ask users are about their business, messaging, or what they want to communicate -- never about technology choices.
+
+## Routing Table
+
+Read the focused reference based on the task:
+
+| Need | Reference |
+|------|-----------|
+| Runtime checks (Node/pnpm/uv/CLI availability) | `references/runtime-and-tooling.md` |
+| Initialize project from starter repository | `references/starter-repositories.md` |
+| Use `agent-browser` for snapshot/screenshot/click | `references/agent-browser.md` |
+| Export artifacts, preview apps, share URLs | `references/artifacts-and-sharing.md` |
+| Create frontend design and websites | `references/frontend-design.md` |
+| Data analysis, charts, file processing | `references/data-analysis.md` |
+| Bulk scraping, multi-step tool pipelines, code-driven tool orchestration | `references/tool-chaining.md` |
+
+When the request spans multiple areas, follow references in this order:
+1. `references/runtime-and-tooling.md`
+2. `references/starter-repositories.md`
+3. `references/tool-chaining.md`
+4. `references/data-analysis.md`
+5. `references/agent-browser.md`
+6. `references/artifacts-and-sharing.md`
+
+## Core Tools (Sandbox Toolkit)
+
+| Tool | Use |
+|------|-----|
+| `sandbox_start()` | Start sandbox environment |
+| `sandbox_shutdown()` | Shut down and destroy the sandbox |
+| `shell(command)` | Execute commands in the sandbox with cwd auto-set to the current session working directory |
+| `python(code)` | Execute Python |
+| `javascript(code)` | Execute JavaScript |
+| `sandbox_pwd()` | Show the current sandbox active directory |
+| `sandbox_set_active_directory(path)` | Set the default directory for shell and file tools |
+| `sandbox_edit_file(path, old, new)` | Edit existing files; relative paths resolve inside the active directory |
+| `sandbox_write_file(path, content)` | Create or overwrite a file; relative paths resolve inside the active directory |
+| `sandbox_check_running_port(port)` | Check if a port is active |
+| `sandbox_health_check(port)` | Health check a running service |
+| `sandbox_get_preview_url(port)` | Get public URL for running app |
+| `sandbox_screenshot(url)` | Screenshot URL and return file URL |
+| `display_file(path=...)` | Show file to user in chat |
+
+## Sandbox Lifecycle
+
+1. The default sandbox is persistent. Use it across runs unless the task is truly one-time.
+2. Sandboxes auto-pause after inactivity and can be resumed later with files preserved.
+3. When the user wants to stop the entire sandbox, call `sandbox_shutdown()`.
+4. Stopping a process inside the sandbox is not the same as shutting down the sandbox itself.
+
+## Best Practices
+
+1. Treat the sandbox as a persistent owned workspace for the current agent, and treat the active directory as the default root for shell and file tools.
+2. `shell(command)` already starts in the sandbox active directory. Do not begin by `cd`-ing to guessed app paths.
+3. For app workflows, clone into a clear project folder under `/home/user`, then call `sandbox_set_active_directory(path=...)` for that folder.
+4. Confirm tool availability (`node`, `pnpm`, `vp`, `uv`, `agent-browser`) before relying on them.
+5. Use `pnpm` for package installation, `vp dev` for frontend dev servers, `uv` for Python.
+6. Keep app preview and artifact export separate: preview with `sandbox_get_preview_url`, share files from `/files/`.
+7. Prefer normal agent tool calls (outside sandbox Python) for most tool usage.
+8. Use in-sandbox `call_tool` only for bulk/high-volume workflows (for example scraping/enrichment loops) where local Python orchestration is necessary.
+9. Until fully validated, only use in-sandbox `call_tool` for tools that do **not** require approval (`requires_approval` / `sensitive_operation` should be false). For approval-sensitive tools, call them directly via normal agent tool calls.
+10. For file transfers into the sandbox, use `copy_files(...)` to copy files explicitly into `/home/user/...`.
+11. For Python analysis, let `python(code)` produce charts/files naturally first. If you want a chat attachment, copy the file to `/files/...` with `copy_files(...)` first, then call `display_file(path="/files/...")`.
+12. `sandbox_shutdown()` permanently destroys the sandbox. Warn the user that unsaved work will be lost. If they only want to stop a specific process (e.g. a dev server), use `shell("kill ...")` instead.
+13. If the user is building an app, reuse the persistent sandbox so preview URLs, files, logs, and terminal history stay attached to the same `sandbox_id`.
+14. If preview fails, trust the returned status. `app_not_running` means the app is not serving yet -- start or restart the dev server.
+15. **NEVER** start dev servers with shell `&` (e.g. `vp dev &`). This freezes the thread. Always use `shell(command, background=True)`.
+
+## Critical File Boundary Rule
+
+- Never treat `/files/...` as if it exists inside sandbox Python.
+- These patterns are wrong and will fail:
+  - `open("/files/data.json")`
+  - `pd.read_csv("/files/data.csv")`
+  - reading a tool-returned `/files/...` path from Python without copying it first
+- Correct options:
+  - `read_file(path="/files/data.csv")` when you only need to inspect the VFS file
+  - `copy_files(sources=["/files/data.csv"], destination="/home/user/data.csv")` before opening it in Python
+  - `call_tool(...)` or `call_tool_sync(...)` from Python when you truly need tool chaining rather than file handoff

--- a/skills/sandbox/references/agent-browser.md
+++ b/skills/sandbox/references/agent-browser.md
@@ -1,0 +1,37 @@
+---
+name: Agent Browser
+description: Use this reference for compact, ref-based browser automation in sandbox sessions.
+---
+
+## Typical Flow
+
+```bash
+agent-browser open https://example.com
+agent-browser snapshot -i
+agent-browser click @e2
+agent-browser screenshot <thread-working-directory>/snapshots/page.png
+agent-browser close
+```
+
+## Why Use It
+
+- Compact output for agent context efficiency.
+- Deterministic element refs from accessibility snapshots.
+- Better repeatability for click/type/screenshot flows.
+
+## Setup Checks
+
+```bash
+agent-browser --version
+```
+
+If browser binaries are missing, install Playwright browsers:
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+## Artifact Handling
+
+- Save screenshots to a known path, then move/copy to `/files/` when sharing.
+- Do not leave generated screenshot/video artifacts tracked in git by default.

--- a/skills/sandbox/references/artifacts-and-sharing.md
+++ b/skills/sandbox/references/artifacts-and-sharing.md
@@ -1,0 +1,35 @@
+---
+name: Atifacts and Sharing
+description: Use this reference for preview URLs, file exports, and clean artifact handling.
+---
+
+## Filesystem Roles
+
+- `/home/user/` sandbox home
+- Current thread sandbox working directory (typically under `/home/user/sessions/<shortid>/`) for cloned app code and working files
+- `/tmp/` temporary files/logs
+- `/files/` persistent shareable output
+
+## Preview Running Apps
+
+For local dev servers:
+
+```bash
+hyper-preview 3000
+```
+
+Use explicit ports and confirm server health before sharing preview URLs.
+
+## Share Files with Users
+
+Save deliverables under `/files/`, then generate URL:
+
+```bash
+hyper-url /files/report.pdf
+```
+
+## Artifact Hygiene
+
+- Keep generated media (screenshots/videos) outside repository tracking unless explicitly requested.
+- If needed for user download, copy from working path to a user-accessible destination (for example local Downloads or `/files/` URL).
+- Verify git cleanliness before claiming completion when repository artifacts are involved.

--- a/skills/sandbox/references/data-analysis.md
+++ b/skills/sandbox/references/data-analysis.md
@@ -1,0 +1,109 @@
+---
+name: Data Analysis
+description: Use this reference for data analysis, chart creation, file processing, and report generation in the sandbox.
+---
+
+## Getting Files Into the Sandbox
+
+Use `copy_files(...)` to move input data into the sandbox explicitly:
+
+```python
+copy_files(sources=["/files/input.csv"], destination="/home/user/data/input.csv")
+```
+Sandbox Python only sees `/home/user/...`. Persistent files stay in `/files/...` until you copy them over.
+
+## Running Analysis
+
+The sandbox Python venv has pre-installed libraries:
+
+```python
+python("""
+import pandas as pd
+import numpy as np
+
+df = pd.read_csv('/home/user/data/input.csv')
+summary = df.describe()
+print(summary)
+""")
+```
+
+Available libraries: pandas, numpy, scipy, matplotlib, seaborn, plotly, openpyxl, httpx.
+
+## Creating Charts
+
+Use normal plotting libraries directly in `python(code)`. Native sandbox results now surface logs, structured chart JSON, and file artifacts in the UI:
+
+```python
+python("""
+import matplotlib.pyplot as plt
+import pandas as pd
+
+df = pd.read_csv('/home/user/data/input.csv')
+fig, ax = plt.subplots(figsize=(10, 6))
+df.plot(kind='bar', ax=ax)
+plt.tight_layout()
+plt.savefig('/home/user/data/chart.png', dpi=150)
+print('Chart saved')
+""")
+```
+
+For Plotly, prefer returning the figure or writing HTML/PNG files when needed:
+
+```python
+python("""
+import pandas as pd
+import plotly.express as px
+
+df = pd.read_csv('/home/user/data/input.csv')
+fig = px.bar(df, x='category', y='value', title='Category totals')
+fig
+""")
+```
+
+## Showing Results to the User
+
+Default behavior:
+- Let `python(code)` return its native results first. The sandbox UI now shows console output, rendered charts, and file artifacts automatically.
+- Use `display_file(path=...)` only for files already copied into `/files/...`.
+- If the file was created in the sandbox VM under `/home/user/...`, copy it into `/files/...` first. No exceptions.
+
+Example:
+
+```python
+copy_files(sources=["/home/user/data/chart.png"], destination="/files/chart.png")
+display_file(path="/files/chart.png")
+```
+
+## Exporting Files
+
+Use `copy_files(...)` to persist files outside the sandbox, then `display_file(path="/files/...")` when you want to attach them in chat:
+
+```python
+copy_files(sources=["/home/user/data/report.csv"], destination="/files/report.csv")
+display_file(path="/files/report.csv")
+```
+
+## PDF Report Generation
+
+ReportLab is pre-installed for generating professional PDF reports:
+
+```python
+python("""
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas('/home/user/data/report.pdf', pagesize=A4)
+c.drawString(72, 750, 'Analysis Report')
+c.save()
+print('PDF saved')
+""")
+```
+
+## Workflow Pattern
+
+1. Copy/prepare input data with `copy_files(...)`
+2. Analyze with `python(code)` using pandas/numpy
+3. Create visualizations with matplotlib/seaborn/plotly
+4. Let the native sandbox results UI render logs/charts/files
+5. Use `display_file(path=...)` for explicit chat attachments
+6. Export with `sandbox_download_file(path)` or `copy_files(...)` when needed

--- a/skills/sandbox/references/frontend-design.md
+++ b/skills/sandbox/references/frontend-design.md
@@ -1,0 +1,56 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+## Brand Research (Reference URL Provided)
+
+When the user provides a reference URL or asks to match a brand, research the brand BEFORE starting sandbox work. Use normal agent tool calls, not in-sandbox code.
+
+1. Call `analyze_website` as a normal agent tool call to get structured site data (title, description, technologies, metadata).
+2. Use `agent-browser` to open the URL, take a screenshot, and visually inspect the design (colors, fonts, layout, spacing).
+3. Extract and note:
+   - Color palette (primary, secondary, accent, background, text)
+   - Typography (font families, weights, sizes)
+   - Layout patterns (grid, spacing, section structure)
+   - Visual tone (minimal, bold, playful, corporate, etc.)
+4. Apply the extracted brand when building: set CSS variables, choose matching fonts, replicate layout patterns.
+
+Do not ask the user to confirm brand details. Extract, apply, and build.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/skills/sandbox/references/runtime-and-tooling.md
+++ b/skills/sandbox/references/runtime-and-tooling.md
@@ -1,0 +1,74 @@
+---
+name: Runtime and Tooling
+description: Use this reference when you need to verify sandbox runtime/tooling before project work.
+---
+
+## Expected Baseline
+
+- `node` / `npx`
+- `pnpm`
+- `bun`
+- `uv` (Python package manager)
+- `vp` (Vite+ unified frontend toolchain: dev, build, lint, format)
+- `python` (with venv at `/home/user/.venv`)
+- `agent-browser` (snapshots, screenshots, interactions)
+
+Do not assume all are present in every environment version. Verify first.
+
+## Verification Commands
+
+```bash
+node --version
+pnpm --version
+bun --version
+uv --version
+vp --version
+python --version
+agent-browser --version
+```
+
+If any command fails, install the missing tool before continuing.
+
+## Sandbox Start Pattern
+
+```python
+sandbox_start()
+```
+
+Use the current thread's sandbox working directory as the app root for cloned repositories. In practice this is the active directory attached to the thread, typically under `/home/user/sessions/<shortid>`.
+
+## UI Modes
+
+The product now has two sandbox UI modes:
+
+- Python/data-analysis mode: native `python(code)` / `javascript(code)` results show logs, charts, and file artifacts in the sandbox results surface.
+- App-builder mode: IDE + preview stay rooted to the current thread's sandbox working directory.
+
+Do not try to put Python analysis outputs into the app IDE tree. Keep app source in the current thread's sandbox working directory, and let analysis outputs surface through the sandbox results UI or explicit file sharing.
+
+## Pre-installed Python Libraries
+
+The sandbox venv includes data science libraries out of the box:
+
+- pandas, numpy, scipy
+- matplotlib, seaborn, plotly
+- httpx, aiohttp, openpyxl
+- Pillow, markdown
+- reportlab, pdf2image, weasyprint
+
+PDF helpers available in the template:
+- `poppler-utils` for `pdf2image`
+- Cairo/Pango/GDK Pixbuf libraries for `weasyprint`
+
+## Guardrails
+
+- Check runtime health before clone/build commands.
+- Keep commands deterministic and non-interactive.
+- If a tool is missing, install explicitly and then re-verify with `--version`.
+- Use `pnpm` for package installation (not npm or yarn).
+- Use `vp dev` to start frontend dev servers (not `pnpm dev`, `npx vite`, or raw `vite`).
+- Use `vp build` to build frontend projects, `vp check` for linting and formatting.
+- **NEVER** start dev servers with shell `&` (e.g. `vp dev &`). Use `shell(command, background=True)` instead. Shell `&` freezes the thread.
+- Use direct shell checks like `curl` and `lsof` for app health and port validation.
+- For app work, keep file browsing scoped to the current thread's sandbox working directory.
+- Hidden files should be treated as out of scope for normal file-tree browsing unless explicitly requested.

--- a/skills/sandbox/references/starter-repositories.md
+++ b/skills/sandbox/references/starter-repositories.md
@@ -1,0 +1,64 @@
+---
+name: Starter Repositories
+description: Use this reference when initializing projects in the sandbox.
+---
+
+## Clone-First Rule
+
+Do not scaffold from pre-baked templates in the sandbox image. Always clone a starter repository.
+
+Workspace root:
+
+```bash
+cd <thread-working-directory>
+```
+
+## Generic Clone Workflow
+
+```bash
+cd <thread-working-directory>
+git clone <repo-url> app
+cd <thread-working-directory>/app
+pnpm install
+```
+
+Start the dev server with `shell()` using `background=True`:
+
+```python
+shell("cd <thread-working-directory>/app && vp dev", background=True)
+```
+
+`vp` (Vite+) is the standard frontend toolchain. It wraps Vite, Vitest, Oxlint, and Oxfmt into a single CLI. Use `vp dev` to start dev servers, `vp build` to build, `vp check` to lint and format.
+
+**NEVER** start dev servers with shell `&` (e.g. `pnpm dev &`). This freezes the thread. Always use `background=True`.
+
+## Verify the App is Running
+
+After starting the dev server:
+
+```python
+sandbox_check_running_port(port=8080)
+sandbox_health_check(port=8080)
+sandbox_get_preview_url(port=8080)
+```
+
+The React Router + shadcn starter uses port 8080. Reveal.js uses port 3000.
+
+## Available Starters
+
+| Starter | Repo URL | Dev Port | Use Case |
+|---------|----------|----------|----------|
+| React Router + shadcn | `https://github.com/multigen-ai/hyper-sandbox-1.git` | 8080 | Marketing sites, landing pages, dashboards, websites, apps |
+| Reveal.js Slides | `https://github.com/multigen-ai/reveal-slides-template.git` | 3000 | Presentations, slide decks, pitch decks |
+
+The React Router + shadcn starter includes: React 19, React Router v7 (framework mode), Tailwind CSS v4, shadcn/ui (all components pre-installed), and Vite. Flat project structure — source files live in `app/`, routes in `app/routes/`, components in `app/components/`.
+
+**Default**: The React Router + shadcn starter is the default for ALL web work (websites, landing pages, dashboards, apps). Use it unless the user explicitly requests a different stack. Never ask which starter to use.
+
+## Notes
+
+- Use `pnpm` for package installation (not npm/yarn/bun).
+- Use `vp dev` to start dev servers (not `pnpm dev` or `npx vite`).
+- For app work, always use the sandbox active directory rather than assuming a fixed app path.
+- For monorepos, install from the relevant sub-directory (e.g. `cd client && pnpm install`).
+- For Python projects, use `uv` to manage dependencies instead of pip.

--- a/skills/sandbox/references/tool-chaining.md
+++ b/skills/sandbox/references/tool-chaining.md
@@ -1,0 +1,272 @@
+---
+name: Tool Chaining
+description: Use this reference for bulk data collection, multi-step tool pipelines, and code-driven tool orchestration inside the sandbox.
+---
+
+## When to Use This
+
+Use in-sandbox tool chaining when:
+
+- You need to call the same tool many times in a loop (bulk scraping, enrichment, batch queries).
+- You need to process tool results with Python before passing them to the next tool.
+- The workflow has 3+ sequential steps that depend on each other's output.
+- You want to collect data from one API, transform it, and store it in the database or export as a file.
+
+Do NOT use in-sandbox tool chaining for:
+
+- Single tool calls. Use normal agent tool calls instead.
+- Tools that require user approval (`requires_approval` / `sensitive_operation`). Call those directly as agent tool calls.
+
+## Critical File Boundary Rule
+
+Sandbox Python can only open files that exist inside `/home/user/...`.
+
+- `/files/...` and `/skills/...` are different backends.
+- Do NOT do this inside Python:
+  - `open("/files/result.json")`
+  - `pd.read_csv("/files/data.csv")`
+- If a normal tool returns a VFS file path such as `/files/tmp/...json`, either:
+  - inspect it with `read_file(path="/files/tmp/...json")`
+  - copy it into `/home/user/...` with `copy_files(...)` before opening it in Python
+  - or call the upstream tool directly from Python with `call_tool(...)` / `call_tool_sync(...)` when bulk orchestration is actually needed
+
+## Imports
+
+Inside `python(code)` blocks, the sandbox has a lightweight RPC client pre-installed:
+
+```python
+python("""
+from seti.sandbox import call_tool_sync
+
+result = call_tool_sync("web_search", queries=["AI agents 2025"], num_results=5)
+print(result)
+""")
+```
+
+Two calling styles are available:
+
+**Direct (recommended for clarity):**
+
+```python
+from seti.sandbox import call_tool_sync
+
+result = call_tool_sync("tool_name", arg1="value", arg2=123)
+```
+
+**Async (when running in an async context):**
+
+```python
+from seti.sandbox import call_tool
+
+result = await call_tool("tool_name", arg1="value", arg2=123)
+```
+
+## Common Tools for Chaining
+
+| Tool | Purpose | Example args |
+|------|---------|--------------|
+| `web_search` | Search the web | `queries=["..."], num_results=5, mode="summary"` |
+| `web_scrape_page` | Scrape a single URL | `url="https://..."` |
+| `hyper_data_save` | Save data to a database table | `table="leads", data=[{...}], mode="append"` |
+| `hyper_data_sql` | Query a database table | `sql="SELECT * FROM leads"` |
+| `hyper_data_list_tables` | List existing tables | (no required args) |
+| `firecrawl_scrape_url` | Scrape with Firecrawl | `url="https://..."` |
+| `analyze_website` | Analyze a website | `url="https://..."` |
+
+## Pattern: Search → Process → Save to Database
+
+```python
+python("""
+from seti.sandbox import call_tool_sync
+
+# 1. Search
+result = call_tool_sync("web_search", queries=["top SaaS companies 2025"], num_results=10, mode="summary")
+
+# 2. Process into rows
+rows = []
+for search in result.get("searches", []):
+    for item in search.get("results", []):
+        rows.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": item.get("content", "")[:300],
+        })
+
+print(f"Found {len(rows)} results")
+
+# 3. Save to database
+save_result = call_tool_sync("hyper_data_save", table="saas_research", data=rows, mode="replace")
+print(save_result.get("message"))
+""")
+```
+
+## Pattern: Bulk Scrape → CSV → PDF Report with Charts
+
+```python
+python("""
+import json
+import csv
+from seti.sandbox import call_tool_sync
+
+# 1. Search multiple queries
+all_results = []
+queries = ["AI automation tools", "no-code AI platforms", "enterprise AI agents"]
+
+for query in queries:
+    result = call_tool_sync("web_search", queries=[query], num_results=5, mode="summary")
+    for search in result.get("searches", []):
+        for item in search.get("results", []):
+            all_results.append({
+                "query": query,
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "snippet": item.get("content", "")[:200],
+            })
+
+# 2. Write CSV
+csv_path = "/home/user/data/research.csv"
+with open(csv_path, "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=["query", "title", "url", "snippet"])
+    writer.writeheader()
+    writer.writerows(all_results)
+
+print(f"Saved {len(all_results)} results to CSV")
+""")
+```
+
+Then generate a chart and PDF in a follow-up block:
+
+```python
+python("""
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib import colors
+
+# Load data
+df = pd.read_csv("/home/user/data/research.csv")
+
+# Chart: results per query
+counts = df["query"].value_counts()
+fig, ax = plt.subplots(figsize=(8, 4))
+counts.plot(kind="barh", ax=ax, color="#4f46e5")
+ax.set_xlabel("Results")
+ax.set_title("Search Results by Query")
+plt.tight_layout()
+chart_path = "/home/user/data/chart.png"
+fig.savefig(chart_path, dpi=150)
+
+# Build PDF
+pdf_path = "/home/user/data/report.pdf"
+doc = SimpleDocTemplate(pdf_path, pagesize=A4)
+styles = getSampleStyleSheet()
+elements = []
+
+elements.append(Paragraph("Research Report", styles["Title"]))
+elements.append(Spacer(1, 12))
+elements.append(Paragraph(f"Total results: {len(df)}", styles["Normal"]))
+elements.append(Spacer(1, 12))
+elements.append(Image(chart_path, width=400, height=200))
+elements.append(Spacer(1, 12))
+
+# Table of top results
+table_data = [["Query", "Title", "URL"]]
+for _, row in df.head(10).iterrows():
+    table_data.append([row["query"][:30], row["title"][:40], row["url"][:50]])
+
+t = Table(table_data, colWidths=[100, 150, 200])
+t.setStyle(TableStyle([
+    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#4f46e5")),
+    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+    ("FONTSIZE", (0, 0), (-1, -1), 7),
+    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+]))
+elements.append(t)
+doc.build(elements)
+print(f"PDF report saved to {pdf_path}")
+""")
+```
+
+Then export and display:
+
+```python
+copy_files(sources=["/home/user/data/report.pdf"], destination="/files/report.pdf")
+display_file(path="/files/report.pdf")
+```
+
+## Pattern: Scrape → Enrich → Database
+
+```python
+python("""
+from seti.sandbox import call_tool_sync
+
+urls = [
+    "https://example.com/company-a",
+    "https://example.com/company-b",
+    "https://example.com/company-c",
+]
+
+enriched = []
+for url in urls:
+    analysis = call_tool_sync("analyze_website", url=url)
+    enriched.append({
+        "url": url,
+        "title": analysis.get("title", ""),
+        "description": analysis.get("description", ""),
+        "tech_stack": str(analysis.get("technologies", [])),
+    })
+    print(f"Analyzed: {url}")
+
+# Save to Hyper database
+call_tool_sync("hyper_data_save", table="competitor_analysis", data=enriched, mode="replace")
+print(f"Saved {len(enriched)} rows to competitor_analysis")
+""")
+```
+
+Then query the data:
+
+```python
+python("""
+from seti.sandbox import call_tool_sync
+
+result = call_tool_sync("hyper_data_sql", sql="SELECT * FROM competitor_analysis ORDER BY title")
+for row in result.get("data", []):
+    print(f"{row['title']} — {row['url']}")
+""")
+```
+
+## Error Handling
+
+Tool calls can fail. Always handle errors in loops to avoid losing partial progress:
+
+```python
+python("""
+from seti.sandbox import call_tool_sync
+
+results = []
+errors = []
+
+for query in queries:
+    try:
+        result = call_tool_sync("web_search", queries=[query], num_results=5)
+        results.append(result)
+    except RuntimeError as e:
+        errors.append({"query": query, "error": str(e)})
+        print(f"Failed: {query} — {e}")
+
+print(f"Completed: {len(results)}, Failed: {len(errors)}")
+""")
+```
+
+## Rules
+
+1. All `call_tool_sync` / `call_tool` calls go through the Seti backend via RPC. They are real tool executions with full authentication.
+2. Keep each `python(code)` block focused on one phase. Chain multiple blocks rather than writing a 200-line monolith.
+3. Write intermediate results to files (`/home/user/data/...`) between blocks so progress is recoverable.
+4. For files you want to show the user: copy to `/files/` first, then call `display_file(path="/files/...")`.
+5. For database persistence: use `hyper_data_save` to store structured data, `hyper_data_sql` to query it back.
+6. Do not use `call_tool_sync` for tools that require user approval. Use normal agent tool calls for those.

--- a/skills/seo-research/SKILL.md
+++ b/skills/seo-research/SKILL.md
@@ -1,6 +1,52 @@
 ---
 name: seo-research
 description: Data-driven SEO research and analysis through the Hyper MCP — keyword research, competitor analysis, content planning, AI search visibility (ChatGPT, Claude, Perplexity, Google AI Overviews), backlink trends, search intent classification, page speed / Core Web Vitals, and full site audits. Use when the user asks for an SEO audit, keyword research, content strategy, competitor benchmarks, brand visibility in AI search, ranking history, or any organic search analysis.
+use_cases:
+  - Research keywords for a new product or page
+  - Analyze competitor SEO performance
+  - Find keyword opportunities for a domain
+  - Plan a content strategy based on search data
+  - Audit a domain's organic health
+  - Check brand visibility in AI search (ChatGPT, Perplexity, Claude)
+  - Discover who ranks for target keywords
+  - Compare search demand vs AI search demand
+  - Build a keyword-targeted content calendar
+  - Identify low-difficulty keyword opportunities
+  - Analyze backlink trends over time
+  - Find content gaps between competitors
+  - Track brand mentions across LLMs
+  - Evaluate Google AI Overview citations for a topic
+  - Compare traffic across multiple competitor domains
+  - Find competitors based on shared organic keywords
+  - Track historical SEO performance of a domain over months or years
+  - Classify search intent for a list of keywords
+  - Find keyword overlaps between two specific domains
+  - Check page speed and Core Web Vitals for a URL
+triggers:
+  - seo
+  - keyword research
+  - serp
+  - backlinks
+  - domain audit
+  - ai visibility
+  - competitors
+  - search volume
+  - ranking
+  - keyword difficulty
+  - content strategy
+  - ai search
+  - geo optimization
+  - traffic estimation
+  - page speed
+  - core web vitals
+  - search intent
+  - domain intersection
+  - historical ranking
+requires_toolkits:
+  - hyperseo
+suggested_toolkits:
+  - sandbox
+  - file_manager
 ---
 
 # SEO Research

--- a/skills/skill-creation/SKILL.md
+++ b/skills/skill-creation/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: skill-creation
+description: Create user skills with proper folder structure and YAML frontmatter. Use when the user wants to create a custom skill, document a repeatable workflow as a skill, or fix a skill's structure and metadata.
+use_cases:
+  - Create custom workflow guides
+  - Document repeatable processes
+  - Build skill folders with SKILL.md
+triggers:
+  - create skill
+  - make skill
+  - new skill
+  - skill guide
+  - build skill
+requires_toolkits: []
+suggested_toolkits: []
+always_include: true
+---
+
+# Creating User Skills
+
+Skills are **folders** (not single files) with a required structure.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Skills system (built into Hyper)** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Required Folder Structure
+
+```
+/skills/my-skill-name/           <- Folder name must be slug format (lowercase, hyphens)
+├── SKILL.md                     <- REQUIRED: Main instructions with YAML frontmatter
+├── REFERENCE.md                 <- Optional: Additional reference documentation
+├── references/                   <- Optional: Folder for multiple reference docs
+│   ├── api-docs.md
+│   └── examples.md
+└── scripts/                     <- Optional: Executable scripts
+    └── helper.py
+```
+
+## SKILL.md Format (Required)
+
+```markdown
+---
+name: my-skill-name
+description: Brief description of what this skill does (required, max 1024 chars)
+use_cases:
+  - Use case 1
+  - Use case 2
+triggers:
+  - keyword1
+  - keyword2
+requires_toolkits:
+  - toolkit_id
+suggested_toolkits:
+  - optional_toolkit_id
+---
+
+# Skill Guide Title
+
+Your step-by-step instructions here...
+```
+
+## Creating a Skill (Recommended: Use skills_create Tool)
+
+The `skills_create` tool is the most reliable way to create skills:
+
+```python
+# Create a new skill using the skills_create tool
+skills_create(
+    name="my-skill-name",
+    description="Brief description of what this skill does",
+    triggers=["keyword1", "keyword2"],
+    content="""# My Skill Guide
+
+Step-by-step instructions here...
+
+## Section 1
+Details...
+
+## Section 2
+More details...
+"""
+)
+```
+
+The tool automatically:
+- Creates the folder structure
+- Generates proper YAML frontmatter
+- Validates the skill name (slug format)
+- Sets up semantic search indexing
+
+## Alternative: Using Heredoc Syntax
+
+Heredocs now work for VFS paths:
+
+```python
+shell("""cat > /skills/my-skill-name/SKILL.md << 'EOF'
+---
+name: my-skill-name
+description: Brief description of what this skill does
+use_cases:
+  - Use case 1
+triggers:
+  - keyword1
+---
+
+# My Skill Guide
+
+Step-by-step instructions...
+EOF""")
+```
+
+## Other Skill Tools
+
+```python
+# List all your skills
+skills_list()
+
+# Update a specific field on a skill
+skills_update(skill_id="skill_...", field="description", value="New description")
+
+# Delete a skill
+skills_delete(skill_id="skill_...")
+```
+
+## Critical Rules
+
+1. **Slug format required**: Skill folder names MUST use lowercase letters, numbers, hyphens only (e.g., `my-skill-name`)
+2. **Name field must match**: The `name` field in SKILL.md frontmatter must also be slug format
+3. **Description required**: The `description` field is required and cannot be empty
+4. **Folders only**: Do NOT create flat files like `/skills/my-skill.md` - skills must be folders with `SKILL.md` inside
+5. **Curated is read-only**: Skills in `/skills/_hyper/` are read-only and cannot be modified
+
+## Copying a Curated Skill to Customize
+
+```python
+# Copy entire skill folder to user space
+shell("cp -r /skills/_hyper/example-skill /skills/my-custom-skill")
+
+# Review current content
+shell("cat /skills/my-custom-skill/SKILL.md")
+
+# Update with your customizations using the skills_update tool or heredoc
+```
+
+## Skill Discovery Commands
+
+```python
+# List all your skills
+skills_list()
+
+# Browse all curated skills
+shell("ls /skills/_hyper/")
+
+# Browse a skill folder
+shell("ls /skills/_hyper/skill-name/")
+
+# Read a skill
+shell("cat /skills/_hyper/skill-name/SKILL.md")
+
+# Search skills by topic
+shell("hyper-search 'topic' /skills/")
+```

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: slack
+description: Slack messaging, file sharing, Block Kit formatting, and channel management. Use when the user wants to send Slack messages, post rich Block Kit layouts, share files, react, or manage channels and members.
+use_cases:
+  - Send messages in Slack channels
+  - Upload and share files in Slack
+  - Share generated images in Slack
+  - Format messages with Block Kit
+  - Manage Slack channels and threads
+  - Search Slack messages
+triggers:
+  - slack
+  - channel
+  - message
+  - upload file
+  - block kit
+requires_toolkits:
+  - slack_toolkit
+suggested_toolkits: []
+---
+
+# Slack Messaging
+
+This skill provides comprehensive guidance for Slack messaging, file sharing, and formatting.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Slack integration** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## When NOT to Respond
+
+Return ONLY the text `[NO_RESPONSE]` (nothing else) in these situations:
+
+1. **Message mentions another user, not you**: If the user mentions another person (e.g., `@John` or `@SomeOtherBot`) and the message is directed at that person, not you.
+2. **User explicitly asks to be ignored**: If the user says something like "ignore this", "don't respond", or similar.
+3. **Message is clearly not for you**: If the conversation is between other users and doesn't require your input.
+4. **Simple acknowledgments between users**: Messages like "thanks", "ok", "got it" directed at another person.
+
+**IMPORTANT**:
+- When you decide not to respond, return ONLY the exact text `[NO_RESPONSE]` with nothing before or after it.
+- When in doubt, respond. It's better to be helpful than to stay silent when someone needs you.
+- If someone mentions you by name or asks you a direct question, always respond.
+- In DMs (direct messages), always respond unless explicitly asked not to.
+
+## File Sharing - Critical Rules
+
+**CRITICAL**: Files can ONLY be shared in Slack via upload. URLs and file paths do NOT render as viewable content in Slack.
+
+- Use `slack_upload_file` to share any file in Slack
+- Always upload to both the channel AND thread you are responding in, unless requested otherwise
+- The `slack_upload_file` tool accepts a `file_id` parameter for files already stored in the system
+
+### Sharing Generated Images
+
+When you generate an image (e.g., via `openai_image_generation` or similar tools), the result includes a `file_id`. This image is NOT automatically displayed in Slack. You MUST explicitly upload it:
+
+1. Generate the image using the image generation tool
+2. Note the `file_id` from the result
+3. Call `slack_upload_file` with that `file_id`, the current `channel_id`, and `thread_ts`
+
+**Example workflow:**
+- User asks: "Generate an image of a sunset"
+- You call the image generation tool, which returns `file_id: "abc123"`
+- You then call `slack_upload_file(channel_id="C...", file_id="abc123", thread_ts="...")`
+- Now the image appears in Slack
+
+Do NOT just say "Here's your image" without uploading it. The user will see nothing.
+
+### Sharing Other Files
+
+For any file you want to share (documents, CSVs, etc.), use `slack_upload_file` with either:
+- `file_id`: For files already in the system
+- `file_path`: For local files
+- `content`: For text content to upload as a file
+
+## Message Formatting
+
+### When to Use Plain Text vs Block Kit
+- **Simple messages**: Use plain markdown text via `slack_post_message` or `slack_reply_to_thread`
+- **Tables, lists, structured data**: Use Block Kit `rich_text` blocks via `slack_send_block_kit_message`
+- **Messages over 3000 characters**: Use `slack_send_large_message`
+
+### Slack Markdown
+Slack uses a simplified markdown:
+- `*bold*` (single asterisks, not double)
+- `_italic_`
+- `~strikethrough~`
+- `` `code` `` for inline code
+- ` ```code block``` ` for code blocks
+- `<url|display text>` for links (NOT `[text](url)`)
+
+### Block Kit Rich Text
+
+Block Kit's `rich_text` block provides flexible formatting:
+
+**Available Elements:**
+- `rich_text_section`: Single line of text with inline formatting
+- `rich_text_list`: Bulleted or ordered lists (`style: "bullet"` or `style: "ordered"`)
+- `rich_text_quote`: Quote blocks with vertical bar styling
+
+**Element Types Within Sections:**
+- `text`: Plain or styled text (supports `bold`, `italic`, `strike`, `code`)
+- `link`: Hyperlinks with optional display text
+- `emoji`: Emoji by name
+- `user`: User mentions
+- `channel`: Channel mentions
+
+**Bulleted List Example:**
+```json
+{
+    "type": "rich_text",
+    "elements": [
+        {
+            "type": "rich_text_list",
+            "style": "bullet",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [{"type": "text", "text": "First item"}]
+                },
+                {
+                    "type": "rich_text_section",
+                    "elements": [{"type": "text", "text": "Second item"}]
+                }
+            ]
+        }
+    ]
+}
+```
+
+**Ordered List:** Use `"style": "ordered"` instead of `"bullet"`.
+
+**Nested Lists:** Use the `indent` property:
+```json
+{
+    "type": "rich_text_list",
+    "style": "ordered",
+    "indent": 1,
+    "elements": [...]
+}
+```
+
+**Inline Styling:**
+```json
+{
+    "type": "text",
+    "text": "Bold text",
+    "style": {"bold": true}
+}
+```
+Available styles: `bold`, `italic`, `strike`, `code`
+
+**Links in Text:**
+```json
+{
+    "type": "rich_text_section",
+    "elements": [
+        {"type": "text", "text": "Click "},
+        {"type": "link", "text": "here", "url": "https://example.com"},
+        {"type": "text", "text": " to continue"}
+    ]
+}
+```
+
+## Messaging Tools Quick Reference
+
+| Action | Tool |
+|--------|------|
+| Send a message | `slack_post_message` |
+| Reply in a thread | `slack_reply_to_thread` |
+| Upload/share a file | `slack_upload_file` |
+| Send Block Kit message | `slack_send_block_kit_message` |
+| Send long message (>3000 chars) | `slack_send_large_message` |
+| Update a message | `slack_update_message` |
+| Delete a message | `slack_delete_message` |
+| Add a reaction | `slack_add_reaction` |
+| Pin a message | `slack_pin_message` |
+| Search messages | `slack_search_messages` |
+
+## Channel Management Quick Reference
+
+| Action | Tool |
+|--------|------|
+| List channels | `slack_list_channels` |
+| Get channel info | `slack_get_channel_info` |
+| Create a channel | `slack_create_channel` |
+| Set channel topic | `slack_set_channel_topic` |
+| Set channel purpose | `slack_set_channel_purpose` |
+| Invite users | `slack_invite_users_to_channel` |
+| Get channel members | `slack_get_channel_members` |
+
+## User Operations Quick Reference
+
+| Action | Tool |
+|--------|------|
+| List workspace users | `slack_get_users` |
+| Get user profile | `slack_get_user_profile` |
+| Find user by email | `slack_find_user_by_email` |
+| Get user presence | `slack_get_user_presence` |
+| Set your status | `slack_set_user_status` |
+| Create a reminder | `slack_create_reminder` |

--- a/skills/slides/SKILL.md
+++ b/skills/slides/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: slides
+description: Create themed slide presentations in the sandbox using reveal.js with a JSON data model — preview in-browser, export to PPTX. Use when the user wants a slide deck, pitch deck, presentation, or PPTX export with consistent visual themes.
+use_cases:
+  - Create a slide deck or presentation
+  - Generate pitch deck slides
+  - Build a themed presentation from a brief
+  - Export slides to PowerPoint (PPTX)
+  - Preview a presentation in the browser
+triggers:
+  - slides
+  - slide deck
+  - presentation
+  - pitch deck
+  - reveal.js
+  - pptx
+  - powerpoint
+  - keynote
+  - slide generation
+  - create slides
+requires_toolkits:
+  - sandbox
+---
+
+# Slide Generation
+
+Create themed presentations in the sandbox using the reveal.js starter template. Define slides as structured JSON, preview live in the browser, and export to PPTX.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Sandbox toolkit** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## Core Principles
+
+1. Always clone the reveal-slides-template starter — never scaffold from scratch.
+2. All slide content is defined in `src/slides.json` — this is the single source of truth for both the web preview and PPTX export.
+3. Choose a theme before writing content. Set `meta.theme` and `meta.brandColor` first.
+4. Preview in the browser before declaring done. Take a screenshot to verify.
+5. The PPTX export is available two ways: the Download button in the live preview toolbar, or `pnpm run export:pptx` from CLI.
+6. When using `sandbox_write_file` for `src/slides.json`, serialize the slide data to JSON text first. Do not pass a structured object as the tool argument.
+
+## Routing Table
+
+Read the focused reference based on the task:
+
+| Need | Reference |
+|------|-----------|
+| JSON schema for slides.json (all slide types and fields) | `references/slide-data-model.md` |
+| Available themes, how to pick one, CSS variable overrides | `references/theming.md` |
+| Exporting to PPTX (browser download or CLI) | `references/pptx-export.md` |
+
+For sandbox runtime mechanics (starting sandbox, running commands, file boundaries, artifacts), follow the **sandbox** curated skill and its references.
+
+## Workflow
+
+```
+1. Start sandbox
+2. Clone starter:
+   cd /home/user
+   git clone https://github.com/multigen-ai/reveal-slides-template.git slides
+   sandbox_set_active_directory(path="/home/user/slides")
+   pnpm install
+3. Edit src/slides.json — set meta (title, author, theme, brandColor) and slides array, then write the file as serialized JSON text
+4. Start dev server:
+   pnpm dev
+5. Verify:
+   sandbox_check_running_port(port=3000)
+   sandbox_get_preview_url(port=3000)
+6. Take screenshot to confirm visual output
+7. For PPTX export, either:
+   a. User clicks the Download PPTX button in the live preview toolbar
+   b. Or run: pnpm run export:pptx
+      The file is written to presentation.pptx in the project root
+```
+
+## Slide Types
+
+| Type | Purpose | Key Fields |
+|------|---------|------------|
+| `title` | Opening slide with big heading | `title`, `subtitle` |
+| `section` | Section divider | `title`, `subtitle` |
+| `content` | Bullet-point slide | `title`, `bullets[]` |
+| `two-column` | Side-by-side comparison | `title`, `left{heading, bullets[]}`, `right{heading, bullets[]}` |
+| `image` | Full-width image | `title`, `imageUrl`, `caption` |
+| `quote` | Centered quotation | `quote`, `attribution` |
+| `stat` | Metric cards (1-4 stats) | `title`, `stats[{value, label}]` |
+| `closing` | Final slide with contact info | `title`, `subtitle`, `contactInfo[]` |
+
+## Quick Reference: Sandbox Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `sandbox_start()` | Start sandbox |
+| `shell(command)` | Run commands in the sandbox (clone, install, start dev server) |
+| `sandbox_edit_file(path, old, new)` | Edit slides.json or styles |
+| `sandbox_write_file(path, content)` | Create or overwrite slides.json with JSON text content |
+| `sandbox_check_running_port(port)` | Verify dev server is up on port 3000 |
+| `sandbox_get_preview_url(port)` | Get public preview URL |
+| `sandbox_screenshot(url)` | Capture screenshot for verification |
+
+## Downstream Composition
+
+| Phase | Skill |
+|-------|-------|
+| Sandbox runtime, file boundaries, artifacts | `sandbox` curated skill |
+| Marketing landing pages (different starter) | `marketing-website` curated skill |
+| Deploy to Cloudflare | `cloudflare-app-deployment` curated skill |

--- a/skills/slides/references/pptx-export.md
+++ b/skills/slides/references/pptx-export.md
@@ -1,0 +1,81 @@
+---
+name: PPTX Export
+description: How to export presentations to PowerPoint format — browser download and CLI paths.
+---
+
+## Two Export Paths
+
+### 1. Browser Download (Live Preview)
+
+The live preview includes a floating toolbar at the bottom of the screen with a **Download PPTX** button. Clicking it generates the PPTX client-side using PptxGenJS and triggers a browser download.
+
+This requires the Vite dev server to be running (`pnpm dev`). The user clicks the button in the sandbox preview — no CLI step needed.
+
+### 2. CLI Export
+
+Run from the project root:
+
+```bash
+pnpm run export:pptx
+```
+
+This executes `scripts/export-pptx.ts` via `tsx`. It reads `src/slides.json`, generates the PPTX, and writes it to `presentation.pptx` in the project root.
+
+Custom output path:
+
+```bash
+pnpm run export:pptx -- --output=/home/user/slides/my-deck.pptx
+```
+
+## How It Works
+
+Both export paths use PptxGenJS with `LAYOUT_WIDE` (13.33" x 7.5" — standard widescreen).
+
+For each slide in `slides.json`:
+
+1. A slide is added to the PptxGenJS presentation
+2. The theme's color palette determines background, text, and accent colors
+3. Layout is handled per slide type (title centered, content left-aligned, stats in card grid, etc.)
+4. Images are fetched from their URLs and embedded directly
+
+### Theme-to-Color Mapping
+
+The PPTX exporter maps each theme to a fixed color palette:
+
+| Theme | Background | Foreground | Heading | Surface | Muted |
+|-------|------------|------------|---------|---------|-------|
+| `pitch-dark` | `050505` | `E5E5E5` | `FFFFFF` | `141414` | `888888` |
+| `minimal-swiss` | `F4F4F5` | `27272A` | `09090B` | `FFFFFF` | `71717A` |
+| `neo-brutal` | `FFDF00` | `000000` | `000000` | `FFFFFF` | `333333` |
+| `editorial-nature` | `E8ECE7` | `3A4038` | `1E241C` | `F4F6F3` | `6B7368` |
+
+The `brandColor` from `meta` is used for accent elements (bullets, stat values, accent bars, column headings).
+
+## Image Handling
+
+Image slides use `imageUrl` (an HTTPS URL). PptxGenJS fetches the image at export time and embeds it in the .pptx file.
+
+- Both browser and CLI exports support remote URLs
+- No pre-download step is needed
+- If the URL is unreachable, the slide will have a blank image area
+
+## Output File
+
+- **Browser export**: Downloaded by the browser as `<title-slug>.pptx`
+- **CLI export**: Written to `presentation.pptx` (or custom `--output` path)
+
+To make the CLI output accessible for download from the sandbox:
+
+```python
+shell("pnpm run export:pptx")
+display_file(path="/home/user/slides/presentation.pptx")
+```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `PptxGenJS is not a constructor` | Import compatibility issue — the template handles this with `(Module as any).default ?? Module` |
+| Images show as blank in PPTX | Verify the `imageUrl` is a publicly accessible HTTPS URL |
+| Content not centered | The exporter uses `LAYOUT_WIDE` (13.33" x 7.5") — coordinates are pre-calculated for this layout |
+| CLI export hangs | Image fetch may be slow for large images — use smaller/compressed URLs |

--- a/skills/slides/references/slide-data-model.md
+++ b/skills/slides/references/slide-data-model.md
@@ -1,0 +1,218 @@
+---
+name: Slide Data Model
+description: Full JSON schema for src/slides.json — all slide types, fields, and examples.
+---
+
+## Overview
+
+All presentation content lives in `src/slides.json`. This file is the single source of truth consumed by both the reveal.js renderer (live preview) and the PptxGenJS exporter (PPTX download).
+
+## Top-Level Structure
+
+```json
+{
+  "meta": { ... },
+  "slides": [ ... ]
+}
+```
+
+## Meta Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | Yes | Presentation title (shown on title slide and browser tab) |
+| `author` | string | Yes | Author name (embedded in PPTX metadata) |
+| `theme` | string | Yes | One of: `minimal-swiss`, `neo-brutal`, `editorial-nature`, `pitch-dark` |
+| `brandColor` | string | Yes | Hex color (e.g. `#3b82f6`) used for accents, bullets, stat values |
+| `fontHeading` | string | No | Override heading font family |
+| `fontBody` | string | No | Override body font family |
+
+## Slide Types
+
+Every slide object has a `type` field and an optional `notes` field (string, rendered as speaker notes).
+
+### title
+
+Opening slide with a large centered heading.
+
+```json
+{
+  "type": "title",
+  "title": "The Future of AI",
+  "subtitle": "How artificial intelligence is reshaping every industry",
+  "notes": "Welcome the audience."
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `subtitle` | string | No |
+| `notes` | string | No |
+
+### section
+
+Section divider — use to break the deck into logical parts.
+
+```json
+{
+  "type": "section",
+  "title": "The Landscape",
+  "subtitle": "Where we are today"
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `subtitle` | string | No |
+| `notes` | string | No |
+
+### content
+
+Standard bullet-point slide.
+
+```json
+{
+  "type": "content",
+  "title": "Key Breakthroughs",
+  "bullets": [
+    "Foundation models with trillion-parameter scale",
+    "Multimodal reasoning across text, image, and code",
+    "Autonomous agents that plan, act, and reflect"
+  ]
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `bullets` | string[] | Yes |
+| `notes` | string | No |
+
+### two-column
+
+Side-by-side comparison with independent headings and bullets.
+
+```json
+{
+  "type": "two-column",
+  "title": "Then vs Now",
+  "left": {
+    "heading": "2020",
+    "bullets": ["Single-task models", "Text-only interfaces"]
+  },
+  "right": {
+    "heading": "2026",
+    "bullets": ["General-purpose agents", "Multimodal native"]
+  }
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `left.heading` | string | Yes |
+| `left.bullets` | string[] | Yes |
+| `right.heading` | string | Yes |
+| `right.bullets` | string[] | Yes |
+| `notes` | string | No |
+
+### image
+
+Full-width image with optional caption.
+
+```json
+{
+  "type": "image",
+  "title": "Agent Architecture",
+  "imageUrl": "https://images.unsplash.com/photo-1677442136019-21780ecad995?w=1200&q=80",
+  "caption": "Modern AI systems combine reasoning, tools, and memory"
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `imageUrl` | string | Yes |
+| `caption` | string | No |
+| `notes` | string | No |
+
+Use full HTTPS URLs for images. Both the browser preview and PPTX export can fetch remote images directly.
+
+### quote
+
+Centered quotation with attribution.
+
+```json
+{
+  "type": "quote",
+  "quote": "The best way to predict the future is to invent it.",
+  "attribution": "Alan Kay"
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `quote` | string | Yes |
+| `attribution` | string | No |
+| `notes` | string | No |
+
+### stat
+
+Metric cards — works best with 2-4 stats.
+
+```json
+{
+  "type": "stat",
+  "title": "AI by the Numbers",
+  "stats": [
+    { "value": "$184B", "label": "Global AI market size (2025)" },
+    { "value": "72%", "label": "Enterprises using AI in production" },
+    { "value": "10x", "label": "Productivity gains in code generation" }
+  ]
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `stats` | array | Yes |
+| `stats[].value` | string | Yes |
+| `stats[].label` | string | Yes |
+| `notes` | string | No |
+
+### closing
+
+Final slide with contact information.
+
+```json
+{
+  "type": "closing",
+  "title": "Thank You",
+  "subtitle": "Let's build the future together",
+  "contactInfo": ["hello@hyper.ai", "hyper.ai", "@hyperai"]
+}
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `subtitle` | string | No |
+| `contactInfo` | string[] | No |
+| `notes` | string | No |
+
+## Writing the File
+
+Use `sandbox_write_file` to create or overwrite the entire file:
+
+```python
+sandbox_write_file(
+    file_path="src/slides.json",
+    content='{ "meta": { ... }, "slides": [ ... ] }',
+)
+```
+
+Or use `sandbox_edit_file` for targeted edits to an existing `slides.json`.
+
+The Vite dev server picks up changes automatically via HMR — no restart needed.

--- a/skills/slides/references/theming.md
+++ b/skills/slides/references/theming.md
@@ -1,0 +1,99 @@
+---
+name: Theming
+description: Available themes, how to select one, and CSS variable customization.
+---
+
+## Setting a Theme
+
+Set the `theme` field in `meta` inside `src/slides.json`:
+
+```json
+{
+  "meta": {
+    "title": "My Presentation",
+    "author": "Author Name",
+    "theme": "pitch-dark",
+    "brandColor": "#3b82f6"
+  }
+}
+```
+
+The theme controls background colors, text colors, typography, card styles, and visual personality. The `brandColor` is used for accents (bullets, stat values, section labels, decorative bars) across all themes.
+
+## Available Themes
+
+| Theme | Background | Feel | Best For |
+|-------|------------|------|----------|
+| `pitch-dark` | Near-black (#050505) | Deep contrast, subtle glowing accents, large card radius (24px) | Investor pitch decks, product demos, tech talks |
+| `minimal-swiss` | Light grey (#f4f4f5) | Ultra-clean, monochrome, sharp typography, zero border radius | Corporate reports, data presentations, formal decks |
+| `neo-brutal` | Vibrant yellow (#ffdf00) | High contrast, thick borders (4px), offset box shadows, uppercase titles | Creative agencies, bold announcements, startup pitches |
+| `editorial-nature` | Light sage (#e8ece7) | Elegant, muted earth tones, serif headings (Playfair Display), italic style | Thought leadership, editorial content, sustainability topics |
+
+### Legacy Themes
+
+These are also available but less polished:
+
+| Theme | Background | Notes |
+|-------|------------|-------|
+| `dark` | Dark navy (#0a0a0f) | Generic dark theme |
+| `light` | Off-white (#fafafa) | Generic light theme |
+| `corporate` | Deep blue (#0f172a) | Traditional corporate palette |
+| `creative` | Deep purple (#1a0533) | Purple-toned creative palette |
+
+## Brand Color
+
+The `brandColor` hex value overrides the `--brand-color` CSS variable. It is used for:
+
+- Bullet point markers
+- Stat card values
+- Section labels
+- Title slide accent bar
+- Column headings
+- Quote marks
+- Progress bar
+
+Pick a brand color that contrasts well with the theme's background. Examples:
+
+| Theme | Good brand colors |
+|-------|-------------------|
+| `pitch-dark` | `#3b82f6` (blue), `#10b981` (green), `#f59e0b` (amber) |
+| `minimal-swiss` | `#000000` (black), `#dc2626` (red), `#2563eb` (blue) |
+| `neo-brutal` | `#000000` (black), `#dc2626` (red) — keep high contrast on yellow |
+| `editorial-nature` | `#15803d` (green), `#92400e` (brown), `#1e40af` (deep blue) |
+
+## CSS Variable System
+
+Themes are implemented as CSS variable overrides on `[data-theme="<name>"]`. The variables:
+
+| Variable | Controls |
+|----------|----------|
+| `--bg` | Main slide background |
+| `--bg-secondary` | Section slide background |
+| `--fg` | Body text color |
+| `--fg-muted` | Subtitles, captions, labels |
+| `--fg-heading` | Heading text color |
+| `--accent` | Derived from `--brand-color` |
+| `--surface` | Card/column backgrounds |
+| `--surface-border` | Card border color |
+| `--font-heading` | Heading font stack |
+| `--font-body` | Body font stack |
+| `--card-radius` | Card corner radius |
+| `--card-shadow` | Card box shadow |
+| `--border-width` | Card border thickness |
+
+## Custom Font Overrides
+
+Set `fontHeading` and `fontBody` in the meta object to override the theme's defaults:
+
+```json
+{
+  "meta": {
+    "theme": "pitch-dark",
+    "brandColor": "#3b82f6",
+    "fontHeading": "Poppins",
+    "fontBody": "Source Sans Pro"
+  }
+}
+```
+
+The fonts must be available in the browser (Google Fonts can be loaded via a `<link>` tag in `index.html`).

--- a/skills/tiktok-ads/SKILL.md
+++ b/skills/tiktok-ads/SKILL.md
@@ -1,13 +1,29 @@
 ---
 name: tiktok-ads
 description: Plan and create TikTok advertising campaigns end-to-end via the Hyper MCP, with strict parameter validation for objective-specific requirements. Use when the user wants to launch TikTok ads, set up TikTok traffic or reach campaigns, configure conversions or app-promotion campaigns, upload TikTok video creatives, or analyze TikTok ad performance. Also triggers on tiktok marketing, tiktok campaign, tiktok ppc, or tiktok ads manager.
+use_cases:
+  - Create TikTok ad campaigns
+  - Set up TikTok traffic campaigns
+  - Configure TikTok reach campaigns
+  - Upload TikTok video ads
+  - Analyze TikTok ad performance
+  - TikTok brand awareness campaigns
+triggers:
+  - tiktok
+  - tiktok ads
+  - tiktok campaign
+  - tiktok marketing
+requires_toolkits:
+  - tiktok_marketing
+suggested_toolkits:
+  - file_manager
 ---
 
 # TikTok Ads
 
 Strategic guide for managing TikTok advertising campaigns. Research deeply, validate parameters carefully, and guide users through the platform's strict objective-specific requirements.
 
-This skill is for **paid TikTok ads** (the TikTok Marketing API surface). For organic TikTok video posting, see the future `tiktok-posting` sibling skill.
+This skill is for **paid TikTok ads** (the TikTok Marketing API surface). For organic TikTok video posting, see the [`tiktok`](../tiktok) skill.
 
 ## Requirements
 

--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: tiktok
 description: Publish organic TikTok content (videos, photos, carousels) through the TikTok-compliant interactive posting form via the Hyper MCP. Use when the user wants to post a video to TikTok, share photos on TikTok, upload to TikTok, or any phrase like "post this to TikTok" / "share on TikTok" / "put this on my TikTok". For paid TikTok advertising campaigns, use the `tiktok-ads` skill instead.
+use_cases:
+  - Post a video to TikTok
+  - Post photos to TikTok
+  - Share media on TikTok with privacy controls
+  - Complete TikTok branded content disclosures
+triggers:
+  - tiktok post
+  - post to tiktok
+  - upload to tiktok
+  - share on tiktok
+  - tiktok content
+requires_toolkits:
+  - tiktok
+suggested_toolkits:
+  - file_manager
 ---
 
 # TikTok

--- a/skills/twilio/SKILL.md
+++ b/skills/twilio/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: twilio
+description: Twilio messaging, voice, phone number management, and verification workflows. Use when the user wants to send SMS or WhatsApp messages, make voice calls, buy or configure phone numbers, or run OTP verification.
+use_cases:
+  - Send SMS messages
+  - Send WhatsApp messages
+  - Make phone calls
+  - Manage Twilio phone numbers
+  - Build OTP verification flows
+triggers:
+  - twilio
+  - sms
+  - whatsapp
+  - phone verification
+  - otp
+  - send message
+requires_toolkits:
+  - twilio_toolkit
+suggested_toolkits:
+  - file_manager
+---
+
+# Twilio Communications
+
+Use this skill for all Twilio tasks including SMS, WhatsApp, voice calls, and verification.
+
+## Requirements
+
+- **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
+- **Twilio integration** enabled at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations).
+
+## WhatsApp Sandbox Setup (Required for Testing)
+
+Before sending WhatsApp messages in sandbox/testing mode, users must join the sandbox:
+
+1. User goes to: https://console.twilio.com/us1/develop/sms/try-it-out/whatsapp-learn
+2. They find their unique join code (e.g., "join happy-turtle")
+3. They send that message from WhatsApp to **+14155238886**
+4. Once confirmed, use `twilio_send_whatsapp` with `from_number` set to `"+14155238886"`
+
+**If WhatsApp message fails with "not a valid WhatsApp-enabled number" or similar:**
+- The user likely hasn't joined the sandbox yet
+- Guide them through the steps above
+
+## Tool Quick Reference
+
+### Messaging
+- `twilio_send_sms` - Send SMS/MMS messages
+- `twilio_send_whatsapp` - Send WhatsApp messages (sandbox: use +14155238886 as from_number)
+- `twilio_list_messages` - List message history
+- `twilio_check_delivery_status` - Check if message was delivered
+
+### Voice Calls
+- `twilio_make_call` - Initiate outbound call (requires TwiML URL or inline TwiML)
+- `twilio_list_calls` - List call history
+- `twilio_list_recordings` - List call recordings
+
+### Phone Numbers
+- `twilio_list_phone_numbers` - List numbers in account (use to find valid from_number)
+- `twilio_lookup_phone` - Validate phone number and get carrier info
+
+### Verification (OTP)
+- `twilio_create_verification_service` - Create verification service first
+- `twilio_send_verification` - Send OTP code
+- `twilio_check_verification` - Verify user's code
+
+## Common Patterns
+
+**Before sending SMS/WhatsApp:** Call `twilio_list_phone_numbers` first to find a valid sender number.
+
+**WhatsApp sandbox flow:**
+1. Confirm user has joined sandbox (provide instructions if not)
+2. Call `twilio_send_whatsapp` with:
+```json
+{
+  "to": "+1XXXXXXXXXX",
+  "body": "Hello from the assistant",
+  "from_number": "+14155238886"
+}
+```
+
+**Phone verification flow:**
+
+Step 1 -- Call `twilio_create_verification_service` with:
+```json
+{
+  "friendly_name": "My App"
+}
+```
+
+Step 2 -- Call `twilio_send_verification` with:
+```json
+{
+  "service_sid": "<service_sid_from_step_1>",
+  "to": "+1XXXXXXXXXX",
+  "channel": "sms"
+}
+```
+
+Step 3 -- Call `twilio_check_verification` with:
+```json
+{
+  "service_sid": "<service_sid>",
+  "to": "+1XXXXXXXXXX",
+  "code": "<user_provided_code>"
+}
+```
+
+## Safety Rules
+
+- Never assume a valid sender number; always verify with `twilio_list_phone_numbers`.
+- Do not continue silently after failures; report exact error and ask user how to proceed.
+- For verification flows, keep service SIDs and code checks explicit and auditable.

--- a/skills/video-generation/SKILL.md
+++ b/skills/video-generation/SKILL.md
@@ -1,6 +1,44 @@
 ---
 name: video-generation
 description: End-to-end AI video production through the Hyper MCP — text-to-video and image-to-video generation (Sora, Veo, Seedance), scene chaining, video analysis, transcription, subtitles, TikTok / karaoke captions, voiceover (TTS), audio mixing, clipping, stitching, and text overlays. Use when the user asks to generate a video, create UGC, scene-chain, add captions or subtitles, add narration, stitch clips, clip a podcast highlight, or do any AI video editing.
+use_cases:
+  - Generate AI videos
+  - Create video content
+  - Scene-by-scene video production
+  - Text-to-video generation
+  - Image-to-video conversion
+  - Video editing and post-production
+  - Add subtitles and captions
+  - TikTok/Reels highlighted captions
+  - Stitch video clips together
+  - Add text overlays and graphics
+  - Review and analyze video quality
+  - Generate voiceover narration
+  - Add narration to video
+  - Clip video segments
+  - Podcast to short-form content
+triggers:
+  - video
+  - generate video
+  - sora
+  - veo
+  - seedance
+  - bytedance
+  - video creation
+  - video editing
+  - subtitles
+  - captions
+  - tiktok
+  - stitch videos
+  - video review
+  - narration
+  - voiceover
+  - clip video
+  - text to speech
+requires_toolkits:
+  - video_generation_toolkit
+suggested_toolkits:
+  - file_manager
 ---
 
 # Video Generation & Editing

--- a/skills/youtube/SKILL.md
+++ b/skills/youtube/SKILL.md
@@ -1,16 +1,52 @@
 ---
-name: youtube-transcript
-description: Fetch and work with YouTube video transcripts and content. Use when the user pastes a YouTube URL and wants a transcript, summary, blog post, social post, quote extraction, show notes, or any other text derived from a video. Also use when the user wants to repurpose video content, research competitor videos, extract key points without watching, pull timestamps, translate a video, or analyze what someone said in a YouTube video.
+name: youtube
+description: Work with YouTube content end to end — fetch transcripts and turn them into summaries, blog posts, social content, quotes, or show notes; create high-CTR thumbnails (with the user's face from an upload), clone the style of top-ranking thumbnails; and produce SEO-optimised titles + descriptions. Use when the user pastes a YouTube URL, wants to repurpose video content, research competitor videos, make or refresh a thumbnail, or package a video for upload.
+use_cases:
+  - Get the transcript of a YouTube video
+  - Summarize a YouTube video or extract key points without watching
+  - Turn a video into a blog post, LinkedIn post, or show notes
+  - Pull verbatim quotes with timestamps
+  - Generate a YouTube thumbnail from a video idea, transcript, or YouTube URL
+  - Research the top-performing thumbnails for a search term and clone their style
+  - Add the user's face (uploaded as an image) to a thumbnail
+  - Produce an SEO-optimised title set and description for an upcoming video
+triggers:
+  - youtube
+  - youtube transcript
+  - youtube video
+  - video summary
+  - repurpose video
+  - show notes
+  - thumbnail
+  - youtube thumbnail
+  - thumbnail clone
+  - SEO titles
+  - video description
+  - youtube title
+requires_toolkits:
+  - youtube_toolkit
+suggested_toolkits:
+  - image_gen
+  - sandbox
+  - file_manager
 ---
 
-# YouTube Transcript
+# YouTube
 
-Fetch the full transcript of any YouTube video and turn it into whatever the user needs — summaries, blog posts, social content, quotes, show notes, or raw text.
+Fetch the full transcript of any YouTube video and turn it into whatever the user needs — summaries, blog posts, social content, quotes, show notes, or raw text. Then package videos for upload: high-CTR thumbnails, SEO titles, and descriptions.
+
+## Routing
+
+| User intent | Where to go |
+| --- | --- |
+| Transcript, summary, repurposing, quotes, chapters | This guide (below) |
+| Thumbnails, style cloning, SEO titles/descriptions | `references/thumbnails.md` |
 
 ## Requirements
 
 - **Hyper MCP installed.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
 - **YouTube toolkit enabled** at [https://app.hyperfx.ai/integrations](https://app.hyperfx.ai/integrations) — provides `youtube_transcript` and `youtube_reader`.
+- Thumbnail workflows additionally need the image generation and sandbox toolkits.
 
 If `youtube_transcript` is not in the tool list, stop and tell the user to enable the YouTube toolkit in Hyper.
 
@@ -88,6 +124,10 @@ Once you have the text, ask the user what they need — or infer it from context
 | Repurpose for email | Rewrite as a narrative email — opening hook, key insight, CTA. |
 | Research / competitive analysis | Summarize what the speaker claims, what products they recommend, and what pain points they describe. |
 
+## Thumbnails and SEO packaging
+
+For making or refreshing thumbnails, cloning the style of top-ranking thumbnails, adding the user's face, and generating SEO titles/descriptions, read `references/thumbnails.md`. Every thumbnail workflow is a sandbox script under `scripts/` (`generate_thumbnail.py`, `research_top_thumbnails.py`, `clone_top_thumbnail_style.py`, `analyze_thumbnail_concepts.py`, `generate_seo_titles.py`, `generate_seo_description.py`) — the reference doc is the routing table and the rules for using them.
+
 ## Example outputs
 
 **Input:** `"Get the transcript of https://www.youtube.com/watch?v=NZLAdOL9fP8 and write a LinkedIn post from it"`
@@ -104,12 +144,12 @@ Once you have the text, ask the user what they need — or infer it from context
 1. Call `youtube_transcript(video_id_or_url="[URL]")`
 2. Return 4–6 bullet points of key takeaways, without padding or filler
 
-**Input:** `"Pull the timestamps for each section of this video"`
+**Input:** `"Make me a thumbnail like the top videos for 'AI agents'"`
 
 **Flow:**
-1. Call `youtube_transcript(video_id_or_url="[URL]")`
-2. Use the `segments` array to identify topic shifts
-3. Return a chapter list: `00:00 — Intro`, `01:23 — Feature demo`, etc.
+1. Read `references/thumbnails.md`
+2. Run `scripts/clone_top_thumbnail_style.py` with `query="AI agents"` and the user's topic
+3. Show the top thumbnails, let the user pick a rank, re-run with `chosen_rank` to generate
 
 ## Related skills
 

--- a/skills/youtube/references/composition-tips.md
+++ b/skills/youtube/references/composition-tips.md
@@ -1,0 +1,77 @@
+# Thumbnail composition tips
+
+Quick reference for the agent when generating or critiquing a YouTube
+thumbnail concept. Use these as constraints inside the image-generation
+prompt, not as suggestions appended after the fact.
+
+## The 1-3-5 rule
+
+A scrollable thumbnail can usually be parsed in under one second. Aim for:
+
+- **1 dominant focal point** (a face, an object, a number)
+- **≤3 visual elements** the eye needs to register
+- **≤5 words of overlay text**
+
+If the prompt has more than that, cut something before generating.
+
+## Composition
+
+- **Rule of thirds.** Place the focal subject on a third-line, not centred,
+  unless the concept explicitly calls for symmetry.
+- **Face on the left, text on the right** is the highest-CTR western default
+  because viewers read left-to-right and the face commands attention first.
+- **Eye contact** with the camera outperforms profile shots for human
+  subjects. Pupils visible, no sunglasses, no extreme angles.
+- **Negative space** behind text. Plain background or strong blur. Never put
+  text over busy textures.
+- **Contrast.** Foreground subject must visibly separate from background.
+  Use rim light, drop shadow, or a contrasting backdrop colour.
+
+## Colour palette
+
+- 2-3 colours max, plus white/black for text.
+- High-saturation accent colour (yellow, red, neon green, magenta, cyan)
+  for the focal element or text overlay.
+- Avoid YouTube-red as a dominant colour — it disappears against the UI.
+- Mood-to-palette cheat sheet:
+  - Curiosity / mystery → deep blue + neon accent
+  - Excitement / hype → red + yellow
+  - Tutorial / clean → white background + single accent
+  - Drama / personal → cinematic teal-and-orange
+
+## Text overlay
+
+- Maximum 2-5 words. If you can't say it in 5, you don't need text.
+- Sans-serif, heavy weight (Inter Black, Anton, Bebek, Impact-style).
+- Stroke or drop shadow for legibility on every background.
+- Capitalise content words; one ALL-CAPS power word is fine, never two.
+- Place text where it does **not** overlap the YouTube duration badge
+  (bottom-right corner) or the channel watermark (varies).
+
+## Faces and emotion
+
+- Strong, identifiable emotion: shocked, mind-blown, excited, smug,
+  knowing-smile. Neutral faces underperform.
+- One face per thumbnail unless the video is explicitly about contrast
+  (debate, comparison, before/after).
+- If using the user's uploaded face, preserve identity (no aging, no
+  gender swap, no race shift) and only adjust expression and lighting.
+
+## Mobile-first
+
+- Most YouTube views happen on mobile. Open the generated image at
+  ~280×158 px equivalent and check that:
+  - The focal subject is still recognisable.
+  - The text is still readable.
+  - The visual hook still lands in <1 second.
+
+If any of those fail, tell the user and offer to regenerate with a
+simplified composition.
+
+## What to avoid
+
+- Stock-photo poses (especially handshakes, generic smiles, headsets).
+- Generic AI-art tells (extra fingers, melted text, smooth plastic skin).
+- Watermarks of unknown brands you can't verify.
+- Misleading or fake "exclusive" badges.
+- Heavy emoji walls — one emoji max if the niche expects them.

--- a/skills/youtube/references/thumbnails.md
+++ b/skills/youtube/references/thumbnails.md
@@ -1,0 +1,64 @@
+
+# Thumbnail Creator
+
+Create high click-through YouTube thumbnails and the SEO assets that go with them. This skill orchestrates existing Hyper tools (YouTube research, image generation, AI extraction) through small Python scripts that run in the Hyper sandbox.
+
+## How this skill works
+
+Every workflow is a sandbox script under `scripts/`. The agent reads the matching reference doc, calls the script via the `sandbox` toolkit, and presents the JSON result back to the user. Generated images are persisted as `DBFile`s automatically and shown in chat.
+
+You do **not** chain individual image-generation or YouTube tools yourself unless the user asks for something the scripts don't cover. The scripts are the contract.
+
+## Routing Table
+
+| User intent | Run this script | Reference |
+|-------------|-----------------|-----------|
+| "Make me a thumbnail for X" | `scripts/generate_thumbnail.py` | Direct generation, optional face/brand/style references |
+| "What thumbnails work for `<niche>`?" | `scripts/research_top_thumbnails.py` | Returns top videos + downloaded thumbnails |
+| "Make me a thumbnail like the top videos for `<niche>`" | `scripts/clone_top_thumbnail_style.py` | Research → user picks rank → style-cloned generation |
+| "Analyse this video's thumbnail concepts" (URL given) | `scripts/analyze_thumbnail_concepts.py` | Returns 5 ready-to-render thumbnail concepts |
+| "Give me good titles for this video" | `scripts/generate_seo_titles.py` | Returns 10 styled SEO title options |
+| "Write the description for this video" | `scripts/generate_seo_description.py` | Returns hook, summary, takeaways, timestamps, hashtags |
+
+## Composed Workflows
+
+### A. Thumbnail from idea (no face)
+
+1. Confirm the video topic / hook in one sentence with the user.
+2. Run `scripts/generate_thumbnail.py` with `prompt=<your refined prompt>`.
+3. Show the resulting `file_id` in chat (it renders automatically).
+
+### B. Thumbnail with the user's face
+
+1. Ask the user to upload a clean photo of their face if they haven't already in the thread. Tell them a head-and-shoulders, well-lit photo works best.
+2. Once they upload, grab the file's `file_id` from the message attachments (it will look like `file_...`).
+3. Run `scripts/generate_thumbnail.py` with `prompt=<refined prompt>` and `face_file_ids=["<file_id>"]`.
+
+### C. Style-cloned thumbnail
+
+1. Run `scripts/clone_top_thumbnail_style.py` with `query=<niche search term>`, `my_topic=<their video idea>`, optional `face_file_id`, and `top_k=5`.
+2. The script returns the top `top_k` thumbnails so the user can pick the rank they like.
+3. Re-run with `chosen_rank=<n>` to actually generate the cloned thumbnail.
+
+### D. Full YouTube upload package
+
+For users prepping to publish. Run sequentially and present each result before moving to the next:
+
+1. `scripts/research_top_thumbnails.py` — what's working in the niche.
+2. `scripts/clone_top_thumbnail_style.py` — pick a winning style, generate the thumbnail.
+3. `scripts/generate_seo_titles.py` — 10 title options.
+4. `scripts/generate_seo_description.py` — full description with hashtags.
+
+## Rules
+
+1. Treat the user's face like a sensitive asset: only use file_ids the user explicitly uploaded in this thread, and never invent or reuse them across users.
+2. When the user mentions a niche or competitor channel, run `research_top_thumbnails` first — never guess what's working.
+3. Don't dump base64 image data or thumbnail URLs into the chat. Pass the `file_id` and let the platform render it.
+4. For style-cloning, always show the user the top thumbnails first and let them pick the rank. Style-cloning a low-ranked or off-topic video produces bad results.
+5. If the user uploads multiple face photos, prefer the most recent and ignore the rest unless they ask you to compose them.
+6. Use `nano_banana_image_generation` (flash) for cheap iteration and `pro` only when the thumbnail needs strong rendered text inside the image. Use `openai_image_edit` when composing multiple reference images (face + brand + product).
+
+## Reference
+
+- `references/composition-tips.md` — universal composition rules (rule of thirds, contrast, eye-line).
+- `references/youtube-thumbnail-best-practices.md` — YouTube-specific patterns (16:9, mobile-safe text, CTR triggers).

--- a/skills/youtube/references/youtube-thumbnail-best-practices.md
+++ b/skills/youtube/references/youtube-thumbnail-best-practices.md
@@ -1,0 +1,106 @@
+# YouTube thumbnail best practices
+
+Channel-agnostic packaging guidance the agent should apply when designing
+a thumbnail or critiquing one. Pair with `composition-tips.md`, which
+covers the visual mechanics.
+
+## CTR-driven mindset
+
+The thumbnail's only job is to win the click against ~12 sibling thumbnails
+on the suggested feed. Every design decision should be evaluated against:
+
+> "Does this make a viewer pause and click *instead* of the next video?"
+
+If the answer is "it looks nice", the thumbnail is failing.
+
+## The packaging unit
+
+A thumbnail never works alone. It must form a coherent **packaging unit**
+with the title:
+
+- **Curiosity gap** between thumbnail visual and title text — the visual
+  raises a question the title partially answers.
+- **No redundancy** — never use the same words on the thumbnail and in the
+  title. Wasted real estate.
+- **Tone match** — sober thumbnail + clickbait title = trust collapse.
+
+When in doubt, write the title first, then design the thumbnail to create
+tension with it.
+
+## Hook archetypes that consistently work
+
+Use these as a checklist when generating concepts:
+
+1. **Transformation / before-after** — clearly show two states.
+2. **Big number** — "$10K", "100×", "Day 47". Numbers must look hand-set,
+   not auto-rendered.
+3. **Contrarian claim** — visually contradict the audience's prior.
+4. **Curiosity gap** — show the *outcome* but obscure the *cause*.
+5. **Authority** — recognisable expert / celebrity / brand on screen.
+6. **Reaction shot** — strong emotion at something the viewer can't see.
+7. **Comparison / vs.** — two subjects with a divider.
+8. **Process reveal** — peek inside something normally hidden.
+9. **Risk / stakes** — implied danger, deadline, or scarcity.
+10. **Pattern interrupt** — visually breaks the niche's convention.
+
+Always pick one primary hook per thumbnail. Stacking hooks dilutes them.
+
+## Niche conventions
+
+Quickly check the top results for the user's search term (use
+`research_top_thumbnails`) and note the niche convention before designing.
+Common conventions:
+
+- **Tech / coding** — code editor screenshots, dark backgrounds, neon
+  highlights, expressive faces pointing at things.
+- **Finance** — green/red, large numbers, charts going up-and-to-the-right.
+- **Lifestyle / vlog** — bright outdoor shots, full body in frame, warm
+  colour grade.
+- **Educational / explainer** — diagrams, arrows, isolated subject on a
+  flat background.
+
+You can either follow the convention (safer, blends into the feed) or
+intentionally break it (riskier, but a strong differentiator). Tell the
+user which strategy you're using and why.
+
+## Title best practices
+
+- **Length** — keep under 70 characters so it never truncates on mobile or
+  the suggested feed.
+- **Keyword early** — primary keyword in the first 50 characters helps
+  search ranking.
+- **Avoid clickbait that misleads.** YouTube's ranking model penalises
+  high-CTR-but-low-watch-time videos harder than low-CTR ones.
+- **Test variants.** When the user asks for titles, give them 10 stylistic
+  variants (handled by `generate_seo_titles.py`) — they should A/B test.
+
+## Description best practices
+
+The first 1-2 lines show in search snippets and above the fold; everything
+else is for the algorithm.
+
+- **Hook line** — first line restates the value prop, includes the primary
+  keyword.
+- **Summary** — 2-3 sentences, keyword-natural, no stuffing.
+- **Key takeaways** — bulleted, scannable.
+- **Timestamps** — if you have them, include them. They both help retention
+  and unlock chapters.
+- **CTA** — single, specific call-to-action. "Subscribe for more" is dead;
+  "Get the template at <link>" works.
+- **Hashtags** — 3-5 relevant hashtags at the very end. The first 3 show
+  above the title.
+
+`generate_seo_description.py` produces this whole structure plus a
+`flattened` field the user can paste straight into YouTube.
+
+## Iteration loop
+
+When the user is iterating on a thumbnail:
+
+1. Generate 1 thumbnail at a time. Don't dump 4 variants without comment.
+2. After each generation, name the **specific** thing you'd change next
+   ("the text is competing with the face — move it lower", not "we could
+   try variations").
+3. Stop iterating after 3 attempts on the same concept. If it isn't working
+   after 3 tries, the concept is wrong; go back to
+   `analyze_thumbnail_concepts.py` for a different angle.

--- a/skills/youtube/scripts/analyze_thumbnail_concepts.py
+++ b/skills/youtube/scripts/analyze_thumbnail_concepts.py
@@ -1,0 +1,135 @@
+"""Extract 5 ready-to-render thumbnail concepts from a YouTube video.
+
+Pipeline:
+1. ``youtube_reader`` summarises the video (title, hook, key visuals, mood).
+2. ``ai_function`` coerces that summary into a strict 5-concept JSON schema
+   where each concept includes a one-line title, the visual composition, the
+   emotional hook, and a ``ready_to_use_prompt`` that can be passed straight
+   into ``generate_thumbnail.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from seti.sandbox import call_tool
+
+THUMBNAIL_CONCEPTS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "concepts": {
+            "type": "array",
+            "minItems": 5,
+            "maxItems": 5,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Short label for this concept (3-6 words).",
+                    },
+                    "composition": {
+                        "type": "string",
+                        "description": (
+                            "What the viewer sees: subject placement, focal "
+                            "point, background, color palette, mood, lighting."
+                        ),
+                    },
+                    "hook": {
+                        "type": "string",
+                        "description": (
+                            "Emotional or curiosity hook the thumbnail leans on "
+                            "(e.g. shock, transformation, before/after, big "
+                            "number, contrarian claim)."
+                        ),
+                    },
+                    "text_overlay": {
+                        "type": "string",
+                        "description": (
+                            "2-5 word overlay text. Use uppercase if it should "
+                            "render as such. Empty string if no text overlay."
+                        ),
+                    },
+                    "ready_to_use_prompt": {
+                        "type": "string",
+                        "description": (
+                            "Self-contained image-generation prompt that fully "
+                            "describes the thumbnail. Includes composition, "
+                            "subject(s), text overlay, color palette, lighting, "
+                            "and 16:9 framing."
+                        ),
+                    },
+                },
+                "required": [
+                    "title",
+                    "composition",
+                    "hook",
+                    "text_overlay",
+                    "ready_to_use_prompt",
+                ],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["concepts"],
+    "additionalProperties": False,
+}
+
+
+CONCEPT_EXTRACTION_PROMPT = (
+    "You are a YouTube thumbnail strategist. Given a video summary, design 5 "
+    "distinct high-CTR thumbnail concepts. Each concept should use a different "
+    "hook (e.g. shock, transformation, contrarian, big-number, curiosity gap). "
+    "Compositions must be optimised for 16:9 and remain readable on a small "
+    "mobile thumbnail. ready_to_use_prompt must be a complete image-generation "
+    "prompt with subject, composition, color palette, lighting, mood, and "
+    "explicit '16:9 YouTube thumbnail' framing. Do not reference brands you "
+    "are not sure about."
+)
+
+
+async def run(youtube_url: str) -> dict[str, Any]:
+    summary = await call_tool(
+        "youtube_reader",
+        url=youtube_url,
+        instruction=(
+            "Describe this video for a thumbnail designer. Cover the topic, "
+            "the host's appearance and emotion, the strongest visual moments, "
+            "any on-screen text or charts, the overall mood, and the single "
+            "biggest hook a viewer would click for. Be concise."
+        ),
+    )
+
+    summary_text = summary if isinstance(summary, str) else json.dumps(summary)
+
+    concepts_result = await call_tool(
+        "ai_function",
+        instructions=CONCEPT_EXTRACTION_PROMPT,
+        input={"video_summary": summary_text, "youtube_url": youtube_url},
+        output_format="json",
+        output_json_schema=THUMBNAIL_CONCEPTS_SCHEMA,
+        performance="fast",
+    )
+
+    output_json = concepts_result["results"][0].get("output_json") or {}
+    concepts = output_json.get("concepts", [])
+
+    return {
+        "youtube_url": youtube_url,
+        "video_summary": summary_text,
+        "concepts": concepts,
+    }
+
+
+EXAMPLE_INPUT = {"youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/youtube/scripts/clone_top_thumbnail_style.py
+++ b/skills/youtube/scripts/clone_top_thumbnail_style.py
@@ -1,0 +1,180 @@
+"""Clone the style of one of the top-performing thumbnails for a search term.
+
+Two-phase script:
+
+* Phase 1 (no ``chosen_rank``): runs ``research_top_thumbnails`` and returns
+  the top ``top_k`` candidates so the agent can present them to the user and
+  ask which rank to clone.
+
+* Phase 2 (``chosen_rank`` set): looks up the chosen thumbnail's
+  ``thumbnail_file_id`` and runs ``nano_banana_image_edit`` with that file as
+  the style reference. If a ``face_file_id`` is provided, the prompt is
+  augmented to composite the user's face into the cloned style.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from seti.sandbox import call_tool
+
+
+async def _research(query: str, top_k: int) -> list[dict[str, Any]]:
+    res = await call_tool(
+        "youtube_top_videos",
+        query=query,
+        max_results=top_k,
+        sort_by="views",
+        download_thumbnails=True,
+    )
+    items = res.get("items", []) if isinstance(res, dict) else []
+    return items
+
+
+def _build_clone_prompt(my_topic: str, has_face: bool, source_title: str | None) -> str:
+    base = (
+        f"Recreate this exact thumbnail style and composition, but for a video "
+        f"about: {my_topic.strip()}. Match the color palette, lighting, "
+        f"text-overlay style, character pose, and emotional tone of the "
+        f"reference image. Keep the 16:9 framing and a single dominant focal "
+        f"point. Replace any subject-specific imagery so it clearly relates "
+        f"to '{my_topic.strip()}'."
+    )
+    if source_title:
+        base += f" The reference is from a video titled '{source_title}'."
+    if has_face:
+        base += (
+            " Replace the main person in the thumbnail with the person from "
+            "the supplied face reference, preserving their identity, "
+            "expression style, and approximate pose. Composite cleanly with "
+            "matched lighting."
+        )
+    return base
+
+
+async def run(
+    query: str,
+    my_topic: str,
+    face_file_id: str | None = None,
+    top_k: int = 5,
+    chosen_rank: int | None = None,
+) -> dict[str, Any]:
+    if not query or not query.strip():
+        raise ValueError("query is required")
+    if not my_topic or not my_topic.strip():
+        raise ValueError("my_topic is required")
+
+    items = await _research(query, top_k)
+
+    if chosen_rank is None:
+        return {
+            "phase": "research",
+            "query": query,
+            "my_topic": my_topic,
+            "candidates": [
+                {
+                    "rank": item.get("rank"),
+                    "title": item.get("title"),
+                    "channel": item.get("channel"),
+                    "url": item.get("url"),
+                    "view_count": item.get("view_count"),
+                    "thumbnail_url": item.get("thumbnail_url"),
+                    "thumbnail_file_id": item.get("thumbnail_file_id"),
+                }
+                for item in items
+            ],
+            "next_step": (
+                "Show these candidates to the user. Then re-run this script "
+                "with chosen_rank=<n> to clone that thumbnail's style for "
+                f"'{my_topic}'."
+            ),
+        }
+
+    chosen = next((it for it in items if it.get("rank") == chosen_rank), None)
+    if chosen is None:
+        raise ValueError(
+            f"chosen_rank={chosen_rank} not found in top {top_k} results "
+            f"for query '{query}'"
+        )
+
+    style_file_id = chosen.get("thumbnail_file_id")
+    if not style_file_id:
+        raise RuntimeError(
+            f"No thumbnail_file_id available for rank {chosen_rank}. "
+            "The thumbnail download likely failed; try a different rank."
+        )
+
+    prompt = _build_clone_prompt(
+        my_topic=my_topic,
+        has_face=bool(face_file_id),
+        source_title=chosen.get("title"),
+    )
+
+    if face_file_id:
+        # OpenAI edit composes multiple references better than nano-banana edit
+        # when we need to preserve a person's identity.
+        result = await call_tool(
+            "openai_image_edit",
+            requests=[
+                {
+                    "prompt": prompt,
+                    "reference_images": [style_file_id, face_file_id],
+                }
+            ],
+            size="1536x1024",
+            quality="high",
+        )
+        used_tool = "openai_image_edit"
+    else:
+        result = await call_tool(
+            "nano_banana_image_edit",
+            file_id=style_file_id,
+            prompt=prompt,
+            n=1,
+            model="pro",
+            aspect_ratio="16:9",
+            image_size="2K",
+        )
+        used_tool = "nano_banana_image_edit"
+
+    images = result.get("images", []) if isinstance(result, dict) else []
+    if not images:
+        raise RuntimeError(f"{used_tool} returned no images: {result}")
+    primary = images[0]
+
+    return {
+        "phase": "generated",
+        "query": query,
+        "my_topic": my_topic,
+        "source": {
+            "rank": chosen.get("rank"),
+            "title": chosen.get("title"),
+            "channel": chosen.get("channel"),
+            "url": chosen.get("url"),
+            "thumbnail_file_id": style_file_id,
+        },
+        "tool_used": used_tool,
+        "prompt": prompt,
+        "primary": {
+            "file_id": primary.get("file_id"),
+            "url": primary.get("url"),
+        },
+    }
+
+
+EXAMPLE_INPUT = {
+    "query": "ai agent tutorial",
+    "my_topic": "Building a customer support agent with Claude",
+    "top_k": 5,
+}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/youtube/scripts/generate_seo_description.py
+++ b/skills/youtube/scripts/generate_seo_description.py
@@ -1,0 +1,161 @@
+"""Generate a structured, SEO-optimised YouTube description.
+
+Produces a hook line, a 2-3 sentence summary, key takeaways, suggested
+timestamps (when transcript or chapters are provided), pull-quotes, a CTA,
+and a list of relevant hashtags. The output is structured so the agent can
+either render it for the user or paste a flattened version into YouTube.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from seti.sandbox import call_tool
+
+SEO_DESCRIPTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "hook": {
+            "type": "string",
+            "description": "First line of the description, <=120 chars, hooks the viewer.",
+        },
+        "summary": {
+            "type": "string",
+            "description": "2-3 sentence summary including the primary keyword naturally.",
+        },
+        "key_takeaways": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 7,
+            "items": {"type": "string"},
+        },
+        "timestamps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "time": {
+                        "type": "string",
+                        "description": "MM:SS or HH:MM:SS",
+                    },
+                    "label": {"type": "string"},
+                },
+                "required": ["time", "label"],
+                "additionalProperties": False,
+            },
+            "description": ("Empty array if no transcript or chapters were provided."),
+        },
+        "pull_quotes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": 3,
+        },
+        "cta": {
+            "type": "string",
+            "description": "Single call-to-action line, <=140 chars.",
+        },
+        "hashtags": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 8,
+            "items": {
+                "type": "string",
+                "description": "Hashtag including the leading #.",
+            },
+        },
+        "flattened": {
+            "type": "string",
+            "description": (
+                "Final description ready to paste into YouTube, combining "
+                "hook, summary, takeaways, timestamps, CTA, and hashtags "
+                "with appropriate line breaks."
+            ),
+        },
+    },
+    "required": [
+        "hook",
+        "summary",
+        "key_takeaways",
+        "timestamps",
+        "pull_quotes",
+        "cta",
+        "hashtags",
+        "flattened",
+    ],
+    "additionalProperties": False,
+}
+
+
+SEO_DESCRIPTION_PROMPT = (
+    "You are a YouTube SEO copywriter. Write a structured, high-CTR video "
+    "description for the given video. Include the primary keyword naturally "
+    "in the hook and summary. Generate timestamps only if a transcript or "
+    "chapter list is provided. Hashtags should be lowercase, no spaces, "
+    "directly relevant. The 'flattened' field must be the final string the "
+    "user can paste into YouTube — assemble hook, summary, takeaways "
+    "(bulleted with '•'), timestamps (one per line as 'MM:SS — Label'), "
+    "the CTA, and hashtags on one line at the end. Avoid spammy emoji "
+    "walls and never invent facts not supported by the inputs."
+)
+
+
+async def run(
+    topic: str,
+    primary_keyword: str | None = None,
+    audience: str | None = None,
+    transcript_summary: str | None = None,
+    chapters: list[dict[str, str]] | None = None,
+    cta_link: str | None = None,
+) -> dict[str, Any]:
+    if not topic or not topic.strip():
+        raise ValueError("topic is required")
+
+    payload: dict[str, Any] = {"topic": topic}
+    if primary_keyword:
+        payload["primary_keyword"] = primary_keyword
+    if audience:
+        payload["audience"] = audience
+    if transcript_summary:
+        payload["transcript_summary"] = transcript_summary
+    if chapters:
+        payload["chapters"] = chapters
+    if cta_link:
+        payload["cta_link"] = cta_link
+
+    res = await call_tool(
+        "ai_function",
+        instructions=SEO_DESCRIPTION_PROMPT,
+        input=payload,
+        output_format="json",
+        output_json_schema=SEO_DESCRIPTION_SCHEMA,
+        performance="fast",
+    )
+
+    output_json = res["results"][0].get("output_json") or {}
+    return {
+        "topic": topic,
+        "primary_keyword": primary_keyword,
+        "description": output_json,
+    }
+
+
+EXAMPLE_INPUT = {
+    "topic": "Building an AI customer support agent in a weekend",
+    "primary_keyword": "AI customer support agent",
+    "audience": "indie SaaS founders",
+    "transcript_summary": (
+        "We build a Claude-powered support agent over a weekend, hook it up "
+        "to a knowledge base, and ship it to a real Intercom inbox."
+    ),
+}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/youtube/scripts/generate_seo_titles.py
+++ b/skills/youtube/scripts/generate_seo_titles.py
@@ -1,0 +1,126 @@
+"""Generate 10 SEO-optimised YouTube title variants.
+
+Each title is tagged with the persuasion style it leans on (curiosity-gap,
+listicle, contrarian, big-number, transformation, how-to, news-jack,
+question, before/after, bold-claim) so the user can quickly pick a tone that
+fits their channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from seti.sandbox import call_tool
+
+SEO_TITLES_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "titles": {
+            "type": "array",
+            "minItems": 10,
+            "maxItems": 10,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": (
+                            "YouTube title, <=70 chars, includes the primary "
+                            "keyword naturally, no clickbait that misleads."
+                        ),
+                    },
+                    "style": {
+                        "type": "string",
+                        "enum": [
+                            "curiosity-gap",
+                            "listicle",
+                            "contrarian",
+                            "big-number",
+                            "transformation",
+                            "how-to",
+                            "news-jack",
+                            "question",
+                            "before-after",
+                            "bold-claim",
+                        ],
+                    },
+                    "rationale": {
+                        "type": "string",
+                        "description": (
+                            "One sentence explaining why this title works for "
+                            "SEO and CTR for the given topic."
+                        ),
+                    },
+                    "char_count": {"type": "integer"},
+                },
+                "required": ["title", "style", "rationale", "char_count"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["titles"],
+    "additionalProperties": False,
+}
+
+
+SEO_TITLE_PROMPT = (
+    "You are a YouTube SEO and packaging expert. Given a topic, target "
+    "keyword, and audience, write 10 distinct title variants. Each must use "
+    "a different persuasion style from the enum. Keep all titles under 70 "
+    "characters. Include the primary keyword naturally in at least 7 of "
+    "them. Avoid all-caps spam, misleading clickbait, and emojis unless the "
+    "audience explicitly expects them. Set char_count to the exact length "
+    "of the title string."
+)
+
+
+async def run(
+    topic: str,
+    primary_keyword: str | None = None,
+    audience: str | None = None,
+    transcript_summary: str | None = None,
+) -> dict[str, Any]:
+    if not topic or not topic.strip():
+        raise ValueError("topic is required")
+
+    payload: dict[str, Any] = {"topic": topic}
+    if primary_keyword:
+        payload["primary_keyword"] = primary_keyword
+    if audience:
+        payload["audience"] = audience
+    if transcript_summary:
+        payload["transcript_summary"] = transcript_summary
+
+    res = await call_tool(
+        "ai_function",
+        instructions=SEO_TITLE_PROMPT,
+        input=payload,
+        output_format="json",
+        output_json_schema=SEO_TITLES_SCHEMA,
+        performance="fast",
+    )
+
+    output_json = res["results"][0].get("output_json") or {}
+    return {
+        "topic": topic,
+        "primary_keyword": primary_keyword,
+        "titles": output_json.get("titles", []),
+    }
+
+
+EXAMPLE_INPUT = {
+    "topic": "Building an AI customer support agent in a weekend",
+    "primary_keyword": "AI customer support agent",
+    "audience": "indie SaaS founders",
+}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/youtube/scripts/generate_thumbnail.py
+++ b/skills/youtube/scripts/generate_thumbnail.py
@@ -1,0 +1,153 @@
+"""Generate a single YouTube thumbnail.
+
+Routing logic chooses the right image-gen tool based on inputs:
+
+- ``style_reference_file_id`` set     -> ``nano_banana_image_edit`` with that
+                                          file as the base image (best for
+                                          cloning a single style reference).
+- ``brand_file_ids`` or
+  ``face_file_ids`` set               -> ``openai_image_edit`` with combined
+                                          reference_images (better at composing
+                                          multiple reference assets).
+- otherwise                           -> ``nano_banana_image_generation``
+                                          (``model='pro'`` if the prompt has
+                                          explicit text overlay, ``flash``
+                                          otherwise).
+
+All tool calls go through the sandbox RPC, so generated images are persisted
+as ``DBFile``s in the conversation thread and metering fires automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Literal
+
+from seti.sandbox import call_tool
+
+# Tokens that suggest the prompt requires legible text rendering inside the
+# image. Nano-banana 'pro' is materially better at text than 'flash'.
+_TEXT_HEAVY_TOKENS = (
+    '"',
+    "“",
+    "”",
+    "headline",
+    "headline:",
+    "text overlay",
+    "text:",
+    "caption",
+    "subtitle",
+    "title text",
+    "label",
+    "logo text",
+)
+
+
+def _looks_text_heavy(prompt: str) -> bool:
+    lowered = prompt.lower()
+    return any(tok in lowered for tok in _TEXT_HEAVY_TOKENS)
+
+
+def _normalise_aspect(aspect_ratio: str | None) -> str:
+    return aspect_ratio or "16:9"
+
+
+async def run(
+    prompt: str,
+    face_file_ids: list[str] | None = None,
+    brand_file_ids: list[str] | None = None,
+    style_reference_file_id: str | None = None,
+    aspect_ratio: str = "16:9",
+    image_size: Literal["1K", "2K", "4K"] = "2K",
+    model: Literal["pro", "flash", "auto"] = "auto",
+    n: int = 1,
+) -> dict[str, Any]:
+    if not prompt or not prompt.strip():
+        raise ValueError("prompt is required")
+
+    refs: list[str] = []
+    if face_file_ids:
+        refs.extend(face_file_ids)
+    if brand_file_ids:
+        refs.extend(brand_file_ids)
+
+    aspect = _normalise_aspect(aspect_ratio)
+    chosen_model = model
+    used_tool: str
+    result: dict[str, Any]
+
+    if style_reference_file_id:
+        used_tool = "nano_banana_image_edit"
+        if chosen_model == "auto":
+            chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        result = await call_tool(
+            used_tool,
+            file_id=style_reference_file_id,
+            prompt=prompt,
+            n=n,
+            model=chosen_model,
+            aspect_ratio=aspect,
+            image_size=image_size,
+        )
+    elif refs:
+        used_tool = "openai_image_edit"
+        # OpenAI image-edit only supports its native sizes.
+        openai_size = "1536x1024" if aspect.startswith("16") else "1024x1024"
+        result = await call_tool(
+            used_tool,
+            requests=[{"prompt": prompt, "reference_images": refs}],
+            size=openai_size,
+            quality="high",
+        )
+    else:
+        used_tool = "nano_banana_image_generation"
+        if chosen_model == "auto":
+            chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        result = await call_tool(
+            used_tool,
+            requests=[{"id": "thumbnail", "prompt": prompt}],
+            n=n,
+            model=chosen_model,
+            aspect_ratio=aspect,
+            image_size=image_size,
+        )
+
+    images = result.get("images", []) if isinstance(result, dict) else []
+    if not images:
+        raise RuntimeError(f"{used_tool} returned no images: {result}")
+
+    primary = images[0]
+    return {
+        "tool_used": used_tool,
+        "model": chosen_model if used_tool != "openai_image_edit" else "gpt-image-2",
+        "aspect_ratio": aspect,
+        "image_size": image_size,
+        "primary": {
+            "file_id": primary.get("file_id"),
+            "url": primary.get("url"),
+        },
+        "all_images": [
+            {"file_id": img.get("file_id"), "url": img.get("url")} for img in images
+        ],
+        "reference_count": len(refs) + (1 if style_reference_file_id else 0),
+    }
+
+
+EXAMPLE_INPUT = {
+    "prompt": (
+        "16:9 YouTube thumbnail, smiling young engineer pointing at a glowing "
+        "AI brain hologram on the right, dark studio background with neon "
+        "blue rim light, bold yellow text overlay 'AI AGENTS EXPLAINED' on "
+        "the left, cinematic depth of field"
+    ),
+}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/youtube/scripts/research_top_thumbnails.py
+++ b/skills/youtube/scripts/research_top_thumbnails.py
@@ -1,0 +1,73 @@
+"""Research the top-performing YouTube videos for a search term.
+
+Calls the new ``youtube_top_videos`` tool with ``download_thumbnails=True`` so
+that every result has a ``thumbnail_file_id`` that subsequent scripts (e.g.
+``clone_top_thumbnail_style``) can pass into image-edit tools as a reference.
+
+Returns a compact, ranked JSON shape that the agent can render or hand back
+to the user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Literal
+
+from seti.sandbox import call_tool
+
+
+async def run(
+    query: str,
+    max_results: int = 10,
+    sort_by: Literal["relevance", "views", "date"] = "views",
+    region: str | None = None,
+    upload_date: Literal["hour", "today", "week", "month", "year"] | None = None,
+) -> dict[str, Any]:
+    res = await call_tool(
+        "youtube_top_videos",
+        query=query,
+        max_results=max_results,
+        sort_by=sort_by,
+        region=region,
+        upload_date=upload_date,
+        download_thumbnails=True,
+    )
+
+    items = res.get("items", []) if isinstance(res, dict) else []
+    ranked: list[dict[str, Any]] = []
+    for item in items:
+        ranked.append(
+            {
+                "rank": item.get("rank"),
+                "title": item.get("title"),
+                "channel": item.get("channel"),
+                "url": item.get("url"),
+                "video_id": item.get("video_id"),
+                "view_count": item.get("view_count"),
+                "duration": item.get("duration"),
+                "published_at": item.get("published_at"),
+                "thumbnail_url": item.get("thumbnail_url"),
+                "thumbnail_file_id": item.get("thumbnail_file_id"),
+            }
+        )
+
+    return {
+        "query": query,
+        "sort_by": sort_by,
+        "region": region,
+        "result_count": len(ranked),
+        "results": ranked,
+    }
+
+
+EXAMPLE_INPUT = {"query": "ai agent tutorial", "max_results": 5}
+
+
+async def main() -> None:
+    result = await run(**EXAMPLE_INPUT)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Companion to [seti#778](https://github.com/multigen-ai/seti/pull/778), which makes seti seed its curated skill set from this repo. This PR moves the bundled skills over so this repo becomes the single source of truth — used both by the Hyper product agent and by external Claude Code users. 20 skills → **35 skills**.

## New skills (moved + renamed from seti `curated/`)

`gmail`, `twilio`, `slides`, `documents` (pdf-generation + markdown-to-pdf merged), `database`, `agents`, `slack`, `browser`, `google-sheets`, `reddit`, `openai-ads`, `polymarket-trading`, `sandbox`, `skill-creation`.

## Consolidations (no duplicates — one skill owns each surface)

- **`gtm`** = marketing-strategy (decision layer: choose focus, write `plan.md`/`status.md`, propose schedules) + marketing-playbooks (execution router). Paid-ads playbook steps now **delegate by reference** to `meta-ads`, `google-ads`, `ad-creative-generation`, `meta-ads-library` instead of duplicating them. Strategy references live under `references/strategy/`, kept playbook steps under `references/playbooks/`.
- **`youtube`** = `youtube-transcript` (renamed) + thumbnail-creator (6 sandbox scripts + composition/best-practice references + `references/thumbnails.md`).
- **`meta-ads`** absorbs meta-account-audit (`references/account-audit.md`) and meta-business's unique cached-insights/dashboard sections (`references/insights-and-dashboards.md`). The rest of meta-business was the ancestor of this skill — superseded.
- **`google-ads`** absorbs seti's GAQL reporting guide (`references/reporting.md` + 9 per-report recipes). The old google-ads-campaigns guide is structurally identical to this skill's current content — retired.

## Frontmatter enrichment (all 35 skills)

Every skill now carries `use_cases` / `triggers` / `requires_toolkits` / `suggested_toolkits` — required for seti's toolkit-gated skill discovery to surface these in-product. Values come from the bundled seti equivalents where they existed; inferred from tool usage for the five repo-only skills (cold-email-outreach, competitor-intel, customer-research, email-lifecycle, hyper-cli).

## Conventions

Moved skills were adapted to repo rules: `Use when` descriptions, `## Requirements` with the Hyper MCP link, `references/` directory naming, internal cross-skill links updated to the new names. README skill table + roadmap and plugin manifests updated (19 → 35 skills, version 1.1.0).

## Verification

- `./validate-skills.sh` — 35 skills, no errors
- All 35 folders load through seti's actual `load_skill_from_folder` with correct names, reference files, scripts, and toolkit requirements (0 failures)

## Not moved

- `admin-diagnostics` (internal prod runbook — stays bundled in seti)
- `cloudflare-app-deployment` (needs an env var that doesn't exist yet — moves later as `cloudflare`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)