### PR TITLE
blog-generation: add the five reference files SKILL.md points at

### DIFF
--- a/skills/blog-generation/references/ai-citation-playbook.md
+++ b/skills/blog-generation/references/ai-citation-playbook.md
@@ -1,0 +1,85 @@
+# AI Citation Playbook
+
+How to get a brand cited and recommended by AI assistants (ChatGPT, Claude, Perplexity, Google AI Overviews and AI Mode, Gemini, Copilot). On-page structure (in `blog-playbook.md`) is necessary but not sufficient. This file covers the levers that decide whether a model trusts and surfaces the brand.
+
+---
+
+## 1. The factor order (what to edit first)
+
+The Princeton GEO study tested optimization tactics on thousands of queries and measured the lift in AI visibility. Edit in this priority order. These are causal, not vibes:
+
+1. **Cite sources** inline. Biggest lever. Add a credible source next to claims.
+2. **Add statistics.** Specific numbers with timeframes.
+3. **Add quotations** from named people or named sources.
+4. **Authoritative, fluent tone.** Clear, confident, well-written prose.
+5. **Improve clarity.** Plain, easy-to-extract sentences.
+
+And the one that hurts: **keyword stuffing scored below the do-nothing baseline.** Density tricks actively reduce AI visibility.
+
+Two findings that change strategy:
+- **The lift is largest for pages not already ranked #1.** A challenger page can gain dramatically from citations and statistics; the incumbent gains little. If the brand is not winning, these tactics are the highest-leverage move available.
+- **Combining tactics beats any single one.** Stat + named quote + source citation in the same section compounds.
+
+A 2026 study of hundreds of thousands of AI-cited URLs adds the correlations: clarity and summarization, E-E-A-T signals, a Q&A format, and clean section structure all track with getting cited, while a **promotional, salesy tone tracks negatively.** Read-out: write like a credible expert explaining something, not like a brochure.
+
+---
+
+## 2. Be the primary source
+
+AI models preferentially cite original, first-hand material over aggregated rehashing. The most citable content a brand can publish:
+
+- **Original data and research.** A survey, a benchmark, an analysis of the brand's own anonymized usage. This is the single best long-term citation asset.
+- **First-party case studies with real numbers.** "[Customer] went from X to Y in Z." Specific, attributable, impossible for a model to generate from training.
+- **Genuine expertise and experience.** First-hand detail, opinions, edge cases, and lessons that only someone who actually did the work would know.
+
+If the page only restates what is already on the web, there is no reason for a model to cite it over the original. Find the brand's proprietary angle and lead with it.
+
+---
+
+## 3. E-E-A-T and author signals (now an eligibility gate)
+
+For queries where sourcing matters, a page with no verifiable author entity is structurally excluded from citation. Treat author identity as infrastructure, not decoration.
+
+- **Named, credentialed authors.** Real person, real bio, real credentials, photo. "Admin" or "Staff" bylines give engines nothing to verify.
+- **Experience layered on expertise.** The bio and the content should show first-hand experience, not just topical knowledge.
+- **Author `Person` schema with `sameAs`.** Link the author to their LinkedIn, X, and any professional or scholarly profile. AI systems traverse these chains to resolve "is this a real, trustworthy person."
+
+---
+
+## 4. Brand entity and off-page presence (the part most people skip)
+
+The biggest blind spot, and for AI recommendation it is decisive. In 2026 analyses, **unlinked brand mentions across the web correlated with AI citations more strongly than backlinks did.** Models recommend brands they have seen described, consistently, in many credible places.
+
+- **Make the brand a clean entity.** Consistent name and description everywhere. An `Organization` schema with `sameAs`. Where the brand qualifies, a Wikidata entry gives it a persistent identifier. Claim the Google Knowledge Panel.
+- **Get mentioned where AI reads.** The engines lean heavily on encyclopedic references, large community sites (Reddit shows up disproportionately, especially in Perplexity), YouTube, and the credible publications of the niche. A mention there is worth more than another link on a low-authority blog.
+- **Get into the "best X" roundups.** Listicle and comparison content is the most-cited format in AI answers. Being honestly included in third-party "best [category]" lists puts the brand into the exact pages models quote for recommendations.
+- **Be consistent.** The same positioning, category, and one-liner across the site, profiles, and third-party mentions.
+
+This is why content alone is necessary but not sufficient: the page makes the brand citable; the off-page footprint makes the model confident enough to actually recommend it.
+
+---
+
+## 5. Per-engine notes
+
+They barely overlap. The same brand can be cited very differently across engines. Cover the topic well and broadly rather than overfitting one engine.
+
+- **ChatGPT search:** leans on Bing's index and on content-to-answer fit; fresher content tends to do better.
+- **Perplexity:** heavy on community sources (notably Reddit), rewards clean atomic answers and clear structure, surfaces PDFs.
+- **Google AI Overviews and AI Mode:** run on core Search ranking plus retrieval and query fan-out. The model decomposes a question into many sub-queries, so cover the whole topic cluster. Recognized entities (Knowledge Graph) get surfaced more.
+- **Copilot:** Bing-based; page speed and indexability matter.
+- **Claude:** selective; favors factual density and authoritative, well-structured sources.
+
+The unifying move is to be the clearest, best-sourced, most-mentioned answer to the question.
+
+---
+
+## 6. The honest Google stance (say this to clients)
+
+Google's own 2026 guidance is the credibility anchor, and worth stating plainly to a customer who has been sold "AEO secrets":
+
+- Optimizing for AI search "is still SEO." AI Overviews and AI Mode use the same core ranking and quality systems, plus retrieval (grounding) and query fan-out.
+- The single biggest lever is unique, people-first, non-commodity content. Do not publish what others already said or what a model could generate on its own.
+- There is no required special markup, no required file, no need to chunk content, and no separate "AI writing style." Eligibility is ordinary: indexed and snippet-eligible.
+- Authentic mentions help; inauthentic mention-farming does not.
+
+The pitch to a customer is honest and durable: there is no trick. There is doing the fundamentals unusually well, in their real voice, with their real proof, structured so a machine can quote it.

