### PR TITLE
feat(writing): add the writing skill — style systems router + lint pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
       "name": "hyper-marketing",
       "displayName": "Hyper Marketing",
       "source": "./",
-      "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 30 skills wrapping 100+ integrations and 500+ marketing tools.",
-      "version": "1.0.1",
+      "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 31 skills wrapping 100+ integrations and 500+ marketing tools.",
+      "version": "1.2.0",
       "category": "marketing",
       "tags": ["marketing", "ads", "seo", "social-media", "analytics", "email", "google-ads", "meta-ads", "tiktok"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hyper-marketing",
   "displayName": "Hyper Marketing",
-  "version": "1.1.0",
-  "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 30 skills wrapping 100+ integrations and 500+ marketing tools.",
+  "version": "1.2.0",
+  "description": "Connect the Hyper MCP to run marketing end-to-end from Claude — Google, Meta, TikTok, Pinterest, Amazon & LinkedIn ads, organic social, SEO & AI-search research, competitor intel, ad creative, email, and analytics. 31 skills wrapping 100+ integrations and 500+ marketing tools.",
   "author": {
     "name": "Hyper AI",
     "url": "https://hyperfx.ai"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Skills are NOT tools. They are markdown instructions plus optional reference fil
 | [`image-generation`](./skills/image-generation) | Tool-selection guide for the bundled image models — OpenAI (`gpt-image-2`), Nano Banana (Gemini 3 Pro / 2.5 Flash), Seedream (ByteDance via fal.ai) — for ad creatives, branded compositions, photoreal product shots, image-to-image edits, and high-resolution output. |
 | [`video-generation`](./skills/video-generation) | End-to-end AI video — text-to-video / image-to-video (Sora, Veo, Seedance), scene chaining, video analysis, transcription, subtitles, TikTok / karaoke captions, voiceover (TTS), audio mixing, clipping, stitching, and text overlays. |
 | [`blog-generation`](./skills/blog-generation) | Generate one excellent, on-brand blog post per run — a stateful engine (reads a brand strategy doc, never repeats a topic) built to rank on Google and get cited by AI search. Firecrawl / HyperSEO / Search Console recommended. |
+| [`writing`](./skills/writing) | Writing style library and quality gate for all prose — routes each deliverable to a named writing system (BLUF / Minto, PAS, AIDA, Smart Brevity, inverted pyramid, classic style, plain language, Diátaxis) with hard checkable rules, then runs a lint pass that strips AI tells. Ships with five references under `references/` (copywriting, business writing, technical writing, prose style, lint-and-humanize). |
 
 ### Outbound & lifecycle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Skills are NOT tools. They are markdown instructions plus optional reference fil
 | [`image-generation`](./skills/image-generation) | Tool-selection guide for the bundled image models — OpenAI (`gpt-image-2`), Nano Banana (Gemini 3 Pro / 2.5 Flash), Seedream (ByteDance via fal.ai) — for ad creatives, branded compositions, photoreal product shots, image-to-image edits, and high-resolution output. |
 | [`video-generation`](./skills/video-generation) | End-to-end AI video — text-to-video / image-to-video (Sora, Veo, Seedance), scene chaining, video analysis, transcription, subtitles, TikTok / karaoke captions, voiceover (TTS), audio mixing, clipping, stitching, and text overlays. |
 | [`blog-generation`](./skills/blog-generation) | Generate one excellent, on-brand blog post per run — a stateful engine (reads a brand strategy doc, never repeats a topic) built to rank on Google and get cited by AI search. Firecrawl / HyperSEO / Search Console recommended. |
+| [`writing`](./skills/writing) | Writing style library and quality gate for all prose — routes each deliverable to a named writing system (BLUF / Minto, PAS, AIDA, Smart Brevity, inverted pyramid, classic style, plain language, Diátaxis) with hard checkable rules, then runs a lint pass that strips AI tells. Ships with five references under `references/` (copywriting, business writing, technical writing, prose style, lint-and-humanize). |
 
 ### Outbound & lifecycle
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ That's `meta-ads` + `google-ads` + `tiktok-ads` + `ad-creative-generation` + `vi
 | [`image-generation`](skills/image-generation) | Generate and edit images — picks the right model for text-heavy creatives, photoreal product shots, or high-res output. | Image gen toolkit |
 | [`video-generation`](skills/video-generation) | Generate AI video and prep it for distribution — text/image-to-video, captions, voiceover, stitching, overlays. | Video gen toolkit |
 | [`blog-generation`](skills/blog-generation) | Generate one excellent, on-brand blog post per run — a stateful engine that never repeats a topic, built for SEO and AI-search citations. | Firecrawl, HyperSEO, and Google Search Console recommended |
+| [`writing`](skills/writing) | Writing style library and quality gate for all prose — routes each deliverable to a named writing system (BLUF, PAS, AIDA, Smart Brevity, classic style, Diátaxis) with checkable rules, then lints out the AI tells. | No toolkit required |
 | **Outbound & lifecycle** | | |
 | [`cold-email-outreach`](skills/cold-email-outreach) | Run end-to-end B2B cold outreach — prospect, enrich, personalize, send, follow up, route replies. | Gmail + Apollo (Firecrawl + LinkedIn scraper bundled) |
 | [`email-lifecycle`](skills/email-lifecycle) | Build welcome, nurture, re-engagement, win-back, and abandoned-cart email programs. | At least one of Klaviyo, Resend, Beehiiv, or Gmail |

--- a/skills/writing/SKILL.md
+++ b/skills/writing/SKILL.md
@@ -26,7 +26,7 @@ Two principles run through everything here:
 
 | Job | Tools |
 | --- | --- |
-| Read and write drafts, read `brand-context.md` | your file tools (`read_file`, `create_file`, `edit_file`) |
+| Read and write drafts, read `brand-context.md` | your agent's file tools |
 | Pull source material or examples from URLs | `firecrawl_urls_scrape`, `web_scrape_page` |
 
 ## Out of scope: defer to other skills

--- a/skills/writing/SKILL.md
+++ b/skills/writing/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: writing
+description: "Writing style library and quality gate for all prose — cold emails, ads, landing pages, memos, blog posts, docs, UI copy. Routes each deliverable to a named writing system (BLUF / Minto, PAS, AIDA, Smart Brevity, inverted pyramid, classic style, plain language, Diátaxis) with hard checkable rules, then runs a lint pass that strips AI tells. Use when the user asks to write, rewrite, edit, or tighten any copy, or when another skill produces prose."
+metadata:
+  version: 1.0.0
+icon: hyper
+short_description: Route any prose to a named writing system with checkable rules, then lint out the AI tells.
+---
+
+# Writing
+
+Almost every skill in this collection ends in prose: an email, an ad, a post, a report. This skill is the layer that makes that prose good. It works as a router plus a quality gate. First classify the deliverable, then apply one named writing system with hard, checkable rules, then run a lint pass that removes the tells of machine writing. Never invent a style ad hoc — enforce a documented one, and tell the user which one you used.
+
+Two principles run through everything here:
+
+1. **"Write well" is not a rule; "no sentence over 25 words" is.** Every system in this skill is expressed as rules you can check a draft against. If you cannot point to the sentence that breaks a rule, the rule does not belong in the system.
+2. **Structure and voice are separate layers.** The writing system governs structure: what comes first, how ideas are ordered, how long things run. Brand voice governs vocabulary, tone, and stance. You can write a BLUF memo in a playful voice or a formal one — the skeleton is the same.
+
+## Requirements
+
+- **Hyper MCP connected.** https://app.hyperfx.ai/mcp — this skill needs no specific toolkit. Drafting, editing, and linting use your file tools.
+- **Recommended: a `brand-context.md`** built by the `brand-context` skill. Read it before drafting anything customer-facing. If it does not exist, ask two questions (who is the reader, what should they do after reading) rather than guessing.
+- **Optional: Firecrawl**, to pull source material or examples the user points at by URL.
+
+## Tool surface
+
+| Job | Tools |
+| --- | --- |
+| Read and write drafts, read `brand-context.md` | your file tools (`read_file`, `create_file`, `edit_file`) |
+| Pull source material or examples from URLs | `firecrawl_urls_scrape`, `web_scrape_page` |
+
+## Out of scope: defer to other skills
+
+This skill is about how to write, not what to publish or research. When the request is one of these, hand off:
+
+| Request | Send them to |
+| --- | --- |
+| A full SEO blog post, topic selection, ranking strategy | `blog-generation` |
+| Prospecting, sending, sequencing cold email | `cold-email-outreach` (use this skill for the copy itself) |
+| Publishing to LinkedIn / Instagram / TikTok | `linkedin`, `instagram`, `tiktok` |
+| Ad copy tied to creative production and campaign setup | `ad-creative-generation` |
+| Building the brand voice doc itself | `brand-context` |
+| Finding real customer language to write with | `customer-research` |
+
+## The workflow
+
+Run these steps in order for every writing or editing request.
+
+**Step 1: Classify the deliverable.** What is it (email, memo, post, doc page), who reads it, and what should they do after reading? If the user's request answers these, do not ask. If the reader or the desired action is genuinely unknown and changes the writing, ask once.
+
+**Step 2: Pick one system from the style map below.** One deliverable, one system. Name it to the user in one line ("Writing this as a BLUF memo"). If the user names a system themselves, use theirs.
+
+**Step 3: Read the reference file for that system.** Each reference holds the hard rules and before/after examples. Do not draft from memory of the system's name.
+
+**Step 4: Read `brand-context.md` if it exists.** Voice, banned words, and proof points come from there. The system's rules never override the brand's banned-word list.
+
+**Step 5: Draft to the rules.** Apply the system's hard rules while writing, not as an afterthought.
+
+**Step 6: Lint.** Run the full pass in [`references/lint-and-humanize.md`](references/lint-and-humanize.md) — the universal rules plus the AI-tell ban list. Fix every violation before showing the draft. This step is not skippable, including for "quick" edits.
+
+**Step 7: Deliver.** Show the draft. State in one line which system you used. If the user asked for a rewrite, show what changed and why in two or three bullets, not a lecture.
+
+When the request is **edit / tighten / "make this sound human"** rather than write-from-scratch: go to Step 6 and run the editing passes in the lint reference against the user's text — but still identify which system the text wants to be (Step 2). A limp cold email usually fails as PAS, not as prose in general.
+
+## The style map
+
+| Deliverable | System | Reference |
+| --- | --- | --- |
+| Cold email, outreach message | PAS | [`copywriting.md`](references/copywriting.md) |
+| Landing page hero + sections | PAS or BAB | [`copywriting.md`](references/copywriting.md) |
+| Ad copy (search, social, display) | AIDA + direct-response rules | [`copywriting.md`](references/copywriting.md) |
+| Product / feature announcement | Smart Brevity | [`business-writing.md`](references/business-writing.md) |
+| Press release | Inverted pyramid | [`business-writing.md`](references/business-writing.md) |
+| Exec memo, status update, report | BLUF / Minto pyramid | [`business-writing.md`](references/business-writing.md) |
+| Proposal, pitch, one-pager | SCQA | [`business-writing.md`](references/business-writing.md) |
+| Case study | SCQA opening + BAB body | [`business-writing.md`](references/business-writing.md) |
+| Newsletter | Smart Brevity | [`business-writing.md`](references/business-writing.md) |
+| Blog post, essay, thought leadership | Classic style | [`prose-style.md`](references/prose-style.md) |
+| Founder / personal social post | Classic style, compressed | [`prose-style.md`](references/prose-style.md) |
+| Docs: tutorial, how-to, reference, explanation | Diátaxis + plain language | [`technical-writing.md`](references/technical-writing.md) |
+| UI copy, error messages, empty states | UX microcopy | [`technical-writing.md`](references/technical-writing.md) |
+| Spec, requirements, API contract | RFC requirement keywords | [`technical-writing.md`](references/technical-writing.md) |
+| Operator instructions, step-by-step procedures | Controlled technical English | [`technical-writing.md`](references/technical-writing.md) |
+
+Two systems can share one piece (a case study opens SCQA and closes with a CTA written to direct-response rules). Never more than two, and say which governs which section.
+
+## The universal lint pass (summary)
+
+The full pass with examples and the editing sweeps is in [`references/lint-and-humanize.md`](references/lint-and-humanize.md). The ten rules every draft must survive, regardless of system:
+
+1. The point of the piece appears in the first two sentences.
+2. No sentence over 25 words unless it earns it; never two in a row.
+3. Active voice unless the actor is truly unknown or irrelevant.
+4. Every claim is concrete: a number, a name, an example — or it goes.
+5. Cut hedges (`quite`, `fairly`, `somewhat`, `arguably`) unless the hedge is the point.
+6. Verbs over nominalizations: "we decided," not "a decision was made."
+7. One idea per paragraph; the first sentence of each paragraph states it.
+8. No filler openers: "It's worth noting," "In today's world," "As we all know."
+9. The last line tells the reader what to do or what happens next.
+10. Zero entries from the AI-tell ban list (see the reference).
+
+## Working with brand voice
+
+- The system decides structure. `brand-context.md` decides words, tone, and proof.
+- On conflict, brand voice wins on word choice; the system wins on ordering and length.
+- If the brand's own voice examples violate the lint pass (marketing sludge in, marketing sludge out), flag it once and follow the lint pass — the user can overrule.

--- a/skills/writing/references/business-writing.md
+++ b/skills/writing/references/business-writing.md
@@ -1,0 +1,110 @@
+# Business writing systems
+
+Structures for documents that inform and decide: memos, updates, announcements, proposals, press releases, case studies. The shared contract: the reader is senior, interrupted, and will stop reading the moment the document stops paying. Front-load accordingly.
+
+## BLUF / Minto pyramid
+
+**Use for:** exec memos, status updates, recommendations, reports — any document whose reader decides something.
+
+BLUF is "bottom line up front." The Minto pyramid is the full discipline: conclusion first, then the 2–4 grouped arguments that support it, then the evidence under each. The reader can stop at any depth and still leave with the right conclusion.
+
+**Hard rules:**
+
+1. Sentence one is the conclusion or recommendation. Not background, not "the purpose of this memo."
+2. Support comes as 2–4 parallel arguments, each stated as a claim, each provable on its own.
+3. Nothing appears in the document that does not support the conclusion. Interesting-but-irrelevant gets cut.
+4. Order arguments by strength for a friendly reader, by objection for a hostile one.
+5. If the reader would ask "so what?" of any paragraph, the paragraph is upside down — its last line is its real first line.
+
+**Before:**
+
+> Over the last quarter we have been evaluating several vendors for the data pipeline migration. The process involved demos, reference calls, and a security review. There were many considerations including cost, support SLAs, and integration complexity. After extensive discussion the team has come to a view.
+
+**After:**
+
+> Recommendation: sign with Vendor B at $84k/yr. Three reasons: (1) it is the only bidder that passed our security review without exceptions, (2) migration effort is 3 weeks vs. 9 for Vendor A, (3) it is $31k/yr cheaper than the incumbent at our volume. Detail on each below; decision needed by Friday to hold pricing.
+
+---
+
+## SCQA — Situation, Complication, Question, Answer
+
+**Use for:** proposals, pitches, one-pagers, case study openings — any document that must earn attention before it argues.
+
+**Hard rules:**
+
+1. Situation is one or two sentences of ground the reader already agrees with. No news here.
+2. Complication is the change or tension that makes the status quo untenable. This is the hook.
+3. The question is the one the complication forces. Usually implied, not written out.
+4. The answer is your proposal — and from there the document continues as a Minto pyramid.
+5. Total SCQA opening: under 120 words. It is a doorway, not a hallway.
+
+**Example (proposal opening):**
+
+> Acme's checkout converts at 2.1%, in line with the industry. (Situation.) But 68% of your traffic is now mobile, where your checkout converts at 0.9% — and mobile share is growing 5 points a quarter. (Complication. Implied question: what do we do about mobile checkout?) We propose a 6-week mobile checkout rebuild, targeting 1.8% mobile conversion, worth roughly $340k/yr at current traffic. (Answer — the rest of the document proves it.)
+
+---
+
+## Smart Brevity
+
+**Use for:** announcements, newsletters, internal broadcasts — high-volume reading where the reader triages.
+
+**Hard rules:**
+
+1. A headline of six to ten words, in sentence case, carrying real information.
+2. One bold first sentence with the single most important fact.
+3. A "Why it matters" line immediately after — the consequence for this reader, not the company.
+4. Then short labeled chunks ("The details," "What's next," "The catch"), each 1–3 sentences or a tight bullet list.
+5. Nothing over 200 words without asking whether the reader chose the long version. Link out for depth.
+
+**Example (feature announcement):**
+
+> **Scheduled exports ship Monday.**
+> Every dashboard can now email itself as a PDF on a schedule you set.
+> **Why it matters:** the #1 support request this year — 340 tickets — was "send my boss this dashboard weekly." That workflow is now two clicks.
+> **The details:** any dashboard → Share → Schedule. PDF or CSV, daily/weekly/monthly.
+> **What's next:** Slack delivery is in beta; reply if you want in.
+
+---
+
+## Inverted pyramid
+
+**Use for:** press releases, incident notices, news-style posts — documents readers abandon at unpredictable points.
+
+**Hard rules:**
+
+1. Paragraph one answers who, what, when, where, why. A reader who stops there is fully informed.
+2. Each subsequent paragraph is less essential than the one before. The document must survive being cut from the bottom at any paragraph boundary.
+3. Quotes add color and authority, never new load-bearing facts.
+4. No teasing. "Read on to find out" structures are the opposite of this system.
+
+---
+
+## Narrative memo (Amazon-style)
+
+**Use for:** big decisions that deserve real scrutiny — strategy docs, annual plans, product bets. The reading is the meeting.
+
+**Hard rules:**
+
+1. Full prose. No bullet lists in the body — bullets hide weak reasoning; sentences expose it.
+2. Every claim carries its evidence in the same paragraph, not in an appendix the reader must trust you about.
+3. Anticipate the three strongest objections and answer them in the document, in their own section.
+4. For product proposals, write the press release and FAQ first (PR-FAQ): if the imagined launch announcement is boring, the product is.
+5. Six pages maximum. If it does not fit, the thinking is not done.
+
+---
+
+## Action titles
+
+**Use for:** headings in any deck or document longer than a page. A discipline layered onto other systems, not a standalone one.
+
+**Hard rules:**
+
+1. Every heading is a claim, not a topic. "Churn is concentrated in month 2" — not "Churn analysis."
+2. Reading only the headings must deliver the full argument.
+3. The body under a heading proves that heading and does nothing else. Evidence that proves a different claim moves under that claim's heading.
+
+**Before → After (deck headings):**
+
+> Background / Market overview / Our approach / Results / Next steps
+
+> Mid-market churn doubled in Q2 → Churn concentrates in month 2, before first value → Customers who complete setup in week 1 retain 3× better → We propose a mandatory onboarding call → Pilot with 50 accounts starts June 1

--- a/skills/writing/references/copywriting.md
+++ b/skills/writing/references/copywriting.md
@@ -1,0 +1,127 @@
+# Copywriting systems
+
+Frameworks for copy that has to persuade: cold emails, landing pages, ads. Pick one framework per piece from the style map in `SKILL.md`. Every framework here shares one contract: the reader is busy, skeptical, and mid-scroll — earn each next line.
+
+## Before you write any copy
+
+Confirm you know these four things (from the request, `brand-context.md`, or one batched question):
+
+1. **Reader** — who exactly, and what do they already believe about the problem?
+2. **Action** — the ONE thing they should do after reading. One CTA per piece.
+3. **Proof** — the numbers, names, and outcomes you can truthfully cite. Never invent proof.
+4. **Language** — the words customers use for the problem (reviews, tickets, calls). Their words beat yours.
+
+---
+
+## PAS — Problem, Agitate, Solve
+
+**Use for:** cold email, landing page sections, any reader who feels a pain but is not shopping yet.
+
+**Hard rules:**
+
+1. Open with the reader's problem in their words. No introduction of yourself or the product first.
+2. The agitation names a concrete cost of the problem: hours, money, missed deals, risk. Not adjectives — consequences.
+3. The solve is one or two sentences. The product appears here for the first time.
+4. One proof element attached to the solve (number, named customer, or specific outcome).
+5. One CTA, sized to the relationship: a cold email asks for interest, not a signature.
+
+**Before:**
+
+> Hi Sam, I'm the founder of Flowmetric, an innovative analytics platform that helps teams unlock insights and streamline reporting workflows. I'd love to jump on a quick call to show you how we can elevate your data game.
+
+**After:**
+
+> Hi Sam — saw your team posts weekly KPI decks by hand. Most RevOps leads tell us that eats 4–6 hours every Friday, and the numbers are stale by Monday's standup. Flowmetric builds that same deck automatically from your warehouse; Loop Returns cut their reporting time to 20 minutes a week. Worth a look? I can send a 2-minute recording.
+
+Why it works: problem in the reader's world (line 1), cost in hours (line 2), solve + named proof (line 3), low-friction CTA (line 4).
+
+---
+
+## AIDA — Attention, Interest, Desire, Action
+
+**Use for:** ads and any placement with a hard character limit, where the reader did not ask to hear from you.
+
+**Hard rules:**
+
+1. Attention is a specific claim or question, never a pun for its own sake.
+2. Interest adds the mechanism — how the claim can be true.
+3. Desire makes it theirs: outcome, timeframe, or social proof.
+4. Action is a verb-first CTA that matches the landing page.
+5. In short placements, each stage can be a single line; no stage may be skipped except Interest.
+
+**Example (search ad, 3 lines + CTA):**
+
+> Your reports build themselves.
+> Flowmetric syncs your warehouse and writes the Friday KPI deck for you.
+> Teams like Loop Returns save 4+ hours a week.
+> Start free →
+
+---
+
+## BAB — Before, After, Bridge
+
+**Use for:** landing page heroes and sections, onboarding emails — readers who need to *see* the change, not hear the pitch.
+
+**Hard rules:**
+
+1. Before is the reader's current state, described so precisely they nod.
+2. After is the same scene with the problem gone. Same character, same setting — only the outcome changes.
+3. The bridge is the product, introduced as the mechanism between the two scenes.
+4. No feature lists inside BAB. Features go in a separate section below.
+
+**Before (the copy, not the framework):**
+
+> Flowmetric is a next-generation analytics suite with 50+ integrations, custom dashboards, and AI-powered insights for modern data teams.
+
+**After:**
+
+> Right now, Friday afternoon means exporting six CSVs and rebuilding the same deck by hand. With Flowmetric, the deck is waiting in Slack at 9 a.m. — built from live data while you slept. Connect your warehouse once; Flowmetric does the Friday work forever.
+
+---
+
+## FAB — Feature, Advantage, Benefit
+
+**Use for:** feature sections, comparison pages, release notes that must sell. FAB is a translation drill, not a page structure.
+
+**Hard rules:**
+
+1. Never ship a feature name without finishing the chain: what it does → what that enables → what the reader gets.
+2. The benefit must be checkable in the reader's world ("your Friday deck builds itself"), not abstract ("boost productivity").
+3. Lead the sentence with the benefit when space is tight; the feature can trail.
+
+**Example chain:**
+
+- Feature: warehouse-native sync.
+- Advantage: reports read live data, not exports.
+- Benefit: the numbers in Monday's standup are Monday's numbers.
+- Shipped line: "Monday's standup runs on Monday's numbers — Flowmetric reads your warehouse live, no exports."
+
+---
+
+## Headlines — the 4U check
+
+**Use for:** every headline, subject line, and hook, whatever framework governs the body.
+
+Score the draft 0–1 on each U; rewrite until it scores at least 3:
+
+1. **Useful** — does the reader gain something by reading on?
+2. **Unique** — could a competitor run the same headline? If yes, it fails.
+3. **Ultra-specific** — is there a number, name, or concrete noun in it?
+4. **Urgent** — is there a reason to care now? (Weakest U; never fake it with countdown pressure.)
+
+**Examples:**
+
+- "Improve your reporting" — scores 1 (useful, barely). Reject.
+- "Cut Friday reporting from 4 hours to 20 minutes" — useful, specific, hard for a competitor to copy honestly. Ship.
+
+---
+
+## Direct-response rules (apply to all copy)
+
+1. **Specificity beats adjectives.** "4,200 finance teams" beats "thousands of happy customers." "20 minutes" beats "fast."
+2. **One CTA.** Multiple asks split the click. Secondary links go in the footer, not the argument.
+3. **Proof over claims.** Every superlative needs a citation the legal team would sign. No proof, no superlative.
+4. **Customer language.** If reviews say "I stopped dreading Fridays," that line outperforms anything you compose.
+5. **The costly claim test.** If the claim costs you nothing to make, it earns nothing. "We care about quality" costs nothing. "Full refund if setup takes over an hour" costs something — and converts.
+6. **No exclamation points.** The sentence must carry its own energy.
+7. **Read the CTA alone.** "Start free," "Get the teardown," "Book the audit" — if the CTA out of context tells you what happens next, it works.

--- a/skills/writing/references/lint-and-humanize.md
+++ b/skills/writing/references/lint-and-humanize.md
@@ -1,0 +1,93 @@
+# The lint pass
+
+The mandatory final pass for every draft, in any system — and the entry point when the user brings existing text ("tighten this," "make it sound human"). Two parts: the universal rules, then the AI-tell ban list. For deeper editing work, run the sweeps at the end of this file.
+
+Fix violations before showing the draft. When editing a user's text, preserve their meaning and voice; you are removing failure, not imposing taste.
+
+## The ten universal rules
+
+Each rule with the failure and the fix:
+
+**1. The point appears in the first two sentences.**
+- Fail: "Reporting has changed a lot over the last decade. Teams have more data than ever, and expectations keep rising. That's why we built..."
+- Fix: "Your Friday KPI deck can build itself. Here's how we do it."
+
+**2. No sentence over 25 words unless it earns it; never two in a row.**
+- A long sentence earns its length by carrying a genuinely compound thought. Two in a row means one of them is hiding two sentences.
+
+**3. Active voice unless the actor is unknown or irrelevant.**
+- Fail: "The migration was completed and improvements were observed."
+- Fix: "We finished the migration; load times dropped 40%."
+- Legitimate passive: "The account was accessed from three countries in one hour" (actor unknown — that's the point).
+
+**4. Every claim is concrete: a number, a name, an example — or it goes.**
+- Fail: "Trusted by leading companies to deliver significant results."
+- Fix: "4,200 finance teams, including Loop Returns, cut reporting time by an average of 3 hours a week." (Only if true. A cut claim is fine; an invented number never is.)
+
+**5. Cut hedges unless the hedge is the point.**
+- "quite," "fairly," "somewhat," "arguably," "in many cases," "to some extent" — delete and reread; the sentence almost always improves. Keep a hedge only when precision requires it ("early data suggests" before real data).
+
+**6. Verbs over nominalizations.**
+- "made a decision" → "decided" · "conducted an analysis" → "analyzed" · "reached an agreement" → "agreed" · "is indicative of" → "indicates."
+
+**7. One idea per paragraph; the first sentence states it.**
+- Test: read only the first sentence of every paragraph. If that skeleton doesn't carry the argument, restructure before polishing words.
+
+**8. No filler openers.**
+- "It's worth noting that," "In today's world," "As we all know," "Needless to say" — the sentence after the filler is the real opener.
+
+**9. The last line tells the reader what to do or what happens next.**
+- Fail: "...and that's why observability matters more than ever."
+- Fix: "...start with one dashboard: errors per deploy. Everything else can wait."
+
+**10. Zero entries from the AI-tell ban list below.**
+
+## The AI-tell ban list
+
+Patterns that mark text as machine-written. Zero tolerance in shipped drafts.
+
+**Banned words** (rewrite the sentence, don't synonym-swap):
+
+> delve, elevate, unleash, unlock, leverage (as a verb), robust, seamless, seamlessly, revolutionize, game-changer, cutting-edge, in today's fast-paced world, digital landscape, ever-evolving, navigate (metaphorically), embark, journey (metaphorically), tapestry, testament to, underscore, foster, empower, supercharge, skyrocket, dive in, let's explore
+
+**Banned constructions:**
+
+1. **The negation flex:** "It's not just X — it's Y." / "This isn't about X. It's about Y." One per document at absolute most; the pattern is the tell, not the words.
+2. **Rule-of-three overload.** Triads are fine; a triad in every paragraph ("clear, compelling, and effective") is a rhythm fingerprint. Break most of them into one strong item.
+3. **The mirrored contrast:** "Where X sees a problem, Y sees an opportunity."
+4. **The false question opener:** "So what does this mean for your business?" as a paragraph transition. Just say what it means.
+5. **The summary paragraph that re-lists the sections.** If the piece needs a recap, it's too long or too shapeless.
+6. **"Whether you're a startup founder or an enterprise CTO..."** — the fake-inclusive audience sweep.
+7. **"In conclusion," "Ultimately," "At the end of the day"** as closers.
+8. **Colon-title headline reflex:** "Reporting: Why It Matters More Than Ever."
+
+**Banned structures:**
+
+1. Uniform paragraph rhythm — every paragraph 3–4 sentences of similar length. Vary or merge.
+2. Bold-lead-in bullet cascades ("**Speed:** ... **Quality:** ... **Cost:** ...") in prose contexts. Bullets are for genuinely parallel facts.
+3. Header-per-two-sentences. If a section is two sentences, it isn't a section.
+4. Em-dash chains — more than one em-dash construction per paragraph reads as generated.
+5. Hedge-stack closings: "Of course, every situation is different, and what works for one team may not work for another." Delete; rule 9 replaces it.
+
+**What humanizing is NOT:**
+
+- Not injected typos, slang, or fake casualness ("Okay so real talk—").
+- Not contractions sprinkled mechanically.
+- Not first-person anecdotes the author never had. Never invent experiences, customers, or numbers to sound human.
+- The honest sources of human texture: specific detail, actual opinion, variable rhythm, and the willingness to say one thing plainly instead of three things safely.
+
+## The editing sweeps
+
+For real editing jobs (a page, a deck, a long email), run ordered passes — one dimension at a time, because a single "make it better" pass catches the loudest problem in each sentence and misses the rest. After each sweep, reread quickly to confirm the earlier sweeps still hold.
+
+**Sweep 1 — Argument.** Does the piece pass rules 1, 7, and 9? Is the structure the right system for the deliverable (check the style map in `SKILL.md`)? Fix structure before touching sentences; polishing a mis-structured draft is wasted work.
+
+**Sweep 2 — Claims.** Every claim gets a source, a number, or a cut (rule 4). Flag anything you cannot verify rather than shipping it.
+
+**Sweep 3 — Sentences.** Rules 2, 3, 5, 6, 8, plus the concision pass in `prose-style.md`. This is the longest sweep.
+
+**Sweep 4 — Tells.** The full ban list above, mechanically. Search the text for the banned words; read for the banned constructions.
+
+**Sweep 5 — Sound.** Read it aloud (rhythm rules in `prose-style.md`). Fix every stumble. Then read only the first and last lines — together they should state the point and the next step.
+
+Report edits to the user as two or three bullets of what changed and why ("cut 40% — mostly hedges and a duplicated argument," "moved the recommendation to sentence one"), not a line-by-line changelog.

--- a/skills/writing/references/prose-style.md
+++ b/skills/writing/references/prose-style.md
@@ -1,0 +1,102 @@
+# Prose style systems
+
+For writing where the sentences themselves carry the value: essays, blog posts, thought leadership, founder posts. Frameworks structure an argument; these systems govern how the prose sounds line by line. The shared contract: the reader gives you their attention one sentence at a time, and every dull sentence is where some of them leave.
+
+## Classic style
+
+**Use for:** essays, thought leadership, explanatory blog posts, founder writing. The default prose model for anything meant to be read voluntarily.
+
+The stance: writing is a window. The writer has seen something, points the reader at it, and trusts them as an equal. The writer is confident, concrete, and invisible — the subject holds the attention, not the prose.
+
+**Hard rules:**
+
+1. Show the thing, don't narrate your process. Cut "In this post I will," "As mentioned above," "Let's take a step back."
+2. Trust the reader: no defensive hedging, no pre-emptive apology, no "of course, this depends" reflex. State the view; handle real exceptions where they genuinely arise.
+3. Concrete nouns and named examples over categories. "Stripe's first API docs" teaches; "best-in-class developer experiences" doesn't.
+4. The prose stays subordinate to the subject. If a sentence exists to sound smart, it goes.
+5. Every abstract claim is followed within two sentences by a concrete instance of it.
+
+**Before:**
+
+> In this article, we'll explore the various ways that pricing can impact the growth trajectory of a SaaS business. It's important to note that pricing is a complex topic and there's no one-size-fits-all answer, but hopefully by the end you'll have some useful frameworks to consider.
+
+**After:**
+
+> Most SaaS companies set their price once, at launch, by copying a competitor — and then never touch it again. Profitwell's data puts the median time between pricing changes at three years. That neglect is expensive: price is the growth lever with the fastest payback and the least code.
+
+---
+
+## Orwell's rules
+
+**Use for:** a fast honesty check on any prose, especially anything with a political, corporate, or defensive job to do. These paraphrase the famous six rules from "Politics and the English Language."
+
+**Hard rules:**
+
+1. Never use a metaphor or figure of speech you are used to seeing. A dead metaphor ("low-hanging fruit," "move the needle") is a placeholder where thinking should be.
+2. Never use a long word where a short one works.
+3. If a word can come out, take it out.
+4. Never use the passive where the active is possible.
+5. Never use jargon or a foreign phrase where everyday English works.
+6. Break any rule before writing something barbarous.
+
+The deeper test behind the rules: vague language usually hides a vague thought — or an unflattering fact. "We are streamlining the organization" means "we are firing people." When you catch abstraction, ask what fact it is protecting, then decide honestly whether to state it.
+
+---
+
+## The concision pass
+
+**Use for:** every draft, as a dedicated editing pass. Concision is not a style — it is the removal of everything that is not the writing.
+
+**Cut on sight:**
+
+1. Throat-clearing openers: "It's worth noting that," "It goes without saying," "At the end of the day."
+2. Redundant pairs: "each and every," "first and foremost," "basic fundamentals," "end result."
+3. Empty intensifiers: "very," "really," "extremely," "incredibly." Either upgrade the word ("huge" → not "very big") or drop the modifier.
+4. Nominalizations: "make a decision" → "decide," "conduct an analysis" → "analyze," "provide assistance" → "help."
+5. "There is / There are" openings: "There are three factors that matter" → "Three factors matter."
+6. "That" wherever the sentence survives without it.
+7. Prepositional chains: "the results of the analysis of the data" → "the data analysis results" — or name the finding.
+
+**Before (41 words):**
+
+> It is important to note that there are a number of different factors that can have an impact on the overall performance of your campaigns, and it is definitely worth taking the time to carefully consider each and every one of them.
+
+**After (11 words):**
+
+> Several factors drive campaign performance. Weigh each before you launch.
+
+---
+
+## Iceberg style
+
+**Use for:** narrative moments inside any piece — customer stories, founding stories, case study openings. Named for Hemingway's principle: the dignity of the writing comes from what stays beneath the surface.
+
+**Hard rules:**
+
+1. Short declarative sentences carry the load. Subordinate clauses are the exception.
+2. Adverbs are rationed: if the verb needs "quickly," find a faster verb.
+3. Show state through action and detail, never through emotional labels. Not "she was frustrated" — "she exported the CSV for the third time that morning."
+4. Leave the conclusion under the surface. If the details are right, the reader feels the point before you state it — and then you often don't need to.
+5. Resist the closing moral. The story that needs its lesson explained wasn't told right.
+
+**Before:**
+
+> Maria was incredibly frustrated with her reporting workflow, which was extremely time-consuming and inefficient, and she knew there had to be a better way.
+
+**After:**
+
+> Maria's Friday started at 6 a.m. with six CSV exports. By ten she had rebuilt the same deck for the ninety-fourth week in a row. Her calendar called it "analysis."
+
+---
+
+## Rhythm
+
+**Use for:** the final read of anything meant to be read voluntarily. Applies across all the systems above.
+
+**Hard rules:**
+
+1. Vary sentence length deliberately. A run of same-length sentences reads as a drone regardless of content.
+2. Follow a long, winding sentence with a short one. The short one lands.
+3. Read the draft aloud (or subvocalize honestly). Wherever you stumble or breathe wrong, the sentence is broken — fix the sentence, don't blame the reading.
+4. Paragraph breaks are pacing tools. A one-line paragraph is a spotlight; use it at most once or twice per piece.
+5. Watch the paragraph shape of the whole piece: uniform blocks of 3–4 sentences each is a machine tell (see `lint-and-humanize.md`).

--- a/skills/writing/references/technical-writing.md
+++ b/skills/writing/references/technical-writing.md
@@ -1,0 +1,112 @@
+# Technical writing systems
+
+Structures for documents that must be acted on correctly: docs, procedures, specs, UI copy. The shared contract: the reader is mid-task, possibly frustrated, and reads to do — not to appreciate. Ambiguity here is not a style problem; it is a defect.
+
+## Plain language
+
+**Use for:** anything a non-specialist must act on — help center articles, policies, onboarding, billing and legal explanations.
+
+**Hard rules:**
+
+1. Address the reader as "you." Name the actor in every sentence.
+2. Common words: "use" not "utilize," "help" not "facilitate," "end" not "terminate."
+3. Sentences average under 20 words. One idea each.
+4. No double negatives, no "unless...except" chains. Rewrite as positive conditions.
+5. Define a necessary technical term at first use, in one sentence, then use only that term (no elegant-variation synonyms).
+6. Headings are questions or tasks the reader actually has ("Cancel your subscription"), not nouns ("Cancellation policy").
+
+**Before:**
+
+> Termination of the subscription may be effectuated by the user at any time via the account management interface, whereupon a pro-rata refund shall be issued, except in cases where usage thresholds have been exceeded.
+
+**After:**
+
+> You can cancel your subscription at any time from Settings → Billing. We refund the unused part of your month. Exception: if you used more than your plan's included volume this month, that usage is billed first.
+
+---
+
+## Diátaxis — the four documentation modes
+
+**Use for:** structuring any docs set, and diagnosing why an existing page fails.
+
+Every docs page is exactly one of four things. Mixing modes on one page is the root cause of most bad documentation.
+
+| Mode | Reader's situation | The page's job | Failure smell |
+| --- | --- | --- | --- |
+| **Tutorial** | New, learning by doing | A guaranteed-success first journey | Detours into options and theory |
+| **How-to guide** | Competent, mid-task, has a goal | The steps for this one goal | Teaching basics the reader has |
+| **Reference** | Knows what they need, wants facts | Complete, accurate, findable description | Chatty prose, opinions |
+| **Explanation** | Curious, off-task | Why it works this way | Step-by-step instructions creeping in |
+
+**Hard rules:**
+
+1. Declare the mode before writing. One page, one mode.
+2. Tutorials promise and deliver success: tested end-to-end, zero forks ("if you prefer X..."), visible result at each stage.
+3. How-to guides start from a named starting condition and assume competence. Numbered steps, one action per step, each step verifiable.
+4. Reference pages are structured like the thing they describe, exhaustive, and free of advice. Advice links out to explanation.
+5. When a page fights you, check its mode first: a "tutorial" full of options is a how-to wearing the wrong clothes.
+
+---
+
+## Controlled technical English
+
+**Use for:** procedures where misreading has a cost — operator instructions, runbooks, safety steps, checklists. Inspired by the ASD-STE100 controlled-language standard.
+
+**Hard rules:**
+
+1. One instruction per sentence. Sentences of 20 words or fewer.
+2. Imperative mood for every instruction: "Press the button." Never "The button should be pressed."
+3. One meaning per word, one word per meaning, everywhere in the document. If "close" means "shut the valve," it never also means "nearly."
+4. State the condition before the instruction: "If the light is red, stop the pump" — never "Stop the pump if the light is red" (the reader may act before reading the condition).
+5. Warnings come before the step they concern, never after.
+6. No pronouns where a noun can repeat. "Remove the filter. Clean the filter." — not "clean it."
+
+**Before:**
+
+> The system should be restarted after configuration changes have been applied, though it's usually fine to wait until the end of a batch, unless changes were made to auth, which need an immediate restart.
+
+**After:**
+
+> If you changed auth settings: restart the system now.
+> For all other changes: restart the system at the end of the current batch.
+
+---
+
+## RFC requirement keywords
+
+**Use for:** specs, API contracts, integration requirements — documents where "should" being read as "must" (or the reverse) causes real disputes.
+
+**Hard rules:**
+
+1. Use the keywords with their standard meanings: **MUST** (absolute requirement), **MUST NOT** (absolute prohibition), **SHOULD** (do it unless you have a good, understood reason), **MAY** (truly optional).
+2. Capitalize the keywords so they read as defined terms.
+3. State the keyword definitions once at the top of the document.
+4. Never use lowercase "should"/"must" loosely elsewhere in the spec — pick the keyword or rewrite the sentence.
+5. Every MUST is testable. If you cannot write the check, you cannot write the MUST.
+
+**Example:**
+
+> Webhook consumers MUST respond with a 2xx within 5 seconds. Consumers SHOULD process payloads asynchronously and respond before processing. Consumers MAY request a replay of events up to 7 days old. Consumers MUST NOT treat event ordering as guaranteed.
+
+---
+
+## UX microcopy
+
+**Use for:** buttons, error messages, empty states, confirmations, tooltips — the words inside the product.
+
+**Hard rules:**
+
+1. Buttons are verb-first and name the outcome: "Save changes," "Send invoice" — never "OK," "Submit," "Yes."
+2. Every error message answers three questions in order: what happened, why (if known), what to do next.
+3. Never blame the user. "That code has expired" — not "You entered an invalid code."
+4. Empty states sell the next action, not the emptiness: what this screen will show, and the one button that starts it.
+5. Confirmations for destructive actions name the object and the consequence: "Delete 'Q3 Report'? This cannot be undone." The confirming button repeats the verb ("Delete report"), never "Yes."
+6. Sentence case everywhere. No exclamation points. No "Oops."
+
+**Before:**
+
+> Error: Invalid input. Please try again!
+
+**After:**
+
+> That email address is missing an "@". Check it and resend — or use SSO if your company uses Google Workspace.

--- a/skills/youtube/references/thumbnails.md
+++ b/skills/youtube/references/thumbnails.md
@@ -56,7 +56,7 @@ For users prepping to publish. Run sequentially and present each result before m
 3. Don't dump base64 image data or thumbnail URLs into the chat. Pass the `file_id` and let the platform render it.
 4. For style-cloning, always show the user the top thumbnails first and let them pick the rank. Style-cloning a low-ranked or off-topic video produces bad results.
 5. If the user uploads multiple face photos, prefer the most recent and ignore the rest unless they ask you to compose them.
-6. Use `images_generate_nano_banana` (flash) for cheap iteration and `pro` only when the thumbnail needs strong rendered text inside the image. Use `images_edit_openai` when composing multiple reference images (face + brand + product).
+6. Use `images_generate` for every generation: `backend_hint="nano_banana"` for cheap iteration, `backend_hint="nano_banana_pro"` only when the thumbnail needs strong rendered text inside the image, and `backend_hint="openai"` when composing multiple reference images (face + brand + product).
 
 ## Reference
 

--- a/skills/youtube/scripts/clone_top_thumbnail_style.py
+++ b/skills/youtube/scripts/clone_top_thumbnail_style.py
@@ -7,9 +7,10 @@ Two-phase script:
   ask which rank to clone.
 
 * Phase 2 (``chosen_rank`` set): looks up the chosen thumbnail's
-  ``thumbnail_file_id`` and runs ``images_edit_nano_banana`` with that file as
-  the style reference. If a ``face_file_id`` is provided, the prompt is
-  augmented to composite the user's face into the cloned style.
+  ``thumbnail_file_id`` and runs ``images_generate`` with that file as a
+  reference image (nano-banana-pro backend). If a ``face_file_id`` is
+  provided, the openai backend composites the user's face into the cloned
+  style.
 """
 
 from __future__ import annotations
@@ -112,32 +113,36 @@ async def run(
         source_title=chosen.get("title"),
     )
 
+    used_tool = "images_generate"
     if face_file_id:
-        # OpenAI edit composes multiple references better than nano-banana edit
-        # when we need to preserve a person's identity.
+        # The openai backend composes multiple references better than
+        # nano-banana when a person's identity must be preserved.
         result = await call_tool(
-            "images_edit_openai",
+            used_tool,
             requests=[
                 {
                     "prompt": prompt,
                     "reference_images": [style_file_id, face_file_id],
                 }
             ],
-            size="1536x1024",
+            backend_hint="openai",
+            aspect_ratio="16:9",
             quality="high",
         )
-        used_tool = "images_edit_openai"
     else:
         result = await call_tool(
-            "images_edit_nano_banana",
-            file_id=style_file_id,
-            prompt=prompt,
+            used_tool,
+            requests=[
+                {
+                    "prompt": prompt,
+                    "reference_images": [style_file_id],
+                }
+            ],
             n=1,
-            model="pro",
+            backend_hint="nano_banana_pro",
             aspect_ratio="16:9",
-            image_size="2K",
+            quality="high",
         )
-        used_tool = "images_edit_nano_banana"
 
     images = result.get("images", []) if isinstance(result, dict) else []
     if not images:

--- a/skills/youtube/scripts/generate_thumbnail.py
+++ b/skills/youtube/scripts/generate_thumbnail.py
@@ -1,18 +1,18 @@
 """Generate a single YouTube thumbnail.
 
-Routing logic chooses the right image-gen tool based on inputs:
+Every call goes through the unified ``images_generate`` facade; routing picks
+the backend via ``backend_hint``:
 
-- ``style_reference_file_id`` set     -> ``images_edit_nano_banana`` with that
-                                          file as the base image (best for
-                                          cloning a single style reference).
+- ``style_reference_file_id`` set     -> nano-banana backend with the file as a
+                                          reference image (``nano_banana_pro``
+                                          when the prompt has explicit text
+                                          overlay, ``nano_banana`` otherwise).
 - ``brand_file_ids`` or
-  ``face_file_ids`` set               -> ``images_edit_openai`` with combined
+  ``face_file_ids`` set               -> ``openai`` backend with combined
                                           reference_images (better at composing
                                           multiple reference assets).
-- otherwise                           -> ``images_generate_nano_banana``
-                                          (``model='pro'`` if the prompt has
-                                          explicit text overlay, ``flash``
-                                          otherwise).
+- otherwise                           -> nano-banana backend, pro/flash chosen
+                                          by prompt text-heaviness.
 
 All tool calls go through the sandbox RPC, so generated images are persisted
 as ``DBFile``s in the conversation thread and metering fires automatically.
@@ -77,41 +77,53 @@ async def run(
     used_tool: str
     result: dict[str, Any]
 
+    # All paths go through the unified images_generate facade; the backend is
+    # selected via backend_hint (provider-specific tools are no longer
+    # exposed on the MCP surface).
+    used_tool = "images_generate"
     if style_reference_file_id:
-        used_tool = "images_edit_nano_banana"
         if chosen_model == "auto":
             chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        backend = "nano_banana_pro" if chosen_model == "pro" else "nano_banana"
         result = await call_tool(
             used_tool,
-            file_id=style_reference_file_id,
-            prompt=prompt,
+            requests=[
+                {
+                    "id": "thumbnail",
+                    "prompt": prompt,
+                    "reference_images": [style_reference_file_id],
+                }
+            ],
             n=n,
-            model=chosen_model,
+            backend_hint=backend,
             aspect_ratio=aspect,
-            image_size=image_size,
+            quality="high" if image_size == "2K" else "standard",
         )
+        chosen_model = backend
     elif refs:
-        used_tool = "images_edit_openai"
-        # OpenAI image-edit only supports its native sizes.
-        openai_size = "1536x1024" if aspect.startswith("16") else "1024x1024"
+        # OpenAI composes multiple references best when identity must be
+        # preserved (face + brand + product).
         result = await call_tool(
             used_tool,
             requests=[{"prompt": prompt, "reference_images": refs}],
-            size=openai_size,
+            backend_hint="openai",
+            aspect_ratio=aspect,
             quality="high",
         )
+        chosen_model = "openai"
     else:
-        used_tool = "images_generate_nano_banana"
         if chosen_model == "auto":
             chosen_model = "pro" if _looks_text_heavy(prompt) else "flash"
+        backend = "nano_banana_pro" if chosen_model == "pro" else "nano_banana"
         result = await call_tool(
             used_tool,
             requests=[{"id": "thumbnail", "prompt": prompt}],
             n=n,
-            model=chosen_model,
+            backend_hint=backend,
             aspect_ratio=aspect,
-            image_size=image_size,
+            quality="high" if image_size == "2K" else "standard",
         )
+        chosen_model = backend
 
     images = result.get("images", []) if isinstance(result, dict) else []
     if not images:
@@ -120,7 +132,7 @@ async def run(
     primary = images[0]
     return {
         "tool_used": used_tool,
-        "model": chosen_model if used_tool != "images_edit_openai" else "gpt-image-2",
+        "model": chosen_model,
         "aspect_ratio": aspect,
         "image_size": image_size,
         "primary": {


### PR DESCRIPTION
## What

Adds `skills/writing` — a writing style library and quality gate for all prose the agent produces.

- **SKILL.md**: classifies the deliverable, routes it to ONE named writing system via a style map, reads brand voice from `brand-context.md`, drafts to the system's hard rules, then runs a mandatory lint pass. Edit/tighten requests jump straight to the lint pass. Out-of-scope table defers publishing and research to sibling skills (`blog-generation`, `cold-email-outreach`, `ad-creative-generation`, `brand-context`, `customer-research`, social skills).
- **references/copywriting.md**: PAS, AIDA, BAB, FAB, 4U headlines, direct-response rules — each with checkable rules and before/after examples.
- **references/business-writing.md**: BLUF / Minto pyramid, SCQA, Smart Brevity, inverted pyramid, Amazon-style narrative memo, action titles.
- **references/technical-writing.md**: plain language, Diátaxis, controlled technical English, RFC requirement keywords, UX microcopy.
- **references/prose-style.md**: classic style, Orwell's rules, the concision pass, iceberg style, rhythm.
- **references/lint-and-humanize.md**: the ten universal rules, the AI-tell ban list (words, constructions, structures), and five ordered editing sweeps.

## Also

- `writing` row added to the skill tables in README.md, AGENTS.md, CLAUDE.md.
- Plugin manifests bumped to **1.2.0** (both files, in sync per CONTRIBUTING), skill count 30 → 31 in descriptions.

## Validation

`./validate-skills.sh` passes: 31 skills, no errors. SKILL.md is 139 lines (≤500), frontmatter has the Use-when trigger, Requirements section points at app.hyperfx.ai/mcp, no banned strings.