### PR TITLE
meta-ads: add Partnership Ads workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Skills are NOT tools. They are markdown instructions plus optional reference fil
 | Skill | What it does |
 | --- | --- |
 | [`google-ads`](./skills/google-ads) | Plan and create new Google Ads campaigns (Search, Display, Performance Max) using the blueprint flow, plus GAQL-backed reports and dashboards on existing accounts. |
-| [`meta-ads`](./skills/meta-ads) | Plan and create Meta (Facebook/Instagram) ad campaigns with Advantage+ as the default; includes an account-audit workflow. |
+| [`meta-ads`](./skills/meta-ads) | Plan and create Meta (Facebook/Instagram) campaigns and Partnership Ads with Advantage+ as the default; includes an account-audit workflow. |
 | [`meta-ads-library`](./skills/meta-ads-library) | Search the Meta Ads Library for competitor ads, optionally enrich with page contact info, and surface structured ad-intelligence summaries inline in chat. |
 | [`amazon-ads`](./skills/amazon-ads) | Plan and create Amazon Sponsored Products campaigns with strategic targeting and budget rules. |
 | [`tiktok-ads`](./skills/tiktok-ads) | Plan and create TikTok Ads (Traffic, Reach, Conversions, App Promotion, Video View) with strict objective-specific parameter validation. |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ That's `meta-ads` + `google-ads` + `tiktok-ads` + `ad-creative-generation` + `vi
 | [`brand-context`](skills/brand-context) | Build one `brand-context.md` per brand — positioning, ICP, personas, verbatim customer language, voice, proof points — that every other skill reads before asking brand questions. | Firecrawl recommended for auto-draft; works standalone via interview |
 | **Paid ads** | | |
 | [`google-ads`](skills/google-ads) | Plan and launch Google Ads campaigns — Search, Display, and Performance Max — and build GAQL-backed reports and dashboards. | Google Ads |
-| [`meta-ads`](skills/meta-ads) | Plan and launch Meta ad campaigns across Facebook and Instagram; audit existing accounts. | Meta Business, Firecrawl |
+| [`meta-ads`](skills/meta-ads) | Plan and launch Meta campaigns and Partnership Ads across Facebook and Instagram; audit existing accounts. | Meta Business, Firecrawl |
 | [`meta-ads-library`](skills/meta-ads-library) | Research competitor ads in the Meta Ads Library. | Apify |
 | [`amazon-ads`](skills/amazon-ads) | Plan and launch Amazon Sponsored Products campaigns. | Amazon Ads |
 | [`tiktok-ads`](skills/tiktok-ads) | Plan and launch TikTok ad campaigns across all objectives. | TikTok Marketing |

--- a/skills/meta-ads/SKILL.md
+++ b/skills/meta-ads/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: meta-ads
-description: Plan and create Meta (Facebook + Instagram) advertising campaigns end-to-end via the Hyper MCP, defaulting to Advantage+ automation. Use when the user wants to launch Meta ads, Facebook ads, Instagram ads, Advantage+ campaigns, carousel ads, dynamic creative ads, set up Meta conversion tracking, analyze performance, audit a Meta ads account, or build Meta performance dashboards. Also triggers on phrases like meta campaign, facebook campaign, advantage+, or meta account audit.
+description: Plan, create, and review Meta (Facebook + Instagram) advertising campaigns through the Hyper MCP. Use when the user wants to launch Meta ads, run Partnership Ads or branded-content ads, promote creator posts, use Instagram Partnership Ad codes, configure Advantage+, analyze performance, audit an account, or build dashboards.
 requires_toolkits:
   - meta_ads
   - meta_business
 icon: meta_ads
-short_description: Plan and create Meta ad campaigns with Advantage+ defaults, audits, and dashboards.
+short_description: Create Meta campaigns and Partnership Ads; audit performance and build dashboards.
 ---
 
 # Meta Ads
 
-Strategic guide for creating and managing Meta advertising campaigns, analyzing performance, and building dashboards from cached data. **Default to Advantage+** unless the user explicitly requests manual control.
+Strategic guide for creating and managing Meta advertising campaigns, Partnership Ads, performance analysis, and dashboards. **Default to Advantage+** unless the user explicitly requests manual control.
 
 ## Out of scope — defer to other skills
 