--- a/skills/blog-generation/references/blog-archetypes.md
+++ b/skills/blog-generation/references/blog-archetypes.md
@@ -1,0 +1,182 @@
+# Blog Archetypes (authoritative per-type specs)
+
+The full playbook for each blog type. Pick one with the table below, then build to that type's exact spec. Every type still obeys the universal rules in `blog-playbook.md` (answer-first lead, question-shaped H2s, self-contained sections, no fabrication) and the voice and quality gate in `brand-voice-and-quality.md`. The schema notes assume the JSON-LD rules in `on-page-and-technical.md`.
+
+## Pick the type
+
+| Archetype | Query / intent it serves | Length | Schema | AI-citation lever |
+| --- | --- | ---: | --- | --- |
+| What-is / definition | "what is X", "X meaning" (informational) | 800-1,500 | Article | Clean definition block; the canonical "X is..." sentence |
+| How-to / step-by-step | "how to X", "X steps" (task) | 1,000-2,000 | Article (ordered steps) | Numbered, self-contained steps |
+| Comparison (X vs Y) | "X vs Y" (commercial) | 1,500-3,000 | Article | The comparison table + clear verdict |
+| Listicle / best-of | "best X", "top X for Y" (commercial) | 1,500-2,500 | Article + ItemList | Ranked table + consistent per-entry blocks |
+| Alternatives | "X alternatives" (commercial) | 1,500-2,500 | Article + ItemList | Per-alternative "best for" framing |
+| Pillar / hub guide | broad head term (authority) | 2,500-4,000 | Article | Topical completeness + internal links |
+| Pain / diagnostic | "why is my X doing Y", "X not working" | 1,000-1,800 | Article | Direct cause-and-fix answer up top |
+| Original research / data | a claim only your data can prove | 1,200-3,000 | Article (+ Dataset if apt) | First-party stats others will cite |
+| Case study | "X results", proof for buyers | 800-1,500 | Article | Named, numeric, attributable outcome |
+| Glossary / definition page | many small "what is X" terms at scale | 300-800 each | DefinedTerm / Article | One crisp definition per term |
+
+Choosing rule: classify the query intent (`hyperseo_intents_search`), then confirm the format against what already ranks (`hyperseo_serp_results_get`). If the SERP is all listicles, do not publish an essay.
+
+---
+
+## What-is / definition guide
+
+**Use for** informational "what is / what does X mean" queries. The workhorse for topical authority and AI definitions.
+
+**Structure**
+1. Lead: "**[Term]** is [one self-contained sentence]." Then 1 to 2 sentences of expansion. This is the block AI quotes for the definition.
+2. "How does [X] work?" (mechanism, plain language).
+3. "Why does [X] matter?" or "What is [X] used for?" (concrete examples, ideally first-hand).
+4. Types / variations, or key components, if the term has them.
+5. "[X] vs [related term]" mini-section if people confuse the two.
+6. FAQ (4 to 8 real questions).
+
+**Pitfalls:** burying the definition; staying abstract with no examples; padding to hit a word count.
+
+---
+
+## How-to / step-by-step guide
+
+**Use for** task intent. People who want to *do* the thing.
+
+**Structure**
+1. Lead: state the outcome and roughly how long / hard it is. "You can [outcome] in [N] steps. Here is how."
+2. Prerequisites or what you need (short).
+3. Numbered steps. Each step: a bolded action-verb name, what to do, and the result. Each step self-contained.
+4. Common mistakes / troubleshooting (this section earns "why is my X failing" citations too).
+5. FAQ.
+
+**AI angle:** numbered, atomic steps are extracted cleanly. Keep each step understandable on its own.
+
+**Pitfalls:** vague steps ("configure your settings"); missing the result of each step; no troubleshooting.
+
+---
+
+## Comparison (X vs Y)
+
+**Use for** commercial "X vs Y" queries where the reader is choosing between two options.
+
+**Structure**
+1. Lead with the verdict: one sentence on who should pick X and who should pick Y. Do not make them scroll for it.
+2. A comparison table near the top (dimensions down the side, X and Y across).
+3. A short section per option: what it is, what it is best at, honest limitation.
+4. "Which should you choose?" tied to reader profiles ("If you [situation], pick X").
+5. FAQ.
+
+**Honesty rules:** compare like to like (product vs product, or company vs company, never mixed). Give each side a real "best for". Never trash the other option; a fair comparison is more persuasive and more citable. If you publish this on your own brand's site, your product can win, but the concession has to be real and the other tools' strengths stated like you mean them.
+
+**Linking:** internal links to your own cluster; no outbound links to a direct competitor's site from a page you want to rank for the shared query (it leaks equity and signals endorsement). Mention them in text; do not link them.
+
+---
+
+## Listicle / best-of (the format AI cites most)
+
+**Use for** "best X", "top X for [use case]", "best X for [vertical]". Listicles and comparisons are the single most-cited content format in AI answers, so this type gets the fullest spec.
+
+**Structure**
+1. **Lead** (40 to 60 words): state what the list covers and who it is for. Name the top pick in the first sentence so AI can extract it.
+2. **Quick-comparison table at the top** (the highest-ROI block): one row per item, consistent columns. Keep the column order fixed, prices in a consistent short form, and "best for" cells concrete. If you score, make the scores vary honestly (not 9.5 for everything) and order the table by rank.
+3. **One section per entry, identical structure** (consistency is what makes the list scannable and extractable):
+   - `### N. [Name]`
+   - One image of the item right after the heading (optional but strong; never caption it as "screenshot of X", let the alt text carry it).
+   - Two or three short paragraphs: what it is and its lane; one concrete capability with a number; pricing transparency plus the best-fit buyer and an honest limitation.
+   - A 4-bullet summary: **Pricing**, **Pros** (3 specifics), **Cons** (3 honest gaps), **Verdict** (one sentence on who it is for).
+4. **"How we chose"** methodology section near the end. An E-E-A-T and trust signal: state the criteria, that you actually evaluated them, and any first-hand testing. It also makes the list more citable.
+5. FAQ.
+
+**Honesty and ranking:** if it is your brand's own list, your product can rank #1, but its Cons bullet must concede something real and its claims must be verifiable. On someone else's list, a brand should sit mid-pack with a sharp "best for" hook; being #1 in a third-party list reads as paid.
+
+**Pitfalls:** inconsistent entry structure; vague "great, easy to use" filler instead of specifics; fabricated scores or fake pros/cons; identical scores; linking out to every listed competitor.
+
+---
+
+## Alternatives page (X alternatives)
+
+**Use for** "X alternatives", "alternatives to X" (a buyer who knows X but is shopping).
+
+**Structure**
+1. Lead: one sentence on why someone looks for alternatives to X (price, missing feature, fit), then name the strongest alternative.
+2. Quick table of alternatives with a "best for" per row.
+3. Per-alternative sections (like a listicle entry, lighter).
+4. "How to choose" by reader situation.
+5. FAQ.
+
+**Scope discipline:** keep the alternatives in the same product class. Someone searching "[CRM] alternatives" wants another CRM, not an adjacent tool. An off-class alternative will not convert and the page reads as bait. Only build this for direct, in-lane peers.
+
+---
+
+## Pillar / hub guide
+
+**Use for** the broad head term that anchors a topic cluster.
+
+**Structure**
+1. Lead: define the topic and tell the reader what the guide covers.
+2. Comprehensive sections covering every major subtopic, each a question-shaped H2 that summarizes and then links out to a dedicated supporting post.
+3. A "chapters" or table-of-contents block near the top for navigation.
+4. FAQ spanning the whole topic.
+
+**Role:** the pillar is the internal-linking hub. Publish the supporting posts first, interlink them, then ship the pillar so it inherits a web of links. See clusters in `blog-playbook.md`.
+
+---
+
+## Pain / diagnostic ("why is my X doing Y")
+
+**Use for** problem-aware queries ("why is my [thing] [bad outcome]", "[thing] not working"). These earn AI Overview citations because the model wants a direct cause-and-fix.
+
+**Structure**
+1. Lead: the most common cause and the one-line fix, immediately. "[Outcome] is usually caused by [cause]. Fix it by [action]."
+2. A ranked list of likely causes, each with how to confirm it and how to fix it.
+3. How to prevent it recurring. (If the brand's product prevents this, the natural, non-salesy place to name it.)
+4. When to get help / escalate.
+5. FAQ.
+
+**AI angle:** the answer-first cause-and-fix is exactly what gets pulled into an AI Overview. Lead with it.
+
+---
+
+## Original research / data study (the best long-term citation asset)
+
+**Use for** a claim only the brand's own data can prove. The most citable thing you can publish, because no model can generate it from training.
+
+**Structure**
+1. Lead: the single headline finding, as one quotable stat. "We analyzed [N] [things]. [Headline number]."
+2. Key findings as a scannable list, each a stat with its number.
+3. Methodology (what you measured, sample size, dates, limitations). Non-negotiable for trust and citation.
+4. Charts/tables of the data (with the numbers in text too, since AI bots may not read the chart image).
+5. What it means / what to do about it.
+
+**Rules:** real data only, never fabricated or "illustrative" numbers presented as real. State the sample and date. This is the asset competitors and journalists cite back to you, which compounds your entity authority.
+
+---
+
+## Case study (first-party proof)
+
+**Use for** buyer-stage proof, and as the page you link every outcome claim back to.
+
+**Structure**
+1. Lead: the named customer and the headline result in one sentence. "[Customer] [did X] and [got Y result]."
+2. The situation / problem.
+3. What they did (the brand's role, specifically).
+4. Results with real numbers and, ideally, a named quote from the customer.
+5. A short "could this work for you" close.
+
+**Rules:** real customer, real numbers, real (approved) quote. The highest-trust, most-citable proof a brand owns. Get permission before naming anyone.
+
+---
+
+## Glossary / definition page (at scale)
+
+**Use for** building many small definition pages for an industry's terms (a programmatic-style cluster).
+
+**Structure (per term):** one clean "**[Term]** is [definition]" lead, a short expansion, a "related terms" set of internal links, and one example. Keep each page genuinely useful and distinct. Do not mass-produce thin, near-identical pages with no added value; that triggers scaled-content spam treatment. Each page needs a real reason to exist.
+
+---
+
+## Cross-references
+
+- Universal structure, content blocks, GEO writing rules, clusters: `blog-playbook.md`
+- Schema per type, on-page, technical: `on-page-and-technical.md`
+- Getting cited, authority, off-page: `ai-citation-playbook.md`
+- Voice, anti-cringe, pre-publish gate: `brand-voice-and-quality.md`

--- a/skills/blog-generation/references/blog-playbook.md
+++ b/skills/blog-generation/references/blog-playbook.md
@@ -1,0 +1,122 @@
+# Blog Playbook: structure that ranks and gets cited
+
+How to write a blog post that wins Google rankings and gets pulled into AI answers. The core of the skill. Read it fully before drafting.
+
+The mechanism to keep in mind: classic search ranks a *page*; AI search extracts a *passage*. A great post is built so that any section can be lifted out and stand on its own as the answer to one question. Write for the passage, and the page wins too.
+
+---
+
+## 1. Pick the archetype first
+
+Match the content type to search intent (from `hyperseo_intents_search`) and to what already ranks (from `hyperseo_serp_results_get`). Do not write a 3,000-word essay where the SERP rewards a listicle. The full per-type specs live in `blog-archetypes.md`; read the one for your chosen type before drafting.
+
+**Length rule:** match the intent and the SERP, then stop. Word count is not a ranking factor. Thin content loses; padded content also loses. The average AI-Overview-cited page in 2026 is roughly 1,300 words, and over half are under 1,000. Long-form earns more links, but only when every paragraph carries weight.
+
+---
+
+## 2. The non-negotiable structure
+
+Every post, regardless of archetype, follows this shape.
+
+1. **Title** in the user's own query language (not a clever hook). Primary keyword near the front, under ~60 characters.
+2. **Answer-first lead (the most important 60 words on the page).** The first one or two sentences directly answer the primary query. No "in today's fast-paced world." This is the block AI extracts and the snippet Google pulls.
+3. **A self-contained definition** of the key term inside the first ~150 words: "**[Term]** is [one clear sentence]." AI uses this as the canonical definition for "what is X" queries.
+4. **A short key-takeaways / TL;DR block** for anything over ~1,200 words, stating the main answer and 3 to 5 bullets.
+5. **Question-shaped H2s and H3s.** Phrase each heading the way a person asks it: "How does X work?", "How much does X cost?", "Is X worth it?" AI does section-level extraction, so a heading that matches the user's question gets the section cited even when the page is not ranked #1.
+6. **Self-contained sections.** Each section answers its own heading in its first sentence, then expands. No orphan pronouns, no "as mentioned above." A reader (or model) dropped into the middle should understand it.
+7. **An FAQ block** of 4 to 8 real questions (mine "People Also Ask" and `hyperseo_serp_results_get`), each answered in 30 to 50 words, answer first.
+8. **One clear call to action** at the end. Exactly one primary next step.
+
+---
+
+## 3. The copy-paste content blocks
+
+These are the extractable units AI search cites most. Use them liberally and fill them with real specifics.
+
+**Definition block** (lead a "what is X" post or section with this):
+```
+[Term] is [one-sentence, self-contained definition: what it is + what it does].
+[One or two sentences of expansion.] [One sentence on why it matters / when it is used].
+```
+
+**Step-by-step block** (how-to):
+```
+To [outcome], [one-sentence overview]. Here is the process:
+
+1. **[Action verb + step name].** [What to do and the result.]
+2. **[Step name].** [What to do.]
+```
+
+**Comparison table** (the single highest-ROI block for commercial and AI queries; AI surfaces tables heavily):
+```
+| Option | Best for | Price | [Key dimension] |
+| --- | --- | --- | --- |
+| [A] | [concrete use case, 4-7 words] | [short form] | [value] |
+
+**Bottom line:** [one-sentence recommendation tied to who the reader is].
+```
+
+**FAQ block:**
+```
+### [Question phrased exactly as users ask it]
+[Direct answer in the first sentence, 30-50 words. No preamble.]
+```
+
+**Statistic-citation block** (a top-three GEO lever; cite the source inline):
+```
+According to [Source, Year], [specific stat with a number and timeframe]. [What it means for the reader.]
+```
+
+**Expert-quote block** (another top GEO lever; attribute fully):
+```
+"[Direct quote]," says [Full Name], [Title] at [Organization].
+```
+
+**Evidence sandwich** (the most citable pattern for a claim that matters):
+```
+[Clear claim stated as a fact.]
+- [Sourced data point 1]
+- [Sourced data point 2]
+[One-sentence actionable conclusion.]
+```
+
+---
+
+## 4. The proven GEO writing rules
+
+Validated by what actually moved rankings and citations, and by the Princeton GEO research (see `ai-citation-playbook.md` for the factor order).
+
+1. **Answer first, explain second.**
+   - Bad: "In today's rapidly evolving digital landscape, businesses are increasingly turning to..."
+   - Good: "AI search optimization means structuring content so ChatGPT, Perplexity, and Google's AI Overviews quote it directly. The three levers that matter most are clear answers, cited statistics, and named-source quotes."
+2. **Named entities and verifiable claims.** Specific, nameable facts get cited; vague claims get skipped.
+   - Bad: "This saves a lot of time."
+   - Good: "This cut setup from four hours to three minutes, documented in [Customer]'s case study."
+3. **Define the key term explicitly** in the first ~200 words, as one clean sentence.
+4. **Use a comparison table** in any post that weighs options. Highest single-tactic ROI for commercial and AI queries.
+5. **Question-shaped sub-headings** that match how people prompt an AI.
+6. **Cite sources, add statistics, add quotations.** The three strongest citation levers. One supporting stat or named source roughly every 150 to 250 words is a good density. Never invent them.
+7. **Be specific to the subject where the goal is recommendation.** When the aim is for AI to recommend a particular product or company, the page must say enough concrete, verifiable things about it (capabilities, numbers, real outcomes, who it is for) for a model to associate it with the topic. A page that is 90% generic advice and 10% product will not get the product recommended.
+8. **On-page keyword placement** (helps Google classify, without stuffing): exact primary keyword in the title, the first paragraph, at least one H2, the meta description, and the URL slug. Once each, naturally. Then stop.
+
+---
+
+## 5. Topic clusters, not orphan posts
+
+A single post rarely builds authority. Plan in clusters.
+
+- **Pillar page:** the broad head term, comprehensive, links out to every supporting post.
+- **Supporting posts:** specific long-tail subtopics, each linking back up to the pillar and across to siblings.
+- **Publish order:** ship 3 to 5 supporting posts and interlink them first, then publish the pillar so it inherits a web of internal links on day one.
+- Every post links to at least two siblings in its cluster and up to the pillar. No orphans.
+
+---
+
+## 6. Improving an existing post (often higher ROI than a new one)
+
+Before writing something new, check `google_search_console_query_insights` for pages that already get impressions:
+
+- **Position 4 to 15, decent impressions, low CTR:** do not write a new post. Rewrite the title and meta to earn the click, and tighten the answer-first lead.
+- **Position 10 to 20 on a relevant query with no dedicated page:** that query is a signal. Write a focused post targeting it, and link to it from related posts.
+- **A long-tail query (5+ words) ranking that you never targeted:** gold. Build the post it is asking for.
+- **Refreshing:** make substantive changes (new data, new sections, corrected claims), then update the visible date and `dateModified`. Do not bump the date with no real change.

--- a/skills/blog-generation/references/brand-voice-and-quality.md
+++ b/skills/blog-generation/references/brand-voice-and-quality.md
@@ -1,0 +1,94 @@
+# Brand Voice and Quality
+
+The difference between content that builds a brand and content that quietly damages it. Off-brand, generic, AI-tell-ridden writing erodes the exact trust you are trying to earn, and AI engines are increasingly tuned against promotional, low-substance text. On-brand and human is a ranking and citation asset, not a finishing touch.
+
+Do this **before** writing the first draft, and enforce the gate at the end before anything ships.
+
+---
+
+## 1. Build a voice profile from the brand's own site
+
+Read the customer's existing site with `firecrawl_urls_scrape` / `web_scrape_page`: homepage, an about page, two or three of their best existing posts, and any product or pricing pages. From that, write a short profile that every draft must honor:
+
+- **What they actually sell**, in one sentence, in their words.
+- **Who it is for** (the specific customer, not "businesses").
+- **Their category and positioning.** What box does the brand sit in, and what is its one-line claim?
+- **Tone**: where they sit on formal vs casual, plain vs technical, bold vs measured. Name it concretely ("plain, confident, lightly wry"; "warm and reassuring"; "clinical and precise").
+- **Reading level and sentence rhythm.** Short and punchy, or longer and considered.
+- **Vocabulary**: the words and phrases they use, and the ones they clearly avoid. Industry terms they expect their reader to know.
+- **Proof assets**: the real numbers, customers, credentials, certifications, and stories they can legitimately cite. (For a dentist: years in practice, procedures, real patient outcomes, credentials. For a jeweler: materials, craftsmanship, provenance, guarantees.)
+- **Point of view**: what they believe about their space that a generic competitor would not say.
+
+When in doubt about voice or a factual claim, ask the customer rather than inventing. A wrong fact in their name is worse than a slow draft.
+
+---
+
+## 2. Positioning clarity: so LLMs file the brand correctly
+
+A specific failure mode the customer cares about: getting recommended by AI **in the right context**. If the content describes the brand vaguely or inconsistently, models either ignore it or recommend it for the wrong thing. Fix that on the page:
+
+- **State the category and the one-liner explicitly and consistently.** "[Brand] is a [category] for [audience] that [core value]." Use the same framing across every page and in the `Organization` schema.
+- **Name the use cases the brand should be recommended for**, in plain language, as their own sections or FAQ entries ("Best for...", "When to use [Brand]"). Models pick these up as the contexts to surface the brand.
+- **Be honest about the edges.** Saying what the brand is *not* for, or who should pick something else, increases trust and makes the right-context recommendation more likely, not less.
+- **Keep naming consistent** everywhere (the exact brand name, product names, category words). Contradictory descriptions across pages confuse entity resolution and the brand gets mis-filed.
+
+---
+
+## 3. Kill the AI tells (the anti-cringe rules)
+
+The fastest way to make good content look like cheap content. Strip all of these:
+
+- **Throat-clearing intros.** "In today's fast-paced / ever-evolving / digital landscape...", "In the world of...", "As we all know...". Delete and start with the answer.
+- **The AI-essay vocabulary.** delve, unlock, elevate, harness, leverage (as filler), realm, tapestry, landscape, navigate the complexities, testament to, game-changer, supercharge, seamless, robust, cutting-edge, when it comes to. If a word smells like a model's default, cut it.
+- **Empty hedging.** "may help", "can potentially", "might be able to". Make the claim or drop it.
+- **The rule of three on autopilot.** Endless "X, Y, and Z" triads in every sentence. Vary the rhythm.
+- **"It's important to note that...", "It's worth mentioning...", "Needless to say...".** Filler. Cut to the point.
+- **Fake-balanced "conclusion" paragraphs** that restate the intro and say nothing new. End with a real takeaway and one action.
+- **Overuse of em-dashes and emoji-bulleted lists** as a default texture. They are a tell when they appear everywhere. Use normal punctuation and plain bullets unless the brand's real voice does otherwise.
+- **Generic openers and stock phrasing** that could appear on any competitor's site. If you could paste the sentence onto a rival's page unchanged, rewrite it with the brand's specifics.
+
+The test: read it aloud as the founder. If they would be slightly embarrassed to publish it, it is not done.
+
+---
+
+## 4. Substance rules (no fabrication, ever)
+
+- **Never invent a statistic, quote, customer, credential, or outcome.** AI engines penalize unverifiable claims, humans lose trust when they catch one, and in regulated verticals (health, finance, legal) a fabricated claim is a real liability. Use the brand's real proof assets, or cite a real external source, or do not make the claim.
+- **Attribute external facts.** A number without a source is a liability; a number with a credible source is a citation magnet.
+- **Specific over generic, always.** The brand's real numbers and stories are both more persuasive to humans and more citable by AI than any amount of polished generality.
+- **Match the reader's sophistication.** Do not over-explain to experts or under-explain to novices.
+
+---
+
+## 5. The pre-publish quality gate
+
+The post is not done until every box is checked.
+
+**Voice and brand**
+- [ ] Reads in the brand's actual voice (tone, vocabulary, reading level from the profile).
+- [ ] No AI tells from section 3.
+- [ ] The category and positioning one-liner are stated clearly and match every other page.
+- [ ] Nothing in it would embarrass the founder.
+
+**Substance**
+- [ ] Every stat, quote, and claim is real and either first-party or sourced. Zero fabrication.
+- [ ] The page says enough specific, verifiable things about the subject to be recommended for the right thing.
+- [ ] It says something a generic competitor or a raw model could not have written.
+
+**Structure**
+- [ ] Answer-first lead; key term defined in the first ~150 words.
+- [ ] Question-shaped H2s; each section self-contained and answer-first.
+- [ ] At least one comparison table or structured block where the topic warrants it.
+- [ ] FAQ block of real questions, each answered in 30 to 50 words.
+
+**On-page and technical**
+- [ ] Title (< ~60 chars, keyword front, click-worthy) and benefit-driven meta.
+- [ ] Internal links into the cluster (siblings + pillar); descriptive anchors; no orphan.
+- [ ] JSON-LD: Article + author Person + Organization, matching visible content.
+- [ ] Visible "Last updated" date and accurate `dateModified`.
+- [ ] The content you want cited is real server-rendered text, on a crawlable, indexable page.
+
+**Measurement**
+- [ ] Baseline captured (GSC position/CTR, `hyperseo_mentions_track`) so impact is provable later.
+
+If any box fails, fix it before publishing.

--- a/skills/blog-generation/references/on-page-and-technical.md
+++ b/skills/blog-generation/references/on-page-and-technical.md
@@ -1,0 +1,112 @@
+# On-Page and Technical
+
+Optimize any page (blog post, landing page, product page) for Google and AI search, ship the right structured data, make sure machines can actually read it, and prove the work moved the needle.
+
+---
+
+## 1. On-page checklist
+
+**Title tag**
+- Primary keyword near the front, in the user's query language.
+- Under ~60 characters so it does not truncate.
+- Earns the click: include a number or a concrete benefit where it fits. Google rewrites titles it finds weak, so make yours the obvious choice.
+
+**Meta description**
+- Not a ranking factor, but it drives click-through. State the benefit; do not just describe the page.
+- ~150 to 160 characters; treat exact counts as soft. Include the primary keyword once, naturally.
+
+**Headings**
+- One H1, matching the page topic. Logical H2/H3 nesting; do not skip levels.
+- Phrase H2s and H3s as the questions people ask.
+
+**Internal linking and topic clusters**
+- Link by usefulness, with descriptive anchor text (never "click here").
+- Build pillar-and-cluster structures: a broad pillar page links to specific supporting pages, each linking back up and across. The strongest on-page authority signal you control.
+- No orphan pages. Aim for roughly 5 to 10 contextual internal links per 1,000 words; anchor-text variety matters more than an exact count.
+
+**Images**
+- Descriptive alt text (~80 to 140 chars) that says what the image shows and why it matters.
+- Compress; serve modern formats (WebP/AVIF).
+
+**URLs**
+- Short (under ~60 chars), lowercase, hyphen-separated, keyword-bearing, shallow (2 to 3 levels).
+- No dates in the slug. Do not rewrite existing URLs just to optimize them.
+
+**Freshness**
+- Show a real, visible "Last updated" date and keep `dateModified` accurate.
+- Freshness is a real lever on fast-moving topics, minor on evergreen ones. Update substantively; do not date-bump cosmetically.
+
+**The answer is on the page**
+- The thing you want cited must be visible text, not buried in a click-to-open accordion, not an image of text, not injected only after interaction.
+
+---
+
+## 2. Structured data (JSON-LD)
+
+Schema does not earn AI citations by itself (a 2026 controlled test found no measurable non-Google lift), but it is cheap, helps Google understand and feature the page, and builds the clean entity data AI systems lean on. Ship it for those reasons; do not over-promise AI impact.
+
+**Rules**
+- **JSON-LD only** (Google's recommended format). Put it in `<head>` or at the end of `<body>`.
+- **Match the visible content.** Never mark up anything not on the page. Wrong schema is worse than none.
+- **Connect the graph.** Use `@graph` with `@id` cross-references so the Article points to its author `Person` and publisher `Organization`.
+
+**The 2026 stack worth shipping for a blog**
+- `Article` (or `BlogPosting`): `headline`, `image`, `datePublished`, `dateModified`, `author` (a `Person` with a `url`), `publisher` (an `Organization` with a `logo`). For `author.name`, use the name only; put titles in separate fields.
+- `Organization` site-wide: name, `logo`, and `sameAs` links to the brand's real profiles.
+- `Person` for the author, with `sameAs` to LinkedIn / X / professional profiles.
+- `BreadcrumbList` for navigation context.
+
+**Deprecations to know (do not promise these rich results):**
+- **FAQ rich results** stopped showing for most sites in 2026. Still write FAQ sections (great for AI extraction and UX), but do not pitch a Google FAQ rich result.
+- **HowTo rich results** are gone too. Keep step structure for readers and extraction; expect no special Google treatment.
+
+**Validating**
+- A plain fetch / curl cannot see JSON-LD injected by JavaScript. Validate with Google's Rich Results Test or a real browser.
+
+---
+
+## 3. Technical AEO: make sure machines can read it
+
+Content the engines cannot reach cannot rank or be cited. These are gates.
+
+**Crawlable and indexable (the eligibility gate)**
+- To appear in Google's AI features at all, a page must be indexed and snippet-eligible. That is the whole technical requirement.
+- Confirm it is not blocked by `robots.txt`, not `noindex`, has a clean canonical, and is in the sitemap.
+- Keep one canonical version of every page. Duplicates split signals.
+
+**AI crawler access**
+- Allow the bots that put you in answers:
+  - **Retrieval / search bots** (allow them): `OAI-SearchBot` (ChatGPT), `PerplexityBot`, `ClaudeBot`, `Google-Extended`, `Bingbot` (Copilot).
+  - **Training bots** (optional): `GPTBot`, `CCBot`. OpenAI and Anthropic split their bots so you can allow retrieval while blocking training.
+- Blocking the retrieval bots removes you from AI answers today. Default for visibility is to allow them.
+- `robots.txt` is advisory; to actually block a bot, use a WAF / Cloudflare.
+
+**Rendering (the quiet killer)**
+- Most AI crawlers do **not** execute JavaScript. They fetch raw HTML and stop. Googlebot renders JS; the AI bots largely do not.
+- Consequence: a client-side-only page can rank in Google yet be invisible to ChatGPT and Perplexity. **Server-render or statically render anything you want AI-cited.**
+
+**Core Web Vitals**
+- A constraint, not a lever. Severe slowness can stop a page from being crawled at all. Fix severe failures (LCP, INP, CLS), then move on.
+
+---
+
+## 4. Measure it and prove impact
+
+Set the expectation up front: content changes show up in classic search in days to weeks, and in AI answers in weeks.
+
+**Classic search signal**
+- `google_search_console_query_insights`: track impressions, clicks, CTR, and average position by query and page. Watch for pages climbing positions, and high-impression / low-CTR pages that need a title or meta rewrite.
+
+**AI search visibility**
+- `hyperseo_mentions_track`: ask the questions a customer would ("best [category] for [use case]") with the brand and 2 to 3 competitors, and see which models name whom, and what they cite. Run before optimizing (baseline) and monthly after.
+- `hyperseo_ai_search_volume_get`: how much query volume exists in AI channels for the target terms.
+- `hyperseo_ai_overviews_get`: whether Google shows an AI Overview for the term and which sources it cites.
+- Google Search Console now reports AI-feature visibility, but as impressions only, with AI Overviews and AI Mode blended. Useful for trend, not clean click attribution.
+- In GA4, AI assistants increasingly show up as their own referral channel, but a large share of AI-referred visits arrive as Direct, so treat AI referral numbers as a floor.
+
+**What good looks like**
+- Movement in GSC position and CTR on the target query.
+- The brand appearing in `hyperseo_mentions_track` for queries where it was absent, within roughly 90 days of shipping strong content.
+- The page showing up among the cited sources in `hyperseo_ai_overviews_get`.
+
+For full audits, competitor benchmarking, and keyword expansion, hand off to the `seo-research` skill.


### PR DESCRIPTION
## What

Adds the `references/` directory for the `blog-generation` skill. SKILL.md has cited these five files since the skill landed (0b1200b), but they were never committed — every `references/*.md` pointer in the workflow was dead.

- `references/blog-archetypes.md` — per-type specs for the 10 blog archetypes
- `references/blog-playbook.md` — answer-first structure, copy-paste blocks, GEO writing rules
- `references/brand-voice-and-quality.md` — voice extraction, anti-AI-tell rules, pre-publish gate
- `references/ai-citation-playbook.md` — GEO factor order, E-E-A-T, per-engine notes
- `references/on-page-and-technical.md` — on-page checklist, JSON-LD schema, crawlability gates

Content is the reference set from the original skill build. Tool names updated to the canonical MCP names SKILL.md already uses: `hyperseo_intents_search`, `hyperseo_serp_results_get`, `hyperseo_ai_overviews_get`, `hyperseo_ai_search_volume_get`, `hyperseo_mentions_track`, `firecrawl_urls_scrape`.

## Checks

- `./validate-skills.sh` — 30 skills, no errors
- No internal paths, internal URLs, account ids, or tokens in the added files