### PR TITLE
ad-creative-generation: integrate cmo_ad_brief archetype recommendations

### DIFF
--- a/skills/ad-creative-generation/SKILL.md
+++ b/skills/ad-creative-generation/SKILL.md
@@ -22,9 +22,15 @@ This skill assumes the [Hyper MCP](https://app.hyperfx.ai/mcp) is connected to y
 | Group | Tools |
 |-------|-------|
 | Brand extraction | `firecrawl_branding_extract` |
+| Archetype recommendations (conditional) | `cmo_ad_brief` |
+| Competitor ad tracking (conditional) | `cmo_ads_track`, `cmo_ads_tracked_list` |
 | Image generation (default) | `images_generate` (`model="gpt-image-2"`) |
 | Image generation (text-heavy) | `images_generate` (`model="nano-banana-pro"`) |
 | Image generation (photoreal product shots) | `images_generate` (`model="seedream-4.5"`) |
+
+The `cmo_*` tools are conditional — they appear when the CMO toolkit is
+enabled in the workspace. When absent, skip them and use the reference
+frameworks; do not fail the workflow.
 
 For deeper image-tool selection guidance see the `image-generation` skill. To turn finished creatives into running campaigns see `google-ads` and `meta-ads`.
 
@@ -32,7 +38,7 @@ For deeper image-tool selection guidance see the `image-generation` skill. To tu
 
 - Picking the right image model when the task isn't ad creative — use `image-generation`.
 - Creating, launching, or budgeting actual ad campaigns — use `google-ads`, `meta-ads`, `tiktok-ads`, `pinterest-ads`, or `amazon-ads`.
-- Searching live competitor ads — use `meta-ads-library`.
+- Searching live competitor ads — use `meta-ads-library`; to save and monitor competitor ads cross-platform (Meta + Google Ads Transparency, durable creatives, longevity ranking), use `cmo_ads_track` / `cmo_ads_tracked_list` when the CMO toolkit is enabled.
 
 ## Critical rules
 
@@ -81,6 +87,20 @@ Both `logo` and `screenshot` are saved images ready to pass as `reference_images
 **For deeper guidance on brand extraction, read `references/brand-extraction.md`.**
 
 ### Phase 2: Ad Copy Generation
+
+**If `cmo_ad_brief` is available, call it first** — it returns ranked ad
+archetypes for the brand's goal and platform with the reasoning, hook
+examples, structure beats, dos/donts, and a generation prompt already
+grounded in the brand's saved data:
+
+```python
+brief = cmo_ad_brief(goal="drive conversions", platform="meta", url="https://example.com")
+```
+
+Build the copy variants and visual direction on the recommended archetypes
+(`brief.recommendations[n].prompt` is a ready generation prompt; unresolved
+placeholders are listed per recommendation). If the tool is not available,
+work from `references/ad-copy-frameworks.md` instead.
 
 Using the brand personality, tone, and value proposition from the extraction, write ad copy variants. Structure copy by what's being tested:
 


### PR DESCRIPTION
Phase 2 now calls `cmo_ad_brief` first when the CMO toolkit is enabled — ranked ad archetypes with reasoning, hooks, structure beats, and brand-grounded generation prompts — falling back to `references/ad-copy-frameworks.md` when absent. Documents `cmo_ads_track` / `cmo_ads_tracked_list` as the cross-platform competitor ad tracker in the out-of-scope table. Tools are marked conditional per repo convention.