### PR TITLE
feat(youtube): thumbnail flows use the unified images_generate facade

### DIFF
--- a/skills/youtube/references/thumbnails.md
+++ b/skills/youtube/references/thumbnails.md
@@ -56,7 +56,7 @@ For users prepping to publish. Run sequentially and present each result before m
 3. Don't dump base64 image data or thumbnail URLs into the chat. Pass the `file_id` and let the platform render it.
 4. For style-cloning, always show the user the top thumbnails first and let them pick the rank. Style-cloning a low-ranked or off-topic video produces bad results.
 5. If the user uploads multiple face photos, prefer the most recent and ignore the rest unless they ask you to compose them.
-6. Use `images_generate_nano_banana` (flash) for cheap iteration and `pro` only when the thumbnail needs strong rendered text inside the image. Use `images_edit_openai` when composing multiple reference images (face + brand + product).
+6. Use `images_generate` for every generation: `backend_hint="nano_banana"` for cheap iteration, `backend_hint="nano_banana_pro"` only when the thumbnail needs strong rendered text inside the image, and `backend_hint="openai"` when composing multiple reference images (face + brand + product).
 
 ## Reference
 

--- a/skills/youtube/scripts/clone_top_thumbnail_style.py
+++ b/skills/youtube/scripts/clone_top_thumbnail_style.py
@@ -7,9 +7,10 @@ Two-phase script:
   ask which rank to clone.
 
 * Phase 2 (``chosen_rank`` set): looks up the chosen thumbnail's
-  ``thumbnail_file_id`` and runs ``images_edit_nano_banana`` with that file as
-  the style reference. If a ``face_file_id`` is provided, the prompt is
-  augmented to composite the user's face into the cloned style.
+  ``thumbnail_file_id`` and runs ``images_generate`` with that file as a
+  reference image (nano-banana-pro backend). If a ``face_file_id`` is
+  provided, the openai backend composites the user's face into the cloned
+  style.
 """
 
 from __future__ import annotations
@@ -112,32 +113,36 @@ async def run(
         source_title=chosen.get("title"),
     )
 
+    used_tool = "images_generate"
     if face_file_id:
-        # OpenAI edit composes multiple references better than nano-banana edit
-        # when we need to preserve a person's identity.
+        # The openai backend composes multiple references better than
+        # nano-banana when a person's identity must be preserved.
         result = await call_tool(
-            "images_edit_openai",
+            used_tool,
             requests=[
                 {
                     "prompt": prompt,
                     "reference_images": [style_file_id, face_file_id],
                 }
             ],
-            size="1536x1024",
+            backend_hint="openai",
+            aspect_ratio="16:9",
             quality="high",
         )
-        used_tool = "images_edit_openai"
     else:
         result = await call_tool(
-            "images_edit_nano_banana",
-            file_id=style_file_id,
-            prompt=prompt,
+            used_tool,
+            requests=[
+                {
+                    "prompt": prompt,
+                    "reference_images": [style_file_id],
+                }
+            ],
             n=1,
-            model="pro",
+            backend_hint="nano_banana_pro",
             aspect_ratio="16:9",
-            image_size="2K",
+            quality="high",
         )
-        used_tool = "images_edit_nano_banana"
 
     images = result.get("images", []) if isinstance(result, dict) else []
     if not images:

--- a/skills/youtube/scripts/generate_thumbnail.py
+++ b/skills/youtube/scripts/generate_thumbnail.py
@@ -1,18 +1,18 @@
 """Generate a single YouTube thumbnail.
 
-Routing logic chooses the right image-gen tool based on inputs:
+Every call goes through the unified ``images_generate`` facade; routing picks
+the backend via ``backend_hint``:
 
-- ``style_reference_file_id`` set     -> ``images_edit_nano_banana`` with that
-                                          file as the base image (best for
-                                          cloning a single style reference).
+- ``style_reference_file_id`` set     -> nano-banana backend with the file as a
+                                          reference image (``nano_banana_pro``
+                                          when the prompt has explicit text
+                                          overlay, ``nano_banana`` otherwise).
 - ``brand_file_ids`` or
-  ``face_file_ids`` set               -> ``images_edit_openai`` with combined
+  ``face_file_ids`` set               -> ``openai`` backend with combined
                                           reference_images (better at composing
                                           multiple reference assets).
-- otherwise                           -> ``images_generate_nano_banana``
-                                          (``model='pro'`` if the prompt has
-                                          explicit text overlay, ``flash``
-                                          otherwise).
+- otherwise                           -> nano-banana backend, pro/flash chosen
+                                          by prompt text-heaviness.
 
 All tool calls go through the sandbox RPC, so generated images are persisted
 as ``DBFile``s in the conversation thread and metering fires automatically.
@@ -77,41 +77,53 @@ async def run(
     used_tool: str
     result: dict[str, Any]
 
+    # All paths go through the unified images_generate facade; the backend is
+    # selected via backend_hint (provider-specific tools are no longer
+    # exposed on the MCP surface).
+    used_tool = "images_generate"
     if style_reference_file_id:
-        used_tool = "images_edit_nano_banana"
         if chosen_model == "auto":
             chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        backend = "nano_banana_pro" if chosen_model == "pro" else "nano_banana"
         result = await call_tool(
             used_tool,
-            file_id=style_reference_file_id,
-            prompt=prompt,
+            requests=[
+                {
+                    "id": "thumbnail",
+                    "prompt": prompt,
+                    "reference_images": [style_reference_file_id],
+                }
+            ],
             n=n,
-            model=chosen_model,
+            backend_hint=backend,
             aspect_ratio=aspect,
-            image_size=image_size,
+            quality="high" if image_size == "2K" else "standard",
         )
+        chosen_model = backend
     elif refs:
-        used_tool = "images_edit_openai"
-        # OpenAI image-edit only supports its native sizes.
-        openai_size = "1536x1024" if aspect.startswith("16") else "1024x1024"
+        # OpenAI composes multiple references best when identity must be
+        # preserved (face + brand + product).
         result = await call_tool(
             used_tool,
             requests=[{"prompt": prompt, "reference_images": refs}],
-            size=openai_size,
+            backend_hint="openai",
+            aspect_ratio=aspect,
             quality="high",
         )
+        chosen_model = "openai"
     else:
-        used_tool = "images_generate_nano_banana"
         if chosen_model == "auto":
             chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        backend = "nano_banana_pro" if chosen_model == "pro" else "nano_banana"
         result = await call_tool(
             used_tool,
             requests=[{"id": "thumbnail", "prompt": prompt}],
             n=n,
-            model=chosen_model,
+            backend_hint=backend,
             aspect_ratio=aspect,
-            image_size=image_size,
+            quality="high" if image_size == "2K" else "standard",
         )
+        chosen_model = backend
 
     images = result.get("images", []) if isinstance(result, dict) else []
     if not images:
@@ -120,7 +132,7 @@ async def run(
     primary = images[0]
     return {
         "tool_used": used_tool,
-        "model": chosen_model if used_tool != "images_edit_openai" else "gpt-image-2",
+        "model": chosen_model,
         "aspect_ratio": aspect,
         "image_size": image_size,
         "primary": {


### PR DESCRIPTION
The provider-specific image tools (`images_generate_nano_banana`, `images_edit_nano_banana`, `images_edit_openai`) are being removed from the Hyper MCP surface — `images_generate` selects the backend via `backend_hint` (`openai` | `nano_banana` | `nano_banana_pro` | `seedream`).

- `skills/youtube/scripts/generate_thumbnail.py`: all three routing branches (style reference, multi-reference identity, plain) now call `images_generate` with the matching `backend_hint`; `model`/`image_size` params map to `backend_hint`/`quality`.
- `skills/youtube/scripts/clone_top_thumbnail_style.py`: style-clone and face-composite paths on the facade.
- `skills/youtube/references/thumbnails.md`: guidance updated.
- `skills/image-generation` was already facade-first; unchanged.

**Land in step with** seti `feat/background-tool-execution` (which hides the provider tools from the MCP surface). Until that deploys, the old tool names still resolve, so merging this first is safe; merging seti first without this breaks the youtube thumbnail scripts.

`./validate-skills.sh`: 30 skills OK. Scripts py-compile clean.