@@ -40,8 +40,10 @@ Use the **exact tool name from your connected tool list**. Canonical names are `
 | Discovery | `meta_ads_adaccount_list`, `meta_ads_owned_pages_list`, `meta_ads_pages_search`, `meta_accounts_list`, `meta_ads_instagram_accounts_list` |
 | Health & sync | `meta_ads_health_check`, `meta_ads_health_get` |
 | Tracking assets | `meta_ads_ad_pixels_list`, `meta_ads_ad_pixels_get`, `meta_ads_custom_audiences_list`, `meta_ads_lookalike_audiences_list`, `meta_ads_targeting_search` |
-| Step-by-step creation (preferred) | `meta_ads_campaign_create`, `meta_ads_adset_create`, `meta_ads_ad_create`, `meta_ads_ad_images_upload`, `meta_ads_creative_create` |
+| Step-by-step creation (preferred) | `meta_ads_campaign_create`, `meta_ads_adset_create`, `meta_ads_ad_create`, `meta_ads_ad_images_upload`, `meta_ads_ad_videos_upload`, `meta_ads_creative_create` |
 | Read & preview | `meta_ads_campaign_get`, `meta_ads_campaigns_search`, `meta_ads_adset_list`, `meta_ads_ad_list`, `meta_ads_ad_get`, `meta_ads_ad_previews_get` |
+| Partnership Ads | `meta_ads_partnership_ad_partners_list`, `meta_ads_partnership_advertisable_content_list`, `meta_ads_partnership_ad_validate`, `meta_ads_partnership_ad_create`, `meta_ads_partnership_existing_post_validate`, `meta_ads_partnership_existing_post_create` |
+| Managed Page content | `meta_ads_page_posts_list`, `meta_ads_page_post_comments_list` |
 | Insights & dashboards | `meta_ads_insights_get`, `hyper_data_build_dashboard`, `database_query` |
 | Launch & edits | `meta_ads_campaigns_activate`, `meta_ads_campaign_update`, `meta_ads_adset_update`, `meta_ads_ad_update` |
 | Automated rules | `meta_ads_adrule_create`, `meta_ads_adrule_list`, `meta_ads_adrule_get`, `meta_ads_adrule_update`, `meta_ads_adrule_delete`, `meta_ads_adrule_history_list` |
@@ -59,15 +61,17 @@ CLI users: translate tool names with the `hyper-cli` skill (`hyperai search "<to
 
 > **ALWAYS START PAUSED**: Create campaigns with `status="PAUSED"`. Never launch live without user review.
 
+> **PARTNERSHIP ADS USE DEDICATED TOOLS**: Read [references/partnership-ads.md](references/partnership-ads.md). Existing creator posts and Instagram Partnership Ad codes use `meta_ads_partnership_existing_post_validate` and `meta_ads_partnership_existing_post_create`. Newly uploaded media uses `meta_ads_partnership_ad_validate` and `meta_ads_partnership_ad_create` and requires exactly one `image_hash` or `video_id`. Never swap the creator publishing identity with the brand sponsor identity.
+
 > **BUILD STEP BY STEP**: Create campaigns with the individual tools — `meta_ads_campaign_create` → `meta_ads_adset_create` → `meta_ads_creative_create` → `meta_ads_ad_create`, capturing each id from the previous response. (The old blueprint tools were removed.) The tools validate requests before sending — campaign objective rules, bid-strategy/bid-amount pairing, billing-event/optimization-goal compatibility, budget coherence — but objective-specific ad-set fields (`optimization_goal`, `promoted_object`) are YOUR responsibility: match them to the campaign objective using the reference file for the campaign type.
 
 > **REGULATED ADVERTISERS NEED `special_ad_categories`**: For gambling, financial, housing, employment, credit, or political advertisers, declare the category on `meta_ads_campaign_create` (e.g. `special_ad_categories=["ONLINE_GAMBLING_AND_GAMING"]`).
 
-> **FIXED RUN WINDOWS GO ON THE AD SET**: When the user gives a run duration or dates ("run it for 7 days", "through end of month"), set `start_time` AND `end_time` (ISO 8601) on `meta_ads_ad_sets_create`. A daily-budget ad set with no `end_time` runs continuously until manually paused — the requested window is silently lost.
+> **FIXED RUN WINDOWS GO ON THE AD SET**: When the user gives a run duration or dates ("run it for 7 days", "through end of month"), set `start_time` AND `end_time` (ISO 8601) on `meta_ads_adset_create`. A daily-budget ad set with no `end_time` runs continuously until manually paused — the requested window is silently lost.
 
 > **GROUND COPY IN THE DESTINATION PAGE (RESEARCH FIRST)**: When the brief centers on a URL ("build a campaign for https://..."), fetch that page FIRST (`web_pages_fetch`) — before discovery and before writing any copy — and ground ad copy in what the page actually says (product name, value props, offer). Never invent copy for a page you have not read; even when the user supplies exact copy or headlines, fetch the page to verify the destination matches the offer.
 
-> **EU-TARGETED AD SETS NEED DSA FIELDS**: If an ad set targets the EU, set `dsa_beneficiary` and `dsa_payor` on `meta_ads_ad_sets_create` (who benefits from / pays for the ad) — required under the EU Digital Services Act, or delivery is restricted.
+> **EU-TARGETED AD SETS NEED DSA FIELDS**: If an ad set targets the EU, set `dsa_beneficiary` and `dsa_payor` on `meta_ads_adset_create` (who benefits from / pays for the ad) — required under the EU Digital Services Act, or delivery is restricted.
 
 > **UTMs ON EVERY DESTINATION AD (`url_tags`)**: Set `url_tags` (UTM params, e.g. `utm_source=meta&utm_medium=paid&utm_campaign=...`) on every creative that drives to a destination — downstream measurement (e.g. AppsFlyer + a data warehouse) stitches on these, so an ad without UTMs is effectively unmeasurable. Use the advertiser's canonical template; if you don't have one, ask rather than ship untracked.
 
@@ -83,7 +87,7 @@ Every task follows this sequence. Do not skip steps.
 
 1. **Identify the goal** — creation, analysis, or both?
 2. **Check the routing table** and read the referenced files before calling any tools
-3. **Make a written plan** — state campaign type, budget in cents, optimization goal, and sequence of steps; show it before acting
+3. **Make a written plan** — state campaign type, budget in cents, optimization goal, and sequence of steps; for Partnership Ads also state source type, creator, sponsor, ad account, ad set, and destination; show it before acting
 4. **Execute step by step**, re-checking [references/constraints.md](references/constraints.md) at each creation step
 5. **Show ad previews** before activation
 6. **Activate only when the user approves** using `meta_ads_campaigns_activate()`
@@ -102,6 +106,10 @@ Every task follows this sequence. Do not skip steps.
 | Create an awareness or engagement campaign | [references/discovery.md](references/discovery.md) → [references/campaigns/awareness-engagement.md](references/campaigns/awareness-engagement.md) |
 | Create an app promotion campaign | [references/discovery.md](references/discovery.md) → [references/campaigns/app-promotion.md](references/campaigns/app-promotion.md) |
 | Create a campaign (any objective) | [references/discovery.md](references/discovery.md) → the matching `references/campaigns/*.md` above, then build step by step |
+| Discover authorized partners or eligible partner content | [references/partnership-ads.md](references/partnership-ads.md) |
+| Validate or create a Partnership Ad from an existing post or ad code | [references/partnership-ads.md](references/partnership-ads.md) |
+| Validate or create a new Partnership Ad from uploaded media | [references/partnership-ads.md](references/partnership-ads.md) |
+| Read managed Facebook Page posts or comments | [references/partnership-ads.md](references/partnership-ads.md#managed-page-content) |
 | Analyze performance / query insights | [references/analytics.md](references/analytics.md) |
 | Audit an account / find optimization opportunities | [references/account-audit.md](references/account-audit.md) |
 | Set up automated rules (auto-pause, budget guards, alerts) | [references/automated-rules.md](references/automated-rules.md) |

--- a/skills/meta-ads/references/partnership-ads.md
+++ b/skills/meta-ads/references/partnership-ads.md
@@ -1,0 +1,177 @@
+# Partnership Ads
+
+Use this workflow for Meta Partnership Ads, branded-content ads, creator-post
+promotion, and Instagram Partnership Ad codes. These tools use the Meta
+Business connection in Hyper; they do not use the separate Instagram organic
+publishing toolkit or publish an organic post to the advertiser's profile.
+
+## Requirements and permissions
+
+Confirm the user has selected the intended Meta ad account, Facebook Page, and
+Instagram professional account. The Meta connection needs `ads_management` for
+ad creation plus the relevant Partnership Ads permissions:
+
+- `facebook_branded_content_ads_brand`
+- `instagram_branded_content_ads_brand`
+- `instagram_basic`
+- `pages_show_list`
+- `pages_read_engagement`
+
+Reading user comments on managed Page posts additionally requires
+`pages_read_user_content`.
+
+If the tools are present but Meta returns a permission error, call
+`meta_ads_health_check`, report the missing permission, and tell the user to
+reconnect Meta after the permission is approved and added to the app's Facebook
+Login for Business configuration. Do not switch to the Instagram toolkit.
+
+## Pick the correct workflow
+
+| Source | Validate | Create |
+| --- | --- | --- |
+| Existing Facebook creator post | `meta_ads_partnership_existing_post_validate` | `meta_ads_partnership_existing_post_create` |
+| Existing Instagram creator media | `meta_ads_partnership_existing_post_validate` | `meta_ads_partnership_existing_post_create` |
+| Instagram Partnership Ad code | `meta_ads_partnership_existing_post_validate` | `meta_ads_partnership_existing_post_create` |
+| Newly uploaded image or video | `meta_ads_partnership_ad_validate` | `meta_ads_partnership_ad_create` |
+
+Never send an existing post or ad code to `meta_ads_partnership_ad_validate` or
+`meta_ads_partnership_ad_create`. Those tools build a new creative and require
+exactly one ad-account media reference: `image_hash` or `video_id`.
+
+## Identity invariant
+
+The creator is the publishing identity. The advertiser is the sponsor:
+
+```text
+creator Facebook Page       -> object_story_spec.page_id
+creator Instagram account   -> object_story_spec.instagram_user_id
+advertiser Facebook Page    -> facebook_branded_content.sponsor_page_id
+advertiser Instagram account-> instagram_branded_content.sponsor_id
+```
+
+Do not infer IDs from similar names. Resolve them from the connected brand
+assets and Partnership Ads content discovery, then show both identities to the
+user before creation. Stop if the discovered creator or sponsor differs from
+the user's intended accounts.
+
+## Discover partners and content
+
+1. Resolve the brand's ad account, Page, and Instagram account with the normal
+   discovery tools.
+2. Optionally call `meta_ads_partnership_ad_partners_list` with the brand's
+   Instagram Graph ID or username. It returns creator relationships authorized
+   for that brand; it is not a directory of every creator.
+3. Call `meta_ads_partnership_advertisable_content_list` with at least the
+   brand Facebook Page or Instagram account. Use one exact lookup when the user
+   supplies it:
+   - `content_ids`
+   - `permalinks`
+   - `ad_codes`
+4. Do not combine an exact lookup with partner filters or `after`. Do not send
+   more than one exact-lookup type in the same request.
+5. Display the selected content's creator, platform, content ID, permalink,
+   media type, `ad_eligibility`, `permission_status`, and tagged sponsor.
+
+An empty broad listing does not prove a known post or ad code is unusable. Retry
+once with the exact content ID, permalink, or code. Do not fall back to the
+deprecated `branded_content_advertisable_medias` or old
+`partnership-ads-advertisable-content` Page edge; use this discovery tool.
+
+`AD_READY` plus an authorized permission is the normal existing-post path. A
+valid Instagram Partnership Ad code is post-level authorization, so lack of an
+account-wide partner relationship does not by itself invalidate that code.
+Meta validation remains authoritative.
+
+## Existing post or Instagram ad-code flow
+
+1. Discover the exact content first. Preserve the creator and sponsor IDs from
+   the returned item.
+2. Resolve the selected ad set and show its ad account, campaign, objective,
+   destination type, and status.
+3. Build the validation call:
+   - Facebook: pass `platform="facebook"`, the composite post ID as
+     `source_post_id`, and the creator/brand Page IDs.
+   - Instagram media: pass `platform="instagram"`, its media ID as
+     `source_post_id`, and the discovered Instagram identities.
+   - Instagram ad code: pass `platform="instagram"`,
+     `partnership_ad_code`, `creator_instagram_user_id`, `brand_page_id`, and
+     `brand_instagram_user_id`.
+4. For a website/Traffic ad set, pass the user-approved `destination_url` and
+   `call_to_action_type` to both validation and creation. Do not invent a URL
+   or silently switch ad sets to avoid this requirement.
+5. Call `meta_ads_partnership_existing_post_validate`. This is read-only.
+6. Show its review summary and Meta validation result. Continue only if the
+   identities, content, destination, ad account, campaign, and ad set match the
+   user's request.
+7. Only when the user requested creation, call
+   `meta_ads_partnership_existing_post_create` with the same reviewed values.
+8. Report the returned ad ID, creative ID, and `PAUSED` status. Fetch a preview
+   with `meta_ads_ad_previews_get` before any later activation.
+
+The ad code authorizes paid promotion of the creator's content. Passing it does
+not activate anything and does not publish the post to the advertiser's
+Facebook or Instagram feed.
+
+## New uploaded-media flow
+
+1. Upload the approved asset to the selected ad account with
+   `meta_ads_ad_images_upload` or `meta_ads_ad_videos_upload` and capture its
+   `image_hash` or `video_id`.
+2. Select an authorized creator relationship with
+   `meta_ads_partnership_ad_partners_list`.
+3. Show and verify the creator Page/Instagram identity, advertiser sponsor
+   Page/Instagram identity, destination, ad account, campaign, and ad set.
+4. Call `meta_ads_partnership_ad_validate` with exactly one of `image_hash` or
+   `video_id`, plus the destination, copy, CTA, and verified identities.
+5. Show the validation review. Only when the user requested creation, call
+   `meta_ads_partnership_ad_create` with the same reviewed values.
+6. Report the ad ID, creative ID, and `PAUSED` status. Fetch a preview before
+   any later activation.
+
+## Prelaunch review
+
+Before any create call, present a compact review containing:
+
+- source post/ad code or uploaded asset
+- creator Page and Instagram IDs
+- sponsor Page and Instagram IDs
+- ad account, campaign, and ad set names/IDs
+- objective and destination type
+- destination URL, CTA, and tracking tags
+- partnership permission and eligibility status
+
+Meta's validate-only operation checks payload validity, authorization, and
+account compatibility. It does not understand whether the person, league,
+product, or subject shown in the creative belongs to the intended advertiser.
+Inspect the creative/source content and compare it with the user's brief and
+selected sponsor. If the content cannot be inspected, say so and require the
+user to verify it. Stop on any content/account mismatch.
+
+Successful create calls always return a `PAUSED` ad. Do not activate it unless
+the user explicitly approves after reviewing the preview.
+
+## Partial failures
+
+Creation happens in two stages: creative, then ad. If the response has
+`creative_created: true` and `ad_created: false`, do not call the operation a
+success. Report the preserved `creative_id`. Ask for explicit approval before
+deleting that orphan with `meta_ads_creative_delete` or before retrying with
+changed inputs.
+
+Common routing errors:
+
+- `Provide exactly one of image_hash or video_id`: an existing post/ad code was
+  sent to a new-media tool, or uploaded media is missing.
+- `Call to Action Required`: supply the approved destination URL and CTA
+  required by the selected website/Traffic ad set.
+- `Unknown path components` or an endpoint-deprecation error: use
+  `meta_ads_partnership_advertisable_content_list`; do not construct Graph API
+  paths manually.
+
+## Managed Page content
+
+`meta_ads_page_posts_list` lists feed posts from a Facebook Page managed by the
+connected user. After the user selects a post, `meta_ads_page_post_comments_list`
+displays user-generated comments. Both are read-only. These tools support Page
+management and should not be used as substitutes for Partnership Ads content
+discovery.


### PR DESCRIPTION
## Summary

- make Partnership Ads and branded-content requests trigger the Meta Ads skill
- add the six dedicated Partnership Ads tools and two managed Page-content tools to the documented surface
- add a detailed workflow for existing creator posts, Instagram Partnership Ad codes, and newly uploaded media
- require creator/sponsor identity review, semantic content/account review, Meta validation, paused creation, and preview before activation
- document Traffic CTA requirements, exact content discovery, permission failures, and partial creative/ad failures
- fix two stale `meta_ads_ad_sets_create` references to the canonical `meta_ads_adset_create` name

## Why

The existing skill does not know about the Partnership Ads tools introduced by [multigen-ai/seti#1168](https://github.com/multigen-ai/seti/pull/1168). Without explicit routing, an agent can send an existing post or ad code to the new-media validator and incorrectly ask for an `image_hash` or `video_id`. The new reference keeps those workflows separate and adds the prelaunch identity/content review needed to prevent selecting the wrong creator or sponsor account.

## Rollout dependency

Keep this PR in draft until:

1. [multigen-ai/seti#1168](https://github.com/multigen-ai/seti/pull/1168) is deployed to the Hyper MCP environment.
2. Meta approves the requested Partnership Ads permissions and users can reconnect the Meta Business integration with those scopes.

## Validation

- `./validate-skills.sh` — 30 skills, no errors
- `git diff --check`
- every newly referenced tool name checked against the candidate Seti tool catalog
