### PR TITLE
google-ads skill: granular build flow replaces blueprints; canonical tool names

### DIFF
--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-ads
-description: Plan and create new Google Ads campaigns and report on existing accounts via the Hyper MCP. Use when the user wants to launch Search, Display, or Performance Max campaigns, build Google Ads reports or dashboards, diagnose conversion tracking, or mentions Google Ads, AdWords, search ads, display ads, Performance Max, PMax, PPC, Google campaigns, Google blueprint, search term reports, budget analysis, conversion funnels, negative keywords, or manager accounts (MCC).
+description: Plan and create new Google Ads campaigns and report on existing accounts via the Hyper MCP. Use when the user wants to launch Search, Display, Performance Max, Video, Demand Gen, Shopping, or App campaigns, build Google Ads reports or dashboards, diagnose conversion tracking, or mentions Google Ads, AdWords, search ads, display ads, Performance Max, PMax, PPC, Google campaigns, search term reports, budget analysis, conversion funnels, negative keywords, or manager accounts (MCC).
 requires_toolkits:
   - google_ads
 icon: google_ads
@@ -9,14 +9,14 @@ short_description: Plan and create Google Ads campaigns and build GAQL-backed re
 
 # Google Ads
 
-Strategic guide for building new Google Ads campaigns and reporting on existing accounts. Research first, consult intelligently, validate everything, and use the blueprint flow for controlled creation. Reporting is GAQL-backed and evidence-first — dashboards are optional presentation surfaces.
+Strategic guide for building new Google Ads campaigns and reporting on existing accounts. Research first, consult intelligently, validate everything, and build with the granular resource tools in dependency order (budget → campaign → targeting → ad groups → ads / asset groups). The API has exactly one campaign create — `google_ads_campaigns_create` — and the campaign type is just `advertising_channel_type`; type-specific requirements are enforced by the tools' built-in validators, which return corrective errors. Reporting is GAQL-backed and evidence-first — dashboards are optional presentation surfaces.
 
 ## Requirements
 
 - **Hyper MCP installed and connected.** [https://app.hyperfx.ai/mcp](https://app.hyperfx.ai/mcp)
 - **Google Ads integration connected** at [https://app.hyperfx.ai/apps](https://app.hyperfx.ai/apps).
 
-If `google_ads_list_accounts` is not in the tool list, stop and tell the user to enable Hyper MCP and connect Google Ads.
+If `google_ads_accounts_list` is not in the tool list, stop and tell the user to enable Hyper MCP and connect Google Ads.
 
 ## Out of scope
 
@@ -26,14 +26,23 @@ If `google_ads_list_accounts` is not in the tool list, stop and tell the user to
 
 ## Tool surface
 
+Reads are GAQL (`google_ads_gaql_query` covers every resource). Writes are one tool per resource operation, named `google_ads_<resource>_<create|update|remove>`; create/update take `(customer_id, body)` where `body` is the bare resource object in snake_case.
+
 | Tool | Purpose |
 | --- | --- |
-| `google_ads_list_accounts` | Discover accessible accounts (and MCC sub-accounts). |
-| `google_ads_execute_gaql` | Run a GAQL query (conversion actions, search term reports, etc.). |
-| `google_ads_search_locations` | Resolve human-readable location names to IDs. |
-| `google_ads_list_assets`, `google_ads_upload_image_asset` | Manage image assets for Display / PMax. |
-| `google_ads_preview_blueprint`, `google_ads_create_from_blueprint` | Validate + create Search/Display campaigns. |
-| `google_ads_preview_pmax_blueprint`, `google_ads_create_from_pmax_blueprint` | Validate + create Performance Max campaigns. |
+| `google_ads_accounts_list` | Discover accessible accounts (and MCC sub-accounts). |
+| `google_ads_gaql_query` | Run a GAQL query (conversion actions, search terms, any resource). |
+| `google_ads_campaign_budgets_create` | Create the budget first (micros!). |
+| `google_ads_campaigns_create` / `_update` / `_remove` | The ONE campaign create — every `advertising_channel_type` (SEARCH, DISPLAY, PERFORMANCE_MAX, VIDEO, DEMAND_GEN, SHOPPING, MULTI_CHANNEL for App). |
+| `google_ads_ad_groups_create` / `_update`, `google_ads_ad_groups_delete` | Ad groups under a campaign. |
+| `google_ads_ad_group_ads_create` / `_update` / `_remove` | Ads (typed: `responsive_search_ad`, `responsive_display_ad`, video / demand-gen ad types). |
+| `google_ads_keywords_create` / `_update` / `_delete` / `_list` | Keywords (positive and negative). |
+| `google_ads_locations_search`, `google_ads_location_targets_add` | Resolve location names, target them. |
+| `google_ads_image_assets_upload` | Image assets — accepts `file_id` from the workspace file manager, `image_url`, or base64. |
+| `google_ads_video_assets_link` | Register a YouTube video ID as a video asset (the Ads API cannot host video files — videos must be on YouTube). |
+| `google_ads_asset_groups_create` | PMax asset group (atomic: text + image assets in one call). |
+| `google_ads_conversion_actions_create`, `google_ads_user_lists_create`, `google_ads_bidding_strategies_create`, `google_ads_shared_sets_create`, … | Full per-resource CRUD surface — same naming pattern. |
+| `google_ads_request` | Raw escape hatch for any uncovered endpoint. |
 | `hyper_data_build_dashboard`, `hyper_data_refresh_dashboard` | Optional dashboards / data apps for reports. |
 
 ## Rules that must never be forgotten
@@ -42,7 +51,7 @@ If `google_ads_list_accounts` is not in the tool list, stop and tell the user to
 
 > **ALWAYS START PAUSED**: Create campaigns with `status="PAUSED"`. Activate only after explicit user approval.
 
-> **PREVIEW BEFORE CREATE**: Always use the blueprint system — build the blueprint JSON, call the **preview** tool, get explicit user approval, then call the **create** tool. Never skip the preview step. The blueprint validates locally, fills smart defaults, resolves locations, and rolls back on failure.
+> **SUMMARIZE BEFORE CREATE**: Present the full build plan (budget, campaign settings, targeting, ad groups, ads/assets) and get explicit user approval before the first mutate. Create in dependency order and reference each created resource by the `resource_name` the mutate returns. The tools validate bodies against the real API schema (writable fields, enum values) plus channel-type rules and return corrective errors — fix and retry rather than guessing.
 
 > **NEVER INVENT**: Don't assume URLs, budgets, or location IDs. Don't skip research. Don't invent keywords or copy — creative comes only from the actual site. Don't build without user buy-in.
 
@@ -60,10 +69,10 @@ Every campaign build follows this sequence. Do not skip steps.
 2. **Check the routing table** and read the referenced files before calling any tools
 3. **Discovery is mandatory for creation** ([references/discovery.md](references/discovery.md)) — account setup, site scan, conversion tracking check, market research, consultation
 4. **Present the pre-creation summary** and wait for explicit approval
-5. **Build blueprint → preview → user approval → create (PAUSED)**, re-checking [references/constraints.md](references/constraints.md) at each step
+5. **Build in dependency order (budget → campaign PAUSED → targeting → ad groups → ads/assets)** after approval, re-checking [references/constraints.md](references/constraints.md) at each step
 6. **Activate only when the user approves**
 
-Full workflow: Initial Setup → Research (site + GAQL + market) → Analyze (goals, audience, keywords) → Consult (options + trade-offs) → Recommend (structure + bids) → Confirm (summary approved) → Build Blueprint → Preview → User Approval → Create (PAUSED) → Activate (post-approval).
+Full workflow: Initial Setup → Research (site + GAQL + market) → Analyze (goals, audience, keywords) → Consult (options + trade-offs) → Recommend (structure + bids) → Confirm (summary approved) → Create in dependency order (PAUSED) → Verify by GAQL → Activate (post-approval).
 
 ## Routing table
 
@@ -72,6 +81,7 @@ Full workflow: Initial Setup → Research (site + GAQL + market) → Analyze (go
 | Create a Search or Display campaign | [references/discovery.md](references/discovery.md) → [references/campaigns/search-display.md](references/campaigns/search-display.md) |
 | Create a Performance Max campaign | [references/discovery.md](references/discovery.md) → [references/campaigns/pmax.md](references/campaigns/pmax.md) |
 | Add an asset group to an existing PMax campaign | [references/campaigns/pmax.md](references/campaigns/pmax.md) |
+| Create a Video, Demand Gen, Shopping, or App campaign | [references/discovery.md](references/discovery.md) → [references/campaigns/other-types.md](references/campaigns/other-types.md) |
 | Run a report / GAQL query / analyze performance (any kind) | [references/reporting.md](references/reporting.md) → the matching `references/reports/*.md` recipe |
 | Account health snapshot / "how is the account doing?" | [references/reporting.md](references/reporting.md) → [references/reports/account-overview.md](references/reports/account-overview.md) |
 | Diagnose conversion tracking | [references/reporting.md](references/reporting.md) → [references/reports/conversion-tracking.md](references/reports/conversion-tracking.md) |

--- a/skills/google-ads/references/campaigns/other-types.md
+++ b/skills/google-ads/references/campaigns/other-types.md
@@ -1,0 +1,28 @@
+# Video, Demand Gen, Shopping, and App campaigns
+
+Same one create tool — `google_ads_campaigns_create` — with the channel type and its required settings. The validators return corrective errors for missing channel requirements. Always: budget first, campaign **PAUSED**, targeting, then the type's ad/asset layer. Follow the approval discipline from [search-display.md](search-display.md).
+
+## Video (YouTube)
+
+- Campaign: `"advertising_channel_type": "VIDEO"` + a bidding scheme (`target_cpm` / `maximize_conversions` per goal).
+- Videos must be on YouTube — the Ads API cannot host video files. Register each with `google_ads_video_assets_link(customer_id, youtube_video_id)`.
+- Ad group (`google_ads_ad_groups_create`), then a video ad via `google_ads_ad_group_ads_create` with the matching typed ad object (e.g. `video_responsive_ad` referencing the video asset).
+
+## Demand Gen
+
+- Campaign: `"advertising_channel_type": "DEMAND_GEN"`, `maximize_conversions` or `target_cpa`.
+- Ad group, then `demand_gen_multi_asset_ad` / `demand_gen_carousel_ad` / `demand_gen_video_responsive_ad` on `google_ads_ad_group_ads_create` — images via `google_ads_image_assets_upload`, videos via YouTube link.
+
+## Shopping
+
+- Requires a linked Merchant Center account: `"shopping_setting": {"merchant_id": ...}` on the campaign body — the create is rejected without it. Find linked accounts by GAQL on `product_link`.
+- `"advertising_channel_type": "SHOPPING"`. Standard Shopping: ad group + `shopping_product_ad` (no creative fields — products come from the feed) + listing-group criteria via `google_ads_ad_group_criteria_create` (`listing_group` field).
+
+## App
+
+- Campaign: `"advertising_channel_type": "MULTI_CHANNEL"` with `"app_campaign_setting": {"app_id": "...", "app_store": "GOOGLE_APP_STORE"|"APPLE_APP_STORE", "bidding_strategy_goal_type": ...}` — required, enforced by the validator.
+- Assets (text/image/video) attach at campaign level; Google assembles the ads.
+
+## Anything else
+
+Every remaining resource has the same `google_ads_<resource>_<create|update|remove>` tools (conversion actions, user lists, bidding strategies, shared sets, labels, experiments, …); reads are GAQL; `google_ads_request` covers any uncovered endpoint.

--- a/skills/google-ads/references/campaigns/pmax.md
+++ b/skills/google-ads/references/campaigns/pmax.md
@@ -1,47 +1,40 @@
-# Performance Max campaigns (blueprint)
+# Performance Max campaigns (granular build)
 
-> **CRITICAL**: Always use the blueprint system for campaign creation. It validates locally, fills smart defaults, resolves locations, and rolls back on failure. Workflow: build blueprint → **preview** → explicit user approval → **create** ([discovery.md](../discovery.md) must be complete and the summary approved first).
+> **CRITICAL**: Present the full plan and get explicit user approval before the first mutate ([discovery.md](../discovery.md) must be complete and the summary approved). PMax campaigns MUST be created **PAUSED** — they need at least one asset group before they can serve, and the create tool enforces this.
 
-## Performance Max Campaigns
+## Build order
 
-**Preview**: `google_ads_preview_pmax_blueprint(blueprint={...})`
-**Create**: `google_ads_create_from_pmax_blueprint(blueprint={...})`
+1. **Budget** — `google_ads_campaign_budgets_create(customer_id, body={"name": "...", "amount_micros": 50000000})`. PMax budgets must not be shared.
+2. **Campaign** — `google_ads_campaigns_create(customer_id, body={...})`:
 
 ```json
 {
-  "customer_id": "1234567890",
   "name": "PMax Campaign",
-  "budget_amount_micros": 50000000,
-  "bidding_strategy": "MAXIMIZE_CONVERSIONS",
+  "advertising_channel_type": "PERFORMANCE_MAX",
   "status": "PAUSED",
-  "location_names": ["United States"],
-  "conversion_action_ids": ["1234567890"],
-  "asset_groups": [
-    {
-      "name": "Asset Group 1",
-      "headlines": ["Headline 1", "Headline 2", "Headline 3"],
-      "long_headlines": ["Longer headline up to 90 characters"],
-      "descriptions": ["Description 1", "Description 2"],
-      "business_name": "Business Name",
-      "final_urls": ["https://example.com"],
-      "marketing_image_asset_ids": ["1234567890"],
-      "square_marketing_image_asset_ids": ["1234567891"],
-      "logo_asset_ids": ["1234567892"]
-    }
-  ]
+  "campaign_budget": "customers/1234567890/campaignBudgets/111",
+  "maximize_conversions": {}
 }
 ```
 
-> **CRITICAL (PMax)**: All three image asset types are REQUIRED with correct aspect ratios. The preview tool validates ratios before creation.
+   Do NOT set `network_settings` or manual bidding — PMax serves across all networks automatically and only accepts `maximize_conversions` / `maximize_conversion_value` (optionally with `target_cpa` / `target_roas` inside the scheme). The validator rejects anything else.
+3. **Locations** — `google_ads_locations_search` → `google_ads_location_targets_add`.
+4. **Image assets** — `google_ads_image_assets_upload` (prefer `file_id` from the workspace file manager). Required ratios: landscape 1.91:1, square 1:1, logo 1:1 (or 4:1).
+5. **Asset group** — `google_ads_asset_groups_create` (atomic: creates the asset group, its text assets, and all links in ONE API call, which the API requires):
+
+   Required: `customer_id`, `campaign_id`, `final_urls`, `headlines` (3–15, ≤30 chars), `long_headlines` (1+, ≤90), `descriptions` (2+, ≤90), `business_name`, and all three image asset ID lists (`marketing_image_asset_ids`, `square_marketing_image_asset_ids`, `logo_asset_ids`).
+6. **Optional video** — register a YouTube video with `google_ads_video_assets_link(customer_id, youtube_video_id)`, then link it to the asset group with `google_ads_asset_group_assets_link(field_type="YOUTUBE_VIDEO")`. Without one, Google auto-generates video from your assets.
 
 ## Standalone PMax asset group (existing campaign)
 
-Use `google_ads_asset_groups_create` (legacy name `google_ads_create_asset_group`) to add an asset group to an **existing** Performance Max campaign without running the full blueprint flow.
-
-Required: `customer_id`, `campaign_id`, `final_urls`, text assets (`headlines`, `long_headlines`, `descriptions`, `business_name`), and all three image asset ID lists.
+`google_ads_asset_groups_create` also adds asset groups to existing PMax campaigns — same required fields as step 5.
 
 ## Campaign dates (API v24)
 
-Optional `start_date` / `end_date` on blueprints and campaign tools use `YYYY-MM-DD`. The backend encodes them to v24 wire fields `startDateTime` / `endDateTime` (`yyyy-MM-dd HH:mm:ss`). Omit both dates to let Google set schedule defaults.
+Optional `start_date` / `end_date` use `YYYY-MM-DD`. The backend encodes them to v24 wire fields `startDateTime` / `endDateTime`. Omit both to let Google set schedule defaults.
 
-Re-check [constraints.md](../constraints.md) (blueprint features, bidding strategies, technical rules) at each creation step.
+## Verify, then activate
+
+Confirm by GAQL (campaign + asset_group + asset_group_asset), present to the user, and only set `status: "ENABLED"` via `google_ads_campaigns_update` after explicit approval.
+
+Re-check [constraints.md](../constraints.md) at each creation step.

--- a/skills/google-ads/references/campaigns/search-display.md
+++ b/skills/google-ads/references/campaigns/search-display.md
@@ -1,73 +1,75 @@
-# Search & Display campaigns (blueprint)
+# Search & Display campaigns (granular build)
 
-> **CRITICAL**: Always use the blueprint system for campaign creation. It validates locally, fills smart defaults, resolves locations, and rolls back on failure.
+> **CRITICAL**: Present the full plan and get explicit user approval before the first mutate ([discovery.md](../discovery.md) must be complete and the summary approved). Create everything **PAUSED**, in dependency order, carrying each returned `resource_name` into the next step. The tools validate bodies (writable fields, real enums, channel-type rules) and return corrective errors — fix and retry.
 
-## Workflow: Preview → Confirm → Create
+## Build order
 
-1. Build the blueprint JSON from research ([discovery.md](../discovery.md) must be complete and the summary approved).
-2. Call the **preview** tool to validate and show the user what will be created.
-3. Get explicit user approval.
-4. Call the **create** tool.
-
-## Search & Display Campaigns
-
-**Preview**: `google_ads_preview_blueprint(blueprint={...})`
-**Create**: `google_ads_create_from_blueprint(blueprint={...})`
+1. **Budget** — `google_ads_campaign_budgets_create(customer_id, body={"name": "...", "amount_micros": 50000000})` ($50/day; micros!). Returns `customers/{cid}/campaignBudgets/{id}`.
+2. **Campaign** — `google_ads_campaigns_create(customer_id, body={...})`:
 
 ```json
 {
-  "customer_id": "1234567890",
   "name": "Campaign Name",
-  "budget_amount_micros": 50000000,
   "advertising_channel_type": "SEARCH",
-  "bidding_strategy": "MAXIMIZE_CLICKS",
   "status": "PAUSED",
-  "location_names": ["New York", "Los Angeles"],  // array in blueprints; note: google_ads_search_locations takes a single string for manual lookup
-  "conversion_action_ids": ["1234567890"],
-  "ad_schedules": [
-    {"day_of_week": "MONDAY", "start_hour": 9, "end_hour": 17}
-  ],
-  "sitelinks": [
-    {"link_text": "Free Trial", "final_urls": ["https://example.com/trial"]}
-  ],
-  "callouts": [{"callout_text": "Free Shipping"}],
-  "ad_groups": [
-    {
-      "name": "Ad Group 1",
-      "keywords": [
-        {"text": "marketing software", "match_type": "PHRASE"},
-        {"text": "competitor brand", "match_type": "EXACT", "negative": true}
-      ],
-      "ads": [
-        {
-          "headlines": ["Headline 1", "Headline 2", "Headline 3"],
-          "descriptions": ["Description 1", "Description 2"],
-          "final_urls": ["https://example.com"]
-        }
-      ],
-      "audiences": [{"audience_id": "1234567890"}]
-    }
-  ]
+  "campaign_budget": "customers/1234567890/campaignBudgets/111",
+  "maximize_clicks": {},
+  "network_settings": {"target_google_search": true, "target_search_network": true}
 }
 ```
 
-For **Display** campaigns, set `"advertising_channel_type": "DISPLAY"` and use `display_ads` instead of `ads`:
+   Bidding is ONE scheme field on the campaign: `maximize_clicks`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_roas`, or `manual_cpc`. For Display set `"advertising_channel_type": "DISPLAY"`.
+3. **Locations** — resolve names with `google_ads_locations_search`, then `google_ads_location_targets_add(customer_id, campaign_id, location_ids=[...])`.
+4. **Ad group** — `google_ads_ad_groups_create(customer_id, body={"name": "Ad Group 1", "campaign": "customers/{cid}/campaigns/{id}", "status": "PAUSED"})`.
+5. **Keywords** (Search) — `google_ads_keywords_create(customer_id, ad_group_id, keywords=[{"text": "marketing software", "match_type": "PHRASE"}, {"text": "competitor brand", "match_type": "EXACT", "negative": true}])`.
+6. **Ads** — `google_ads_ad_group_ads_create(customer_id, body={...})` with exactly ONE typed ad object:
+
 ```json
-"display_ads": [{
-  "headlines": ["Headline 1", "Headline 2", "Headline 3"],
-  "long_headline": "Longer headline up to 90 characters",
-  "descriptions": ["Description 1", "Description 2"],
-  "business_name": "Business Name",
+{
+  "ad_group": "customers/1234567890/adGroups/222",
+  "status": "PAUSED",
+  "ad": {
+    "final_urls": ["https://example.com"],
+    "responsive_search_ad": {
+      "headlines": [{"text": "Headline 1"}, {"text": "Headline 2"}, {"text": "Headline 3"}],
+      "descriptions": [{"text": "Description 1"}, {"text": "Description 2"}]
+    }
+  }
+}
+```
+
+   RSA minimums: 3–15 headlines (≤30 chars), 2–4 descriptions (≤90 chars).
+
+## Display ads
+
+Upload the three image asset types first with `google_ads_image_assets_upload` (prefer `file_id` from the workspace file manager), then create a `responsive_display_ad`:
+
+```json
+"ad": {
   "final_urls": ["https://example.com"],
-  "marketing_image_asset_ids": ["1234567890"],
-  "square_marketing_image_asset_ids": ["1234567891"],
-  "logo_asset_ids": ["1234567892"]
-}]
+  "responsive_display_ad": {
+    "headlines": [{"text": "Headline 1"}],
+    "long_headline": {"text": "Longer headline up to 90 characters"},
+    "descriptions": [{"text": "Description 1"}],
+    "business_name": "Business Name",
+    "marketing_images": [{"asset": "customers/{cid}/assets/{landscape_id}"}],
+    "square_marketing_images": [{"asset": "customers/{cid}/assets/{square_id}"}],
+    "square_logo_images": [{"asset": "customers/{cid}/assets/{logo_id}"}]
+  }
+}
 ```
 
 > **CRITICAL (Display)**: All three image asset types are REQUIRED:
-> - `marketing_image_asset_ids` — landscape 1.91:1 (e.g. 1200×628).
-> - `square_marketing_image_asset_ids` — square 1:1 (e.g. 1200×1200).
-> - `logo_asset_ids` — square 1:1 or landscape 4:1.
+> - marketing images — landscape 1.91:1 (e.g. 1200×628)
+> - square marketing images — square 1:1 (e.g. 1200×1200)
+> - logos — square 1:1 (or landscape 4:1)
 
-Re-check [constraints.md](../constraints.md) (blueprint features, bidding strategies, technical rules) at each creation step.
+## Extensions (sitelinks, callouts)
+
+Create assets with `google_ads_assets_create` (`sitelink_asset` / `callout_asset` field on the body), then link with `google_ads_campaign_assets_link(customer_id, campaign_id, asset_id, field_type="SITELINK"|"CALLOUT")`.
+
+## Verify, then activate
+
+After building, confirm the tree by GAQL (campaign, ad groups, ads, keywords), present it to the user, and only set `status: "ENABLED"` via `google_ads_campaigns_update` after explicit approval.
+
+Re-check [constraints.md](../constraints.md) (bidding strategies, technical rules) at each creation step.

--- a/skills/google-ads/references/constraints.md
+++ b/skills/google-ads/references/constraints.md
@@ -33,10 +33,10 @@ Re-check this file at each creation step.
 
 - Budget in micros: $50 → 50,000,000.
 - Create PAUSED; activate only after approval.
-- Location resolution: use `location_names` in blueprint (auto-resolved) or `google_ads_search_locations` for manual lookup.
+- Location resolution: `google_ads_locations_search` to resolve names, then `google_ads_location_targets_add`.
 - RSA limits: headlines ≤30 chars (min 3), descriptions ≤90 chars (min 2).
 - Creative source: only from the actual site; no generic claims.
-- Image assets must already exist in the account (use `google_ads_list_assets` to find them).
+- Image assets must already exist in the account (use `google_ads_assets_list` to find them).
 
 ## Critical Safety Rules
 

--- a/skills/google-ads/references/discovery.md
+++ b/skills/google-ads/references/discovery.md
@@ -1,10 +1,10 @@
 # Discovery, research, and consultation
 
-Every campaign build starts here. Do not skip any phase — the pre-creation summary at the end must be approved before any blueprint is built.
+Every campaign build starts here. Do not skip any phase — the pre-creation summary at the end must be approved before anything is created.
 
 ## Phase 1: Initial Setup
 
-Call `google_ads_list_accounts()` to list accessible accounts.
+Call `google_ads_accounts_list()` to list accessible accounts.
 
 - If multiple: ask the user to select one.
 - If single: inform the user and proceed.
@@ -27,7 +27,7 @@ google_ads_diagnose_conversion_tracking(customer_id="<from list_accounts>")
 
 This returns all conversion actions, their status, and any tracking signal issues in one call. If the user's MCP doesn't expose `google_ads_diagnose_conversion_tracking`, fall back to GAQL:
 ```
-google_ads_execute_gaql(
+google_ads_gaql_query(
   customer_id="<from list_accounts>",
   query="""
     SELECT conversion_action.id, conversion_action.name,
@@ -38,7 +38,7 @@ google_ads_execute_gaql(
 )
 ```
 
-> **`google_ads_execute_gaql` vs `google_ads_run_gaql`:** `execute_gaql` works on manager accounts (MCC) and sub-accounts. `run_gaql` is only available on non-manager accounts. Use `execute_gaql` consistently — it works everywhere.
+> **`google_ads_gaql_query` vs `google_ads_run_gaql`:** `execute_gaql` works on manager accounts (MCC) and sub-accounts. `run_gaql` is only available on non-manager accounts. Use `execute_gaql` consistently — it works everywhere.
 
 ### Market & Keyword Research
 - Inspect SERPs, competitors, and themes.
@@ -57,7 +57,7 @@ Act as a partner, not order-taker:
 - Present findings (site + GAQL + market).
 - Recommend bidding (default Smart Bidding when tracking exists) with trade-offs.
 - Propose structure (campaign → themed ad groups → keywords + match types).
-- Suggest locations via `google_ads_search_locations(customer_id="...", location_names="New York")`. Note: `location_names` is a single string, not an array — pass a city, state, country, or postal code and the tool returns matching geo target IDs.
+- Suggest locations via `google_ads_locations_search(customer_id="...", location_names="New York")`. Note: `location_names` is a single string, not an array — pass a city, state, country, or postal code and the tool returns matching geo target IDs.
 - Set budget expectations via benchmark ranges.
 - Show reasoning for each choice.
 

--- a/skills/google-ads/references/heuristics.md
+++ b/skills/google-ads/references/heuristics.md
@@ -21,7 +21,7 @@ to keep claims tied to the queried data; they are not optimization rules.
 
 ## Optional dashboard/data app rules
 
-- Use `google_ads_execute_gaql` inside `tool_data_sources`.
+- Use `google_ads_gaql_query` inside `tool_data_sources`.
 - Query the saved cache table with `sql_data_sources`.
 - Bind only SQL output variables inside the dashboard/data app code.
 - Return the persisted dashboard artifact as the final output only when the

--- a/skills/google-ads/references/mcc.md
+++ b/skills/google-ads/references/mcc.md
@@ -3,7 +3,7 @@
 When a user provides a manager account (MCC) with multiple sub-accounts:
 
 ## Batching Rule
-**Never query more than 5 sub-accounts in a single run.** Each `google_ads_execute_gaql` call goes through a proxy with a timeout. Querying 10+ accounts sequentially in one loop reliably causes 504 timeouts.
+**Never query more than 5 sub-accounts in a single run.** Each `google_ads_gaql_query` call goes through a proxy with a timeout. Querying 10+ accounts sequentially in one loop reliably causes 504 timeouts.
 
 Process in batches of 5 and aggregate results before proceeding:
 ```
@@ -16,7 +16,7 @@ Batch 3: accounts[10:15] → collect results
 Announce progress to the user: `"Processing accounts 1-5 of 23..."`.
 
 ## 504 Timeout Recovery
-If a `google_ads_execute_gaql` call times out (504 / "Google Ads API timed out after retries"):
+If a `google_ads_gaql_query` call times out (504 / "Google Ads API timed out after retries"):
 1. The tool already retries 3× internally — do not retry immediately.
 2. Reduce the scope: narrow the date range, add a `LIMIT`, or split the account list further.
 3. Tell the user which accounts succeeded and which failed; do not silently drop accounts.
@@ -26,7 +26,7 @@ If a `google_ads_execute_gaql` call times out (504 / "Google Ads API timed out a
 For MCC search term reports across many sub-accounts:
 
 ```
-1. Get all accounts: google_ads_list_accounts()
+1. Get all accounts: google_ads_accounts_list()
    Filter to sub-accounts: [a for a in result.accounts if not a["manager"]]
 2. For each batch of 5 accounts:
    - Run search_term_view GAQL (using segments.keyword.info.*, NOT ad_group_criterion).

--- a/skills/google-ads/references/reporting.md
+++ b/skills/google-ads/references/reporting.md
@@ -4,7 +4,7 @@ Report on existing Google Ads accounts using GAQL-backed data. Dashboards and da
 
 ## Core contract
 
-- Use `google_ads_execute_gaql` as the canonical Google Ads data tool.
+- Use `google_ads_gaql_query` as the canonical Google Ads data tool.
 - Written GAQL-backed reports are valid outputs. Build a dashboard or data app only when the user asks for one or when an interactive view materially improves the answer.
 - Do not use the alternate GAQL alias (`google_ads_run_gaql`) in new examples — `execute_gaql` works on both manager and sub-accounts.
 - Treat rows as evidence, not as automatic recommendations ([heuristics.md](heuristics.md)).
@@ -13,7 +13,7 @@ Report on existing Google Ads accounts using GAQL-backed data. Dashboards and da
 
 ## Phase 1: Access and scope
 
-1. Call `google_ads_list_accounts()` before touching account data.
+1. Call `google_ads_accounts_list()` before touching account data.
 2. Confirm the customer ID if more than one account is available.
 3. Confirm the reporting window if the user has not given one.
 4. If the user did not ask for a dashboard/data app and the best output is unclear, ask whether they want a written report or an interactive view.
@@ -86,7 +86,7 @@ Before authoring a custom dashboard:
 
 The implementation pattern is:
 
-1. `tool_data_sources` — the report's GAQL runs through `google_ads_execute_gaql` and the rows are saved to a cache table (convention: `gads_<report>_<scope>`).
+1. `tool_data_sources` — the report's GAQL runs through `google_ads_gaql_query` and the rows are saved to a cache table (convention: `gads_<report>_<scope>`).
 2. `sql_data_sources` — re-aggregate the cache table into named variables (KPIs, time series, top lists).
 3. Build the interface with cards, KPIs, charts, tables, and a clear visual hierarchy. Bind only SQL output variables inside the dashboard/data app code.
 4. `refresh` — set `{"mode": "scheduled", "cron": "0 * * * *"}` to keep the dashboard live; default is manual.
@@ -96,7 +96,7 @@ hyper_data_build_dashboard(
     name="Google Ads Report",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {"customer_id": "...", "query": "..."},
             "cache_table": "gads_report_raw",
             "mode": "replace",

--- a/skills/google-ads/references/reports/account-overview.md
+++ b/skills/google-ads/references/reports/account-overview.md
@@ -17,7 +17,7 @@ orient before drilling into a specific issue.
 - `customer_id` (required).
 - `date_range` (default: `LAST_30_DAYS`).
 
-Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+Use the GAQL below through `google_ads_gaql_query` for both ad-hoc
 reporting and refreshable dashboards.
 
 ## GAQL
@@ -56,7 +56,7 @@ result = hyper_data_build_dashboard(
     name="Account Overview",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/ad-performance.md
+++ b/skills/google-ads/references/reports/ad-performance.md
@@ -56,7 +56,7 @@ result = hyper_data_build_dashboard(
     name="Ad Performance",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/budget-distribution.md
+++ b/skills/google-ads/references/reports/budget-distribution.md
@@ -13,7 +13,7 @@ Where spend is actually going across campaigns.
 - `customer_id` (required).
 - `date_range` (default: `LAST_30_DAYS`).
 
-Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+Use the GAQL below through `google_ads_gaql_query` for both ad-hoc
 reporting and refreshable dashboards.
 
 ## GAQL
@@ -51,7 +51,7 @@ result = hyper_data_build_dashboard(
     name="Budget Distribution",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/campaign-performance.md
+++ b/skills/google-ads/references/reports/campaign-performance.md
@@ -17,7 +17,7 @@ reports when an issue surfaces.
 - `date_range` (default: `LAST_30_DAYS`).
 - Optional: `campaign_ids` filter.
 
-Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+Use the GAQL below through `google_ads_gaql_query` for both ad-hoc
 reporting and refreshable dashboards.
 
 ## GAQL
@@ -57,7 +57,7 @@ result = hyper_data_build_dashboard(
     name="Campaign Performance",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/campaign-structure.md
+++ b/skills/google-ads/references/reports/campaign-structure.md
@@ -16,7 +16,7 @@ clicks, and conversions sit across account organization.
 - `customer_id` (required).
 - `date_range` (default: `LAST_30_DAYS`).
 
-Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+Use the GAQL below through `google_ads_gaql_query` for both ad-hoc
 reporting and refreshable dashboards.
 
 ## GAQL
@@ -55,7 +55,7 @@ result = hyper_data_build_dashboard(
     name="Campaign Structure",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/conversion-by-action.md
+++ b/skills/google-ads/references/reports/conversion-by-action.md
@@ -97,7 +97,7 @@ result = hyper_data_build_dashboard(
     name="Conversions by Action",
     tool_data_sources={
         "raw_conversions": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (
@@ -114,7 +114,7 @@ result = hyper_data_build_dashboard(
             "mode": "replace",
         },
         "raw_cost": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/conversion-funnel.md
+++ b/skills/google-ads/references/reports/conversion-funnel.md
@@ -110,7 +110,7 @@ result = hyper_data_build_dashboard(
     name="Lead-Gen Funnel",
     tool_data_sources={
         "raw_conversions": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (
@@ -127,7 +127,7 @@ result = hyper_data_build_dashboard(
             "mode": "replace",
         },
         "raw_cost": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/conversion-tracking.md
+++ b/skills/google-ads/references/reports/conversion-tracking.md
@@ -15,7 +15,7 @@ dashboards.
 
 - `customer_id` (required).
 
-Use the GAQL below through `google_ads_execute_gaql` when you need
+Use the GAQL below through `google_ads_gaql_query` when you need
 conversion-action metadata. This is separate from campaign-level
 conversion metrics, which use `segments.conversion_action*`.
 
@@ -54,7 +54,7 @@ result = hyper_data_build_dashboard(
     name="Conversion Tracking Audit",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (

--- a/skills/google-ads/references/reports/search-terms-waste.md
+++ b/skills/google-ads/references/reports/search-terms-waste.md
@@ -18,7 +18,7 @@ conversion value.
 - Threshold: cost-without-conversion floor (default: $10 / 10_000_000
   micros over the window).
 
-Use the GAQL below through `google_ads_execute_gaql` for both ad-hoc
+Use the GAQL below through `google_ads_gaql_query` for both ad-hoc
 reporting and refreshable dashboards.
 
 ## GAQL
@@ -54,7 +54,7 @@ result = hyper_data_build_dashboard(
     name="Search Terms Waste",
     tool_data_sources={
         "raw": {
-            "tool_name": "google_ads_execute_gaql",
+            "tool_name": "google_ads_gaql_query",
             "tool_args": {
                 "customer_id": "123-456-7890",
                 "query": (


### PR DESCRIPTION
Companion to seti PR multigen-ai/seti#1035 (blueprints removed; SDK-generated CRUD surface). Do not merge before that reaches staging.

- Campaign builds now use the per-resource tools in dependency order (budget → campaign PAUSED → targeting → ad groups → ads/asset groups); the campaign-type workflow knowledge that lived in blueprint code is now skill recipes.
- One `google_ads_campaigns_create` for every channel type; new `references/campaigns/other-types.md` for Video / Demand Gen / Shopping / App.
- PMax recipe uses the atomic `google_ads_asset_groups_create` and documents the PAUSED-until-asset-group rule the validator enforces.
- Image upload by workspace `file_id`; video = YouTube-ID assets (API cannot host video files).
- Canonical MCP tool names throughout (also swept ad-creative-generation's google-ads reference).
- `./validate-skills.sh`: 30 skills OK